### PR TITLE
add detection/logging of http2 delay in intra-cluster request sending

### DIFF
--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -444,6 +444,7 @@ public class Http2SolrClient extends SolrClient {
     final ResponseParser parser =
         solrRequest.getResponseParser() == null ? this.parser : solrRequest.getResponseParser();
     req.onRequestQueued(asyncTracker.queuedListener)
+        .onRequestBegin(request -> asyncListener.onStart())
         .onComplete(asyncTracker.completeListener)
         .send(
             new InputStreamResponseListener() {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
@@ -248,7 +248,8 @@ public class LBHttp2SolrClient extends LBSolrClient {
     void onFailure(Exception e, boolean retryReq);
   }
 
-  private static final long DELAY_WARN_THRESHOLD = TimeUnit.NANOSECONDS.convert(2000, TimeUnit.MILLISECONDS);
+  private static final long DELAY_WARN_THRESHOLD =
+      TimeUnit.NANOSECONDS.convert(2000, TimeUnit.MILLISECONDS);
 
   private Cancellable doRequest(
       String baseUrl,
@@ -268,12 +269,16 @@ public class LBHttp2SolrClient extends LBSolrClient {
 
               @Override
               public void onStart() {
-                // There should be negligible delay between request submission and actually sending the request.
-                // Here we add extra logging to notify us if this assumption is violated.
-                // See: SOLR-16099, SOLR-16129, https://github.com/fullstorydev/lucene-solr/commit/445508adb4a
+                // There should be negligible delay between request submission and actually sending
+                // the request. Here we add extra logging to notify us if this assumption is
+                // violated. See: SOLR-16099, SOLR-16129,
+                // https://github.com/fullstorydev/lucene-solr/commit/445508adb4a
                 long delayed = System.nanoTime() - requestSubmitTimeNanos;
                 if (delayed > DELAY_WARN_THRESHOLD) {
-                  log.info("Remote shard request to {} delayed by {} milliseconds ", req.servers, TimeUnit.MILLISECONDS.convert(delayed, TimeUnit.NANOSECONDS));
+                  log.info(
+                      "Remote shard request to {} delayed by {} milliseconds",
+                      req.servers,
+                      TimeUnit.MILLISECONDS.convert(delayed, TimeUnit.NANOSECONDS));
                 }
                 AsyncListener.super.onStart();
               }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
@@ -19,6 +19,7 @@ package org.apache.solr.client.solrj.impl;
 import static org.apache.solr.common.params.CommonParams.ADMIN_PATHS;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.net.ConnectException;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
@@ -26,6 +27,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.solr.client.solrj.ResponseParser;
@@ -37,6 +39,8 @@ import org.apache.solr.client.solrj.util.AsyncListener;
 import org.apache.solr.client.solrj.util.Cancellable;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.util.NamedList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 /**
@@ -83,6 +87,7 @@ import org.slf4j.MDC;
  * @since solr 8.0
  */
 public class LBHttp2SolrClient extends LBSolrClient {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private final Http2SolrClient solrClient;
 
   /**
@@ -243,6 +248,8 @@ public class LBHttp2SolrClient extends LBSolrClient {
     void onFailure(Exception e, boolean retryReq);
   }
 
+  private static final long DELAY_WARN_THRESHOLD = TimeUnit.NANOSECONDS.convert(2000, TimeUnit.MILLISECONDS);
+
   private Cancellable doRequest(
       String baseUrl,
       Req req,
@@ -257,6 +264,20 @@ public class LBHttp2SolrClient extends LBSolrClient {
             req.getRequest(),
             null,
             new AsyncListener<>() {
+              private final long requestSubmitTimeNanos = System.nanoTime();
+
+              @Override
+              public void onStart() {
+                // There should be negligible delay between request submission and actually sending the request.
+                // Here we add extra logging to notify us if this assumption is violated.
+                // See: SOLR-16099, SOLR-16129, https://github.com/fullstorydev/lucene-solr/commit/445508adb4a
+                long delayed = System.nanoTime() - requestSubmitTimeNanos;
+                if (delayed > DELAY_WARN_THRESHOLD) {
+                  log.info("Remote shard request to {} delayed by {} milliseconds ", req.servers, TimeUnit.MILLISECONDS.convert(delayed, TimeUnit.NANOSECONDS));
+                }
+                AsyncListener.super.onStart();
+              }
+
               @Override
               public void onSuccess(NamedList<Object> result) {
                 rsp.rsp = result;


### PR DESCRIPTION
See also:
1. https://github.com/fullstorydev/lucene-solr/commit/445508adb4a
2. https://issues.apache.org/jira/browse/SOLR-16099
3. https://issues.apache.org/jira/browse/SOLR-16129

To be clear, I haven't tried to evaluate whether this works in practice. Request-sending logic changed considerably as of SOLR-14354, so this wasn't a straight cherry-pick of https://github.com/fullstorydev/lucene-solr/commit/445508adb4a. Following on conversation with Patson though, it sounds like we are seeing these messages logged in staging, so hopefully we can iterate on this if necessary.