### PR TITLE
Removing call to notifyCloudCollectionListeners for changes to state

### DIFF
--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -699,7 +699,10 @@ public class ZkStateReader implements SolrCloseable {
           clusterState.getCollectionStates());
     }
 
-    notifyCloudCollectionsListeners();
+    if (changedCollections.isEmpty()) {
+      // We only need to notify cloud collection listeners on new collections
+      notifyCloudCollectionsListeners();
+    }
 
     for (String collection : changedCollections) {
       notifyStateWatchers(collection, clusterState.getCollectionOrNull(collection));


### PR DESCRIPTION
When an existing collection has a change in state, we don't need to call `notifyCloudCollectionListeners` because that is used for when a new collection is discovered.

From the GCP Profiler when restarting nodes, we've seen that this call takes up quite a bit of CPU time: https://console.cloud.google.com/profiler;timespan=1h/solrcloud-c81/cpu?project=fullstoryapp, so removing it should improve restart performance.