### PR TITLE
Extra logging in SearchHandler [sc-214651] 

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -536,6 +536,7 @@ public class SearchHandler extends RequestHandlerBase
 
             // Was there an exception?
             if (srsp.getException() != null) {
+              log.warn("Shard request failed : {}", srsp);
               // If things are not tolerant, abort everything and rethrow
               if (!tolerant) {
                 shardHandler1.cancelAll();


### PR DESCRIPTION
This PR adds a warn log to the SearchHandler when an Exception is encountered during a ShardRequest.