### PR TITLE
Add java system property to disable config watch 

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/ZkController.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ZkController.java
@@ -2742,6 +2742,10 @@ public class ZkController implements Closeable {
     return confDirListeners;
   }
 
+  public boolean hasConfDirectoryListeners(final String confDir) {
+    return confDirectoryListeners.containsKey(confDir) && !confDirectoryListeners.isEmpty();
+  }
+
   private final Map<String, Set<Runnable>> confDirectoryListeners = new HashMap<>();
 
   private class WatcherImpl implements Watcher {

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -190,6 +190,7 @@ import org.slf4j.LoggerFactory;
 public class SolrCore implements SolrInfoBean, Closeable {
 
   public static final String version = "1.0";
+  public static final String DISABLE_ZK_CONFIG_WATCH = "disable.zk.config.watch";
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private static final Logger requestLog =
@@ -3364,6 +3365,7 @@ public class SolrCore implements SolrInfoBean, Closeable {
    * some data so that events are triggered.
    */
   private void registerConfListener() {
+    if (Boolean.getBoolean(DISABLE_ZK_CONFIG_WATCH)) return;
     if (!(resourceLoader instanceof ZkSolrResourceLoader)) return;
     final ZkSolrResourceLoader zkSolrResourceLoader = (ZkSolrResourceLoader) resourceLoader;
     if (zkSolrResourceLoader != null)

--- a/solr/core/src/test/org/apache/solr/core/SolrCoreConfigTest.java
+++ b/solr/core/src/test/org/apache/solr/core/SolrCoreConfigTest.java
@@ -22,31 +22,33 @@ import org.apache.solr.cloud.AbstractFullDistribZkTestBase;
 import org.junit.Test;
 
 public class SolrCoreConfigTest extends AbstractFullDistribZkTestBase {
-    @Override
-    public void distribSetUp() throws Exception {
-        System.setProperty(SolrCore.DISABLE_ZK_CONFIG_WATCH, "true");
-        super.distribSetUp();
-    }
+  @Override
+  public void distribSetUp() throws Exception {
+    System.setProperty(SolrCore.DISABLE_ZK_CONFIG_WATCH, "true");
+    super.distribSetUp();
+  }
 
-    @Override
-    public void distribTearDown() throws Exception {
-        try {
-            super.distribTearDown();
-        } finally {
-            System.clearProperty(SolrCore.DISABLE_ZK_CONFIG_WATCH);
-        }
+  @Override
+  public void distribTearDown() throws Exception {
+    try {
+      super.distribTearDown();
+    } finally {
+      System.clearProperty(SolrCore.DISABLE_ZK_CONFIG_WATCH);
     }
+  }
 
-    @Test
-    public void testNoZkConfigWatch() {
-        CoreContainer cc = getContainer();
-        assertFalse("There shouldn't be any conf listener", cc.getZkController().hasConfDirectoryListeners("/configs/conf1"));
-    }
+  @Test
+  public void testNoZkConfigWatch() {
+    CoreContainer cc = getContainer();
+    assertFalse(
+        "There shouldn't be any conf listener",
+        cc.getZkController().hasConfDirectoryListeners("/configs/conf1"));
+  }
 
-    private CoreContainer getContainer() {
-        for (JettySolrRunner jetty : jettys) {
-            return jetty.getCoreContainer();
-        }
-        return null;
+  private CoreContainer getContainer() {
+    for (JettySolrRunner jetty : jettys) {
+      return jetty.getCoreContainer();
     }
+    return null;
+  }
 }

--- a/solr/core/src/test/org/apache/solr/core/SolrCoreConfigTest.java
+++ b/solr/core/src/test/org/apache/solr/core/SolrCoreConfigTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.core;
+
+import org.apache.solr.client.solrj.embedded.JettySolrRunner;
+import org.apache.solr.cloud.AbstractFullDistribZkTestBase;
+import org.junit.Test;
+
+public class SolrCoreConfigTest extends AbstractFullDistribZkTestBase {
+    @Override
+    public void distribSetUp() throws Exception {
+        System.setProperty(SolrCore.DISABLE_ZK_CONFIG_WATCH, "true");
+        super.distribSetUp();
+    }
+
+    @Override
+    public void distribTearDown() throws Exception {
+        try {
+            super.distribTearDown();
+        } finally {
+            System.clearProperty(SolrCore.DISABLE_ZK_CONFIG_WATCH);
+        }
+    }
+
+    @Test
+    public void testNoZkConfigWatch() {
+        CoreContainer cc = getContainer();
+        assertFalse("There shouldn't be any conf listener", cc.getZkController().hasConfDirectoryListeners("/configs/conf1"));
+    }
+
+    private CoreContainer getContainer() {
+        for (JettySolrRunner jetty : jettys) {
+            return jetty.getCoreContainer();
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
This PR ports the system property `disable.zk.config.watch` to Solr 9.

[[sc-214578]](https://app.shortcut.com/fullstory/story/214578/add-java-system-property-to-disable-config-watch)