### PR TITLE
Fixing the JWTAuthPluginIntegrationTest by removing indentation in expected JSON

### DIFF
--- a/solr/modules/jwt-auth/src/test/org/apache/solr/security/jwt/JWTAuthPluginIntegrationTest.java
+++ b/solr/modules/jwt-auth/src/test/org/apache/solr/security/jwt/JWTAuthPluginIntegrationTest.java
@@ -163,10 +163,10 @@ public class JWTAuthPluginIntegrationTest extends SolrCloudAuthTestCase {
     String authData = new String(Base64.getDecoder().decode(headers.get("X-Solr-AuthData")), UTF_8);
     assertEquals(
         "{\n"
-            + "  \"scope\":\"solr:admin\",\n"
-            + "  \"redirect_uris\":[],\n"
-            + "  \"authorizationEndpoint\":\"http://acmepaymentscorp/oauth/auz/authorize\",\n"
-            + "  \"client_id\":\"solr-cluster\"}",
+            + "\"scope\":\"solr:admin\",\n"
+            + "\"redirect_uris\":[],\n"
+            + "\"authorizationEndpoint\":\"http://acmepaymentscorp/oauth/auz/authorize\",\n"
+            + "\"client_id\":\"solr-cluster\"}",
         authData);
     myCluster.shutdown();
   }
@@ -185,10 +185,10 @@ public class JWTAuthPluginIntegrationTest extends SolrCloudAuthTestCase {
     String authData = new String(Base64.getDecoder().decode(headers.get("X-Solr-AuthData")), UTF_8);
     assertEquals(
         "{\n"
-            + "  \"scope\":\"solr:admin\",\n"
-            + "  \"redirect_uris\":[],\n"
-            + "  \"authorizationEndpoint\":\"http://acmepaymentscorp/oauth/auz/authorize\",\n"
-            + "  \"client_id\":\"solr-cluster\"}",
+            + "\"scope\":\"solr:admin\",\n"
+            + "\"redirect_uris\":[],\n"
+            + "\"authorizationEndpoint\":\"http://acmepaymentscorp/oauth/auz/authorize\",\n"
+            + "\"client_id\":\"solr-cluster\"}",
         authData);
     myCluster.shutdown();
   }


### PR DESCRIPTION
This PR: https://github.com/cowpaths/fullstory-solr/pull/46 seems to have removed indentation for the JSON used in these tests as well. This isn't an issue in terms of functionality but if broke the comparison in the test. This change removes indentation from the expected JSON to fix these tests.