### PR TITLE
Add java system property to overseer queue size

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/Overseer.java
+++ b/solr/core/src/java/org/apache/solr/cloud/Overseer.java
@@ -152,7 +152,8 @@ public class Overseer implements SolrCloseable {
   public static final int STATE_UPDATE_DELAY = ZkStateReader.STATE_UPDATE_DELAY;
   public static final int STATE_UPDATE_BATCH_SIZE =
       Integer.getInteger("solr.OverseerStateUpdateBatchSize", 10000);
-  public static final int STATE_UPDATE_MAX_QUEUE = 20000;
+  public static final int STATE_UPDATE_MAX_QUEUE =
+      Integer.getInteger("solr.OverseerStateUpdateMaxQueueSize", 20000);
 
   public static final int NUM_RESPONSES_TO_STORE = 10000;
   public static final String OVERSEER_ELECT = "/overseer_elect";
@@ -271,8 +272,8 @@ public class Overseer implements SolrCloseable {
               byte[] data = fallbackQueue.peek();
               while (fallbackQueueSize > 0 && data != null) {
                 final ZkNodeProps message = ZkNodeProps.load(data);
-                if (log.isDebugEnabled()) {
-                  log.debug(
+                if (log.isInfoEnabled()) {
+                  log.info(
                       "processMessage: fallbackQueueSize: {}, message = {}",
                       fallbackQueue.getZkStats().getQueueLength(),
                       message);
@@ -336,8 +337,8 @@ public class Overseer implements SolrCloseable {
               for (Pair<String, byte[]> head : queue) {
                 byte[] data = head.second();
                 final ZkNodeProps message = ZkNodeProps.load(data);
-                if (log.isDebugEnabled()) {
-                  log.debug(
+                if (log.isInfoEnabled()) {
+                  log.info(
                       "processMessage: queueSize: {}, message = {}",
                       stateUpdateQueue.getZkStats().getQueueLength(),
                       message);


### PR DESCRIPTION
This PR adds a Java system property for overseer queue size. 

Note: the null pointer exception fix was not included in this PR since it was fixed in this Solr upstream PR: [SOLR-15146](https://github.com/cowpaths/fullstory-solr/commit/4a78b458047c8803aed583d0d17ec6017d72b766#diff-45a542ca16eb58266f1bf2774184fbcb9713011e10d3126010cdf8529d6059ec)