### PR TITLE
sc 214640 : log cleanup and req tracing [from lucene-solr]

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -181,6 +181,7 @@ import org.eclipse.jetty.io.RuntimeIOException;
 import org.glassfish.jersey.server.ApplicationHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MarkerFactory;
 
 /**
  * SolrCore got its name because it represents the "core" of Solr -- one index and everything needed
@@ -2895,7 +2896,12 @@ public class SolrCore implements SolrInfoBean, Closeable {
 
     if (rsp.getToLog().size() > 0) {
       if (requestLog.isInfoEnabled()) {
-        requestLog.info(rsp.getToLogAsString());
+        Object path = rsp.getToLog().get("path");
+        if (path instanceof String) {
+          requestLog.info(MarkerFactory.getMarker((String) path), rsp.getToLogAsString());
+        } else {
+          requestLog.info(rsp.getToLogAsString());
+        }
       }
 
       /* slowQueryThresholdMillis defaults to -1 in SolrConfig -- not enabled.*/

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -26,13 +26,17 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+
+import com.google.common.collect.Iterators;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.index.ExitableDirectoryReader;
 import org.apache.lucene.search.TotalHits;
@@ -44,6 +48,7 @@ import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.CursorMarkParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.ShardParams;
+import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.core.CloseHook;
@@ -327,9 +332,26 @@ public class SearchHandler extends RequestHandlerBase
   @Override
   public void handleRequestBody(SolrQueryRequest req, SolrQueryResponse rsp) throws Exception {
     if (req.getParams().getBool(ShardParams.IS_SHARD, false)) {
+      // log a simple message on start
+      log.info("Start Forwarded Search Query");
+      SolrParams filteredParams = removeVerboseParams(req.getParams());
+      rsp.getToLog()
+              .asShallowMap(false)
+              .put("params", "{" + filteredParams + "}"); // replace "params" with the filtered version
       int purpose = req.getParams().getInt(ShardParams.SHARDS_PURPOSE, 0);
       SolrPluginUtils.forEachRequestPurpose(
           purpose, n -> shardPurposes.computeIfAbsent(n, name -> new Counter()).inc());
+    } else {
+      // Then it is the first time this req hitting Solr - not a req distributed by another higher
+      // level req.
+      // We have to log the query here as
+      // 1. It's useful to know the query before the processing start in case if the query stalls
+      // 2. The existing logging in SolrCore does not contain the query as query construction
+      // happens after the log
+      //    entries are added to rsp.toLog
+      if (log.isInfoEnabled()) {
+        log.info("Start External Search Query: {}", req.getParamString());
+      }
     }
 
     List<SearchComponent> components = getComponents();
@@ -605,6 +627,31 @@ public class SearchHandler extends RequestHandlerBase
       shardInfo.add(shardInfoName, nl);
       rsp.getValues().add(ShardParams.SHARDS_INFO, shardInfo);
     }
+  }
+
+  private static final List<String> VERBOSE_LOGGING_PARAMS = Arrays.asList("fq", "json");
+
+  private SolrParams removeVerboseParams(final SolrParams params) {
+    // Filter params by removing kv of VERBOSE_LOGGING_PARAMS, so that we can then call toString
+    SolrParams filteredParams =
+            new SolrParams() {
+              @Override
+              public Iterator<String> getParameterNamesIterator() {
+                return Iterators.filter(
+                        params.getParameterNamesIterator(), s -> !VERBOSE_LOGGING_PARAMS.contains(s));
+              }
+
+              @Override
+              public String get(String param) {
+                return params.get(param);
+              }
+
+              @Override
+              public String[] getParams(String param) {
+                return params.getParams(param);
+              }
+            };
+    return filteredParams;
   }
 
   private void tagRequestWithRequestId(ResponseBuilder rb) {

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -22,6 +22,7 @@ import static org.apache.solr.common.params.CommonParams.PATH;
 import static org.apache.solr.common.params.CommonParams.STATUS;
 
 import com.codahale.metrics.Counter;
+import com.google.common.collect.Iterators;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.invoke.MethodHandles;
@@ -35,8 +36,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
-
-import com.google.common.collect.Iterators;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.index.ExitableDirectoryReader;
 import org.apache.lucene.search.TotalHits;
@@ -336,8 +335,8 @@ public class SearchHandler extends RequestHandlerBase
       log.info("Start Forwarded Search Query");
       SolrParams filteredParams = removeVerboseParams(req.getParams());
       rsp.getToLog()
-              .asShallowMap(false)
-              .put("params", "{" + filteredParams + "}"); // replace "params" with the filtered version
+          .asShallowMap(false)
+          .put("params", "{" + filteredParams + "}"); // replace "params" with the filtered version
       int purpose = req.getParams().getInt(ShardParams.SHARDS_PURPOSE, 0);
       SolrPluginUtils.forEachRequestPurpose(
           purpose, n -> shardPurposes.computeIfAbsent(n, name -> new Counter()).inc());
@@ -634,23 +633,23 @@ public class SearchHandler extends RequestHandlerBase
   private SolrParams removeVerboseParams(final SolrParams params) {
     // Filter params by removing kv of VERBOSE_LOGGING_PARAMS, so that we can then call toString
     SolrParams filteredParams =
-            new SolrParams() {
-              @Override
-              public Iterator<String> getParameterNamesIterator() {
-                return Iterators.filter(
-                        params.getParameterNamesIterator(), s -> !VERBOSE_LOGGING_PARAMS.contains(s));
-              }
+        new SolrParams() {
+          @Override
+          public Iterator<String> getParameterNamesIterator() {
+            return Iterators.filter(
+                params.getParameterNamesIterator(), s -> !VERBOSE_LOGGING_PARAMS.contains(s));
+          }
 
-              @Override
-              public String get(String param) {
-                return params.get(param);
-              }
+          @Override
+          public String get(String param) {
+            return params.get(param);
+          }
 
-              @Override
-              public String[] getParams(String param) {
-                return params.getParams(param);
-              }
-            };
+          @Override
+          public String[] getParams(String param) {
+            return params.getParams(param);
+          }
+        };
     return filteredParams;
   }
 

--- a/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/HttpSolrCall.java
@@ -131,6 +131,7 @@ import org.apache.solr.util.tracing.TraceUtils;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.slf4j.MarkerFactory;
 
 /** This class represents a call made to Solr */
@@ -506,6 +507,13 @@ public class HttpSolrCall {
 
     try {
       init();
+
+      if (solrReq != null && solrReq.getParams() != null) {
+        String reqId = solrReq.getParams().get(CommonParams.REQUEST_ID);
+        if (reqId != null) {
+          MDC.put(CommonParams.REQUEST_ID, reqId);
+        }
+      }
 
       TraceUtils.ifNotNoop(getSpan(), this::populateTracingSpan);
 

--- a/solr/server/resources/log4j2.xml
+++ b/solr/server/resources/log4j2.xml
@@ -23,7 +23,7 @@
     <Console name="STDOUT" target="SYSTEM_OUT">
       <PatternLayout>
         <Pattern>
-          %maxLen{%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%notEmpty{c:%X{collection}}%notEmpty{ s:%X{shard}}%notEmpty{ r:%X{replica}}%notEmpty{ x:%X{core}}] %c{1.} %m%notEmpty{ =>%ex{short}}}{10240}%n
+          %maxLen{%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%notEmpty{c:%X{collection}}%notEmpty{ s:%X{shard}}%notEmpty{ r:%X{replica}}%notEmpty{ x:%X{core}}%notEmpty{ rid:%X{rid}}] %c{1.} %m%notEmpty{ =>%ex{short}}}{10240}%n
         </Pattern>
       </PatternLayout>
     </Console>
@@ -34,7 +34,7 @@
         filePattern="${sys:solr.log.dir}/solr.log.%i" >
       <PatternLayout>
         <Pattern>
-          %maxLen{%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%notEmpty{c:%X{collection}}%notEmpty{ s:%X{shard}}%notEmpty{ r:%X{replica}}%notEmpty{ x:%X{core}}] %c{1.} %m%notEmpty{ =>%ex{short}}}{10240}%n
+          %maxLen{%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%notEmpty{c:%X{collection}}%notEmpty{ s:%X{shard}}%notEmpty{ r:%X{replica}}%notEmpty{ x:%X{core}}%notEmpty{ rid:%X{rid}}] %c{1.} %m%notEmpty{ =>%ex{short}}}{10240}%n
         </Pattern>
       </PatternLayout>
       <Policies>
@@ -50,7 +50,7 @@
         filePattern="${sys:solr.log.dir}/solr_slow_requests.log.%i" >
       <PatternLayout>
         <Pattern>
-          %maxLen{%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%notEmpty{c:%X{collection}}%notEmpty{ s:%X{shard}}%notEmpty{ r:%X{replica}}%notEmpty{ x:%X{core}}] %c{1.} %m%notEmpty{ =>%ex{short}}}{10240}%n
+          %maxLen{%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%notEmpty{c:%X{collection}}%notEmpty{ s:%X{shard}}%notEmpty{ r:%X{replica}}%notEmpty{ x:%X{core}}%notEmpty{ rid:%X{rid}}] %c{1.} %m%notEmpty{ =>%ex{short}}}{10240}%n
         </Pattern>
       </PatternLayout>
       <Policies>


### PR DESCRIPTION
## Description
Apply changes from https://github.com/fullstorydev/lucene-solr/pull/102

## Solution
Apply changes for the above branch, details:

Changes included in this PR:
1. Add log marker based on path (upstreamed in https://issues.apache.org/jira/browse/SOLR-16582)
2. Add info message on search start (not upstreamed, see discussions in https://github.com/apache/solr/pull/1237 https://issues.apache.org/jira/browse/SOLR-16586)
3. Simplified message on sub-shard requests -(not upstreamed as this is quite specific to FS usage. Solr community might not like the fact that full query is no longer printed for handler processing in the data node - for us it's okay as it's easy for us to see ALL logs across nodes including QA node from BQ)
4.  Enable handling of rid from external systems - (not upstreamed, Solr is using the OpenTracing context at [here](https://github.com/apache/solr/blob/main/solr/core/src/java/org/apache/solr/servlet/ServletUtils.java#L255) which is in theory more generic. However, for FS, it's easier for us to use rid as our request id generated from alexa/anita does not comply to OpenTracing trace ID format, hence it's easier for us to "workaround" it by using rid which has no format restriction)
5. Adding rid to the [solr/server/resources/log4j2.xml](https://github.com/cowpaths/fullstory-solr/pull/49/files#diff-f950301391ca4cf160f002305de69ca7fc4b02a0b284b67d3b04b0f3291de6ee) , use the %notEmpty{} expression to avoid empty rid tags

Changes skipped in this PR:
1. In SearchHandler, generate/tag rid (request id) earlier and include such in MDC context. Very similar change was already implemented in 9.0 by another contributor https://issues.apache.org/jira/browse/SOLR-15790 . 
