### PR TITLE
SAI-4401 : Deeper prs docCollection refactoring

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/DistributedClusterStateUpdater.java
+++ b/solr/core/src/java/org/apache/solr/cloud/DistributedClusterStateUpdater.java
@@ -507,7 +507,7 @@ public class DistributedClusterStateUpdater {
             // have them
             fetchedPerReplicaStates =
                 PerReplicaStatesFetcher.fetch(
-                    docCollection.getZNode(), zkStateReader.getZkClient(), fetchedPerReplicaStates);
+                    docCollection.getZNode(), zkStateReader.getZkClient());
             // Transpose the per replica states into the cluster state
             updatedState =
                 updatedState.copyWith(

--- a/solr/core/src/java/org/apache/solr/cloud/ShardLeaderElectionContextBase.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ShardLeaderElectionContextBase.java
@@ -238,8 +238,7 @@ class ShardLeaderElectionContextBase extends ElectionContext {
         }
       }
       if (coll != null && coll.isPerReplicaState()) {
-        PerReplicaStates prs =
-            PerReplicaStatesFetcher.fetch(coll.getZNode(), zkClient, coll.getPerReplicaStates());
+        PerReplicaStates prs = PerReplicaStatesFetcher.fetch(coll.getZNode(), zkClient);
         PerReplicaStatesOps.flipLeader(
                 zkStateReader
                     .getClusterState()

--- a/solr/core/src/java/org/apache/solr/cloud/ZkController.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ZkController.java
@@ -1799,7 +1799,7 @@ public class ZkController implements Closeable {
       // as overseer does not and should not handle those entries
       if (coll != null && coll.isPerReplicaState() && coreNodeName != null) {
         PerReplicaStates perReplicaStates =
-            PerReplicaStatesFetcher.fetch(coll.getZNode(), zkClient, coll.getPerReplicaStates());
+            PerReplicaStatesFetcher.fetch(coll.getZNode(), zkClient);
         PerReplicaStatesOps.flipState(coreNodeName, state, perReplicaStates)
             .persist(coll.getZNode(), zkClient);
       }
@@ -1884,8 +1884,7 @@ public class ZkController implements Closeable {
               docCollection.getName());
         }
         PerReplicaStates perReplicaStates =
-            PerReplicaStatesFetcher.fetch(
-                docCollection.getZNode(), zkClient, docCollection.getPerReplicaStates());
+            PerReplicaStatesFetcher.fetch(docCollection.getZNode(), zkClient);
         PerReplicaStatesOps.deleteReplica(coreNodeName, perReplicaStates)
             .persist(docCollection.getZNode(), zkClient);
       }
@@ -2958,9 +2957,7 @@ public class ZkController implements Closeable {
                   }
                 });
             PerReplicaStatesOps.downReplicas(
-                    replicasToDown,
-                    PerReplicaStatesFetcher.fetch(
-                        coll.getZNode(), zkClient, coll.getPerReplicaStates()))
+                    replicasToDown, PerReplicaStatesFetcher.fetch(coll.getZNode(), zkClient))
                 .persist(coll.getZNode(), zkClient);
           }
         }

--- a/solr/core/src/java/org/apache/solr/cloud/api/collections/CreateCollectionCmd.java
+++ b/solr/core/src/java/org/apache/solr/cloud/api/collections/CreateCollectionCmd.java
@@ -425,14 +425,11 @@ public class CreateCollectionCmd implements CollApiCmds.CollectionApiCommand {
                 TimeUnit.SECONDS,
                 ccc.getSolrCloudManager().getTimeSource()); // could be a big cluster
         PerReplicaStates prs =
-            PerReplicaStatesFetcher.fetch(
-                collectionPath, ccc.getZkStateReader().getZkClient(), null);
+            PerReplicaStatesFetcher.fetch(collectionPath, ccc.getZkStateReader().getZkClient());
         while (!timeout.hasTimedOut()) {
           if (prs.allActive()) break;
           Thread.sleep(100);
-          prs =
-              PerReplicaStatesFetcher.fetch(
-                  collectionPath, ccc.getZkStateReader().getZkClient(), null);
+          prs = PerReplicaStatesFetcher.fetch(collectionPath, ccc.getZkStateReader().getZkClient());
         }
         if (prs.allActive()) {
           // we have successfully found all replicas to be ACTIVE

--- a/solr/core/src/java/org/apache/solr/cloud/overseer/CollectionMutator.java
+++ b/solr/core/src/java/org/apache/solr/cloud/overseer/CollectionMutator.java
@@ -128,7 +128,7 @@ public class CollectionMutator {
           log.error("trying to set perReplicaState to {} from {}", val, coll.isPerReplicaState());
           continue;
         }
-        PerReplicaStates prs = PerReplicaStatesFetcher.fetch(coll.getZNode(), zkClient, null);
+        PerReplicaStates prs = PerReplicaStatesFetcher.fetch(coll.getZNode(), zkClient);
         replicaOps =
             enable ? PerReplicaStatesOps.enable(coll, prs) : PerReplicaStatesOps.disable(prs);
         if (!enable) {

--- a/solr/core/src/java/org/apache/solr/cloud/overseer/NodeMutator.java
+++ b/solr/core/src/java/org/apache/solr/cloud/overseer/NodeMutator.java
@@ -120,11 +120,7 @@ public class NodeMutator {
 
     if (needToUpdateCollection) {
       if (docCollection.isPerReplicaState()) {
-        PerReplicaStates prs =
-            client == null
-                ? docCollection.getPerReplicaStates()
-                : PerReplicaStatesFetcher.fetch(
-                    docCollection.getZNode(), client, docCollection.getPerReplicaStates());
+        PerReplicaStates prs = PerReplicaStatesFetcher.fetch(docCollection.getZNode(), client);
 
         return Optional.of(
             new ZkWriteCommand(

--- a/solr/core/src/java/org/apache/solr/cloud/overseer/ZkStateWriter.java
+++ b/solr/core/src/java/org/apache/solr/cloud/overseer/ZkStateWriter.java
@@ -273,7 +273,7 @@ public class ZkStateWriter {
                     name,
                     cmd.collection.copyWith(
                         PerReplicaStatesFetcher.fetch(
-                            cmd.collection.getZNode(), reader.getZkClient(), null)));
+                            cmd.collection.getZNode(), reader.getZkClient())));
           }
 
           // Update the state.json file if needed
@@ -295,24 +295,13 @@ public class ZkStateWriter {
               Stat stat = reader.getZkClient().setData(path, data, c.getZNodeVersion(), true);
               DocCollection newCollection =
                   new DocCollection(
-                      name,
-                      c.getSlicesMap(),
-                      c.getProperties(),
-                      c.getRouter(),
-                      stat.getVersion(),
-                      c.getPerReplicaStates());
+                      name, c.getSlicesMap(), c.getProperties(), c.getRouter(), stat.getVersion());
               clusterState = clusterState.copyWith(name, newCollection);
             } else {
               log.debug("going to create_collection {}", path);
               reader.getZkClient().create(path, data, CreateMode.PERSISTENT, true);
               DocCollection newCollection =
-                  new DocCollection(
-                      name,
-                      c.getSlicesMap(),
-                      c.getProperties(),
-                      c.getRouter(),
-                      0,
-                      c.getPerReplicaStates());
+                  new DocCollection(name, c.getSlicesMap(), c.getProperties(), c.getRouter(), 0);
               clusterState = clusterState.copyWith(name, newCollection);
             }
           }
@@ -325,7 +314,7 @@ public class ZkStateWriter {
                       name,
                       currentCollState.copyWith(
                           PerReplicaStatesFetcher.fetch(
-                              currentCollState.getZNode(), reader.getZkClient(), null)));
+                              currentCollState.getZNode(), reader.getZkClient())));
             }
           }
         }

--- a/solr/core/src/java/org/apache/solr/handler/admin/ClusterStatus.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/ClusterStatus.java
@@ -31,7 +31,6 @@ import org.apache.solr.common.cloud.Aliases;
 import org.apache.solr.common.cloud.ClusterState;
 import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.cloud.DocRouter;
-import org.apache.solr.common.cloud.PerReplicaStates;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.cloud.ZkNodeProps;
@@ -189,10 +188,11 @@ public class ClusterStatus {
       }
       String configName = clusterStateCollection.getConfigName();
       collectionStatus.put("configName", configName);
-      if (message.getBool("prs", false) && clusterStateCollection.isPerReplicaState()) {
-        PerReplicaStates prs = clusterStateCollection.getPerReplicaStates();
-        collectionStatus.put("PRS", prs);
-      }
+      //      if (message.getBool("prs", false) && clusterStateCollection.isPerReplicaState()) {
+      // PerReplicaStates prs = clusterStateCollection.getPerReplicaStates(); //TODO. The usage is
+      // from this? BaseHttpClusterStateProvider#fillPrs
+      //        collectionStatus.put("PRS", prs);
+      //      }
       collectionProps.add(name, collectionStatus);
     }
 

--- a/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
@@ -44,12 +44,14 @@ import org.apache.solr.common.cloud.PerReplicaStates;
 import org.apache.solr.common.cloud.PerReplicaStatesFetcher;
 import org.apache.solr.common.cloud.PerReplicaStatesOps;
 import org.apache.solr.common.cloud.Replica;
+import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.util.CommonTestInjection;
 import org.apache.solr.common.util.ExecutorUtil;
 import org.apache.solr.common.util.SolrNamedThreadFactory;
 import org.apache.solr.common.util.TimeSource;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.common.util.ZLibCompressor;
 import org.apache.solr.handler.admin.ConfigSetsHandler;
 import org.apache.solr.util.LogLevel;
@@ -243,11 +245,22 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
     fixture.zkClient.makePath(ZkStateReader.COLLECTIONS_ZKNODE + "/c1", true);
 
     ClusterState clusterState = reader.getClusterState();
+
+    Map<String, Slice> slices = new HashMap<>();
+    Map<String, Object> props = new HashMap<>();
+    String nodeName = "node1:10000_solr";
+    props.put(ZkStateReader.NODE_NAME_PROP, nodeName);
+    props.put(ZkStateReader.BASE_URL_PROP, Utils.getBaseUrlForNodeName(nodeName, "http"));
+    props.put(ZkStateReader.CORE_NAME_PROP, "core1");
+    props.put(ZkStateReader.CONFIGNAME_PROP, ConfigSetsHandler.DEFAULT_CONFIGSET_NAME);
+    Replica replica = new Replica("r1", props, "c1", "shard1");
+    Slice slice = new Slice("shard1", Map.of("r1", replica), null, "c1");
+
     // create new collection
     DocCollection state =
         new DocCollection(
             "c1",
-            new HashMap<>(),
+            Map.of("shard1", slice),
             Map.of(
                 ZkStateReader.CONFIGNAME_PROP,
                 ConfigSetsHandler.DEFAULT_CONFIGSET_NAME,
@@ -263,7 +276,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
     // inserted
     reader.registerCore("c1");
 
-    TimeOut timeOut = new TimeOut(5000, TimeUnit.MILLISECONDS, TimeSource.NANO_TIME);
+    TimeOut timeOut = new TimeOut(500000, TimeUnit.MILLISECONDS, TimeSource.NANO_TIME);
     timeOut.waitFor(
         "Timeout on waiting for c1 to show up in cluster state",
         () -> reader.getClusterState().getCollectionOrNull("c1") != null);
@@ -274,15 +287,20 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
     // no more dummy node
     assertEquals(0, ref.get().getChildNodesVersion());
 
+
+
     DocCollection collection = ref.get();
     PerReplicaStates prs = PerReplicaStatesFetcher.fetch(collection.getZNode(), fixture.zkClient);
     PerReplicaStatesOps.addReplica("r1", Replica.State.DOWN, false, prs)
         .persist(collection.getZNode(), fixture.zkClient);
     timeOut.waitFor(
-        "Timeout on waiting for c1 updated to have PRS state r1",
+        "Timeout on waiting for PRS state r1 to be visible",
         () -> {
-          DocCollection c = reader.getCollection("c1");
-          return c.getReplica("r1").getState() == Replica.State.DOWN;
+            DocCollection c = reader.getCollection("c1");
+          return c.getReplica("r1") != null && c.getReplica("r1").getState() == Replica.State.DOWN;
+//          //the best we could verify now is PerReplicaStatesFetch eventually see the change on c1 eventually
+//          PerReplicaStates perReplicaStates = PerReplicaStatesFetcher.fetch(DocCollection.getCollectionPath("c1"), fixture.zkClient);
+//          return perReplicaStates
         });
 
     ref = reader.getClusterState().getCollectionRef("c1");
@@ -335,7 +353,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
         "Timeout on waiting for c1 updated to have PRS state r1",
         () -> {
           DocCollection c = reader.getCollection("c1");
-          return c.getReplica("r1").getState() == Replica.State.DOWN;
+          return  c.getReplica("r1") != null && c.getReplica("r1").getState() == Replica.State.DOWN;
         });
 
     ref = reader.getClusterState().getCollectionRef("c1");
@@ -374,6 +392,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
     assertNotNull(ref);
     assertFalse(ref.isLazilyLoaded());
     assertEquals(0, ref.get().getZNodeVersion());
+
 
     // update the collection
     state =

--- a/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
@@ -287,8 +287,6 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
     // no more dummy node
     assertEquals(0, ref.get().getChildNodesVersion());
 
-
-
     DocCollection collection = ref.get();
     PerReplicaStates prs = PerReplicaStatesFetcher.fetch(collection.getZNode(), fixture.zkClient);
     PerReplicaStatesOps.addReplica("r1", Replica.State.DOWN, false, prs)
@@ -296,11 +294,13 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
     timeOut.waitFor(
         "Timeout on waiting for PRS state r1 to be visible",
         () -> {
-            DocCollection c = reader.getCollection("c1");
+          DocCollection c = reader.getCollection("c1");
           return c.getReplica("r1") != null && c.getReplica("r1").getState() == Replica.State.DOWN;
-//          //the best we could verify now is PerReplicaStatesFetch eventually see the change on c1 eventually
-//          PerReplicaStates perReplicaStates = PerReplicaStatesFetcher.fetch(DocCollection.getCollectionPath("c1"), fixture.zkClient);
-//          return perReplicaStates
+          //          //the best we could verify now is PerReplicaStatesFetch eventually see the
+          // change on c1 eventually
+          //          PerReplicaStates perReplicaStates =
+          // PerReplicaStatesFetcher.fetch(DocCollection.getCollectionPath("c1"), fixture.zkClient);
+          //          return perReplicaStates
         });
 
     ref = reader.getClusterState().getCollectionRef("c1");
@@ -353,7 +353,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
         "Timeout on waiting for c1 updated to have PRS state r1",
         () -> {
           DocCollection c = reader.getCollection("c1");
-          return  c.getReplica("r1") != null && c.getReplica("r1").getState() == Replica.State.DOWN;
+          return c.getReplica("r1") != null && c.getReplica("r1").getState() == Replica.State.DOWN;
         });
 
     ref = reader.getClusterState().getCollectionRef("c1");
@@ -392,7 +392,6 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
     assertNotNull(ref);
     assertFalse(ref.isLazilyLoaded());
     assertEquals(0, ref.get().getZNodeVersion());
-
 
     // update the collection
     state =

--- a/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateWriterTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateWriterTest.java
@@ -33,7 +33,6 @@ import org.apache.solr.cloud.ZkTestServer;
 import org.apache.solr.common.cloud.ClusterState;
 import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.cloud.DocRouter;
-import org.apache.solr.common.cloud.PerReplicaStates;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.cloud.SolrZkClient;
@@ -177,14 +176,7 @@ public class ZkStateWriterTest extends SolrTestCaseJ4 {
         prsProps.put("perReplicaState", Boolean.TRUE);
         ZkWriteCommand prs1 =
             new ZkWriteCommand(
-                "prs1",
-                new DocCollection(
-                    "prs1",
-                    new HashMap<>(),
-                    prsProps,
-                    DocRouter.DEFAULT,
-                    0,
-                    PerReplicaStates.empty("prs1")));
+                "prs1", new DocCollection("prs1", new HashMap<>(), prsProps, DocRouter.DEFAULT, 0));
         ZkStateWriter writer =
             new ZkStateWriter(reader, new Stats(), -1, STATE_COMPRESSION_PROVIDER);
 
@@ -259,14 +251,7 @@ public class ZkStateWriterTest extends SolrTestCaseJ4 {
         prsProps.put("perReplicaState", Boolean.TRUE);
         ZkWriteCommand prs1 =
             new ZkWriteCommand(
-                "prs1",
-                new DocCollection(
-                    "prs1",
-                    new HashMap<>(),
-                    prsProps,
-                    DocRouter.DEFAULT,
-                    0,
-                    PerReplicaStates.empty("prs1")));
+                "prs1", new DocCollection("prs1", new HashMap<>(), prsProps, DocRouter.DEFAULT, 0));
         ZkStateWriter writer =
             new ZkStateWriter(reader, new Stats(), -1, STATE_COMPRESSION_PROVIDER);
 

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/impl/ZkClientClusterStateProvider.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/impl/ZkClientClusterStateProvider.java
@@ -119,9 +119,7 @@ public class ZkClientClusterStateProvider implements ClusterStateProvider {
         stateMap,
         liveNodes,
         new DocCollection.PrsSupplier(
-            () ->
-                PerReplicaStatesFetcher.fetch(
-                    DocCollection.getCollectionPath(coll), zkClient, null)));
+            () -> PerReplicaStatesFetcher.fetch(DocCollection.getCollectionPath(coll), zkClient)));
   }
 
   @Override

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/impl/ZkDistribStateManager.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/client/solrj/impl/ZkDistribStateManager.java
@@ -216,6 +216,6 @@ public class ZkDistribStateManager implements DistribStateManager {
   @Override
   public PerReplicaStates getReplicaStates(String path)
       throws KeeperException, InterruptedException {
-    return PerReplicaStatesFetcher.fetch(path, zkClient, null);
+    return PerReplicaStatesFetcher.fetch(path, zkClient);
   }
 }

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/PerReplicaStatesOps.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/PerReplicaStatesOps.java
@@ -97,7 +97,7 @@ public class PerReplicaStatesOps {
         if (log.isInfoEnabled()) {
           log.info("Stale state for {}, attempt: {}. retrying...", znode, i);
         }
-        operations = refresh(PerReplicaStatesFetcher.fetch(znode, zkClient, null));
+        operations = refresh(PerReplicaStatesFetcher.fetch(znode, zkClient));
       }
     }
   }

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -334,13 +334,9 @@ public class ZkStateReader implements SolrCloseable {
               watch.currentState = null;
             } else { // both new and old states are non-null
               int oldCVersion =
-                  oldState.getPerReplicaStates() == null
-                      ? -1
-                      : oldState.getPerReplicaStates().cversion;
+                  oldState.isPerReplicaState() ? oldState.getChildNodesVersion() : -1;
               int newCVersion =
-                  newState.getPerReplicaStates() == null
-                      ? -1
-                      : newState.getPerReplicaStates().cversion;
+                  newState.isPerReplicaState() ? newState.getChildNodesVersion() : -1;
               if (oldState.getZNodeVersion() < newState.getZNodeVersion()
                   || oldCVersion < newCVersion) {
                 watch.currentState = newState;

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -333,10 +333,8 @@ public class ZkStateReader implements SolrCloseable {
               log.debug("Removing cached collection state for [{}]", collection);
               watch.currentState = null;
             } else { // both new and old states are non-null
-              int oldCVersion =
-                  oldState.isPerReplicaState() ? oldState.getChildNodesVersion() : -1;
-              int newCVersion =
-                  newState.isPerReplicaState() ? newState.getChildNodesVersion() : -1;
+              int oldCVersion = oldState.isPerReplicaState() ? oldState.getChildNodesVersion() : -1;
+              int newCVersion = newState.isPerReplicaState() ? newState.getChildNodesVersion() : -1;
               if (oldState.getZNodeVersion() < newState.getZNodeVersion()
                   || oldCVersion < newCVersion) {
                 watch.currentState = newState;

--- a/solr/solrj-zookeeper/src/test/org/apache/solr/common/cloud/TestPerReplicaStates.java
+++ b/solr/solrj-zookeeper/src/test/org/apache/solr/common/cloud/TestPerReplicaStates.java
@@ -95,7 +95,7 @@ public class TestPerReplicaStates extends SolrCloudTestCase {
     }
 
     ZkStateReader zkStateReader = cluster.getZkStateReader();
-    PerReplicaStates rs = PerReplicaStatesFetcher.fetch(root, zkStateReader.getZkClient(), null);
+    PerReplicaStates rs = PerReplicaStatesFetcher.fetch(root, zkStateReader.getZkClient());
     assertEquals(3, rs.states.size());
     assertTrue(rs.cversion >= 5);
 
@@ -103,7 +103,7 @@ public class TestPerReplicaStates extends SolrCloudTestCase {
     assertEquals(1, ops.get().size());
     assertEquals(PerReplicaStates.Operation.Type.ADD, ops.ops.get(0).typ);
     ops.persist(root, cluster.getZkClient());
-    rs = PerReplicaStatesFetcher.fetch(root, zkStateReader.getZkClient(), null);
+    rs = PerReplicaStatesFetcher.fetch(root, zkStateReader.getZkClient());
     assertEquals(4, rs.states.size());
     assertTrue(rs.cversion >= 6);
     assertEquals(6, cluster.getZkClient().getChildren(root, null, true).size());
@@ -115,7 +115,7 @@ public class TestPerReplicaStates extends SolrCloudTestCase {
     assertEquals(PerReplicaStates.Operation.Type.DELETE, ops.ops.get(2).typ);
     assertEquals(PerReplicaStates.Operation.Type.DELETE, ops.ops.get(3).typ);
     ops.persist(root, cluster.getZkClient());
-    rs = PerReplicaStatesFetcher.fetch(root, zkStateReader.getZkClient(), null);
+    rs = PerReplicaStatesFetcher.fetch(root, zkStateReader.getZkClient());
     assertEquals(4, rs.states.size());
     assertEquals(3, rs.states.get("R1").version);
 
@@ -123,7 +123,7 @@ public class TestPerReplicaStates extends SolrCloudTestCase {
     assertEquals(1, ops.ops.size());
     ops.persist(root, cluster.getZkClient());
 
-    rs = PerReplicaStatesFetcher.fetch(root, zkStateReader.getZkClient(), null);
+    rs = PerReplicaStatesFetcher.fetch(root, zkStateReader.getZkClient());
     assertEquals(3, rs.states.size());
 
     ops = PerReplicaStatesOps.flipLeader(Set.of("R4", "R3", "R1"), "R4", rs);
@@ -131,11 +131,11 @@ public class TestPerReplicaStates extends SolrCloudTestCase {
     assertEquals(PerReplicaStates.Operation.Type.ADD, ops.ops.get(0).typ);
     assertEquals(PerReplicaStates.Operation.Type.DELETE, ops.ops.get(1).typ);
     ops.persist(root, cluster.getZkClient());
-    rs = PerReplicaStatesFetcher.fetch(root, zkStateReader.getZkClient(), null);
+    rs = PerReplicaStatesFetcher.fetch(root, zkStateReader.getZkClient());
     ops = PerReplicaStatesOps.flipLeader(Set.of("R4", "R3", "R1"), "R3", rs);
     assertEquals(4, ops.ops.size());
     ops.persist(root, cluster.getZkClient());
-    rs = PerReplicaStatesFetcher.fetch(root, zkStateReader.getZkClient(), null);
+    rs = PerReplicaStatesFetcher.fetch(root, zkStateReader.getZkClient());
     assertTrue(rs.get("R3").isLeader);
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/BaseHttpClusterStateProvider.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/BaseHttpClusterStateProvider.java
@@ -36,7 +36,6 @@ import org.apache.solr.client.solrj.response.CollectionAdminResponse;
 import org.apache.solr.common.cloud.Aliases;
 import org.apache.solr.common.cloud.ClusterState;
 import org.apache.solr.common.cloud.DocCollection;
-import org.apache.solr.common.cloud.PerReplicaStates;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
@@ -169,16 +168,17 @@ public abstract class BaseHttpClusterStateProvider implements ClusterStateProvid
   @SuppressWarnings({"rawtypes", "unchecked"})
   private DocCollection fillPrs(int znodeVersion, Map.Entry<String, Object> e, Map m) {
     DocCollection.PrsSupplier prsSupplier = null;
-    if (m.containsKey("PRS")) {
-      Map prs = (Map) m.remove("PRS");
-      prsSupplier =
-          new DocCollection.PrsSupplier(
-              () ->
-                  new PerReplicaStates(
-                      (String) prs.get("path"),
-                      (Integer) prs.get("cversion"),
-                      (List<String>) prs.get("states")));
-    }
+    //    if (m.containsKey("PRS")) { //TODO this probably has never worked? "PRS" set is
+    // PerReplicateStates which is not a map anyway?
+    //      Map prs = (Map) m.remove("PRS");
+    //      prsSupplier =
+    //          new DocCollection.PrsSupplier(
+    //              () ->
+    //                  new PerReplicaStates(
+    //                      (String) prs.get("path"),
+    //                      (Integer) prs.get("cversion"),
+    //                      (List<String>) prs.get("states")));
+    //    }
     return ClusterState.collectionFromObjects(e.getKey(), m, znodeVersion, prsSupplier);
   }
 

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/DocCollection.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/DocCollection.java
@@ -220,7 +220,7 @@ public class DocCollection extends ZkNodeProps implements Iterable<Slice> {
           propMap,
           router,
           znodeVersion,
-          childNodesVersion);
+          newPerReplicaStates.cversion);
     } else {
       return this;
     }

--- a/solr/solrj/src/test/org/apache/solr/client/solrj/impl/CloudSolrClientTest.java
+++ b/solr/solrj/src/test/org/apache/solr/client/solrj/impl/CloudSolrClientTest.java
@@ -1167,8 +1167,7 @@ public class CloudSolrClientTest extends SolrCloudTestCase {
     assertEquals("This should be OK", 0, response.getStatus());
 
     DocCollection c = cluster.getZkStateReader().getCollection(testCollection);
-    PerReplicaStates prs =
-        PerReplicaStatesFetcher.fetch(collectionPath, cluster.getZkClient(), null);
+    PerReplicaStates prs = PerReplicaStatesFetcher.fetch(collectionPath, cluster.getZkClient());
     assertEquals(4, prs.states.size());
 
     JettySolrRunner jsr = null;
@@ -1178,7 +1177,7 @@ public class CloudSolrClientTest extends SolrCloudTestCase {
       // Now let's do an add replica
       CollectionAdminRequest.addReplicaToShard(testCollection, "shard1")
           .process(cluster.getSolrClient());
-      prs = PerReplicaStatesFetcher.fetch(collectionPath, cluster.getZkClient(), null);
+      prs = PerReplicaStatesFetcher.fetch(collectionPath, cluster.getZkClient());
       assertEquals(5, prs.states.size());
 
       // create a collection with PRS and v2 API
@@ -1192,7 +1191,7 @@ public class CloudSolrClientTest extends SolrCloudTestCase {
           .build()
           .process(cluster.getSolrClient());
       cluster.waitForActiveCollection(testCollection, 2, 4);
-      prs = PerReplicaStatesFetcher.fetch(collectionPath, cluster.getZkClient(), null);
+      prs = PerReplicaStatesFetcher.fetch(collectionPath, cluster.getZkClient());
       assertEquals(4, prs.states.size());
     } finally {
       if (jsr != null) {

--- a/solr/solrj/src/test/org/apache/solr/common/cloud/PerReplicaStatesIntegrationTest.java
+++ b/solr/solrj/src/test/org/apache/solr/common/cloud/PerReplicaStatesIntegrationTest.java
@@ -78,7 +78,7 @@ public class PerReplicaStatesIntegrationTest extends SolrCloudTestCase {
       DocCollection c = cluster.getZkStateReader().getCollection(testCollection);
       PerReplicaStates prs =
           PerReplicaStatesFetcher.fetch(
-              DocCollection.getCollectionPath(testCollection), cluster.getZkClient(), null);
+              DocCollection.getCollectionPath(testCollection), cluster.getZkClient());
       assertEquals(4, prs.states.size());
       JettySolrRunner jsr = cluster.startJettySolrRunner();
       // Now let's do an add replica
@@ -87,7 +87,7 @@ public class PerReplicaStatesIntegrationTest extends SolrCloudTestCase {
       cluster.waitForActiveCollection(testCollection, 2, 5);
       prs =
           PerReplicaStatesFetcher.fetch(
-              DocCollection.getCollectionPath(testCollection), cluster.getZkClient(), null);
+              DocCollection.getCollectionPath(testCollection), cluster.getZkClient());
       assertEquals(5, prs.states.size());
 
       // Test delete replica
@@ -97,7 +97,7 @@ public class PerReplicaStatesIntegrationTest extends SolrCloudTestCase {
       cluster.waitForActiveCollection(testCollection, 2, 4);
       prs =
           PerReplicaStatesFetcher.fetch(
-              DocCollection.getCollectionPath(testCollection), cluster.getZkClient(), null);
+              DocCollection.getCollectionPath(testCollection), cluster.getZkClient());
       assertEquals(4, prs.states.size());
 
       testCollection = "perReplicaState_testv2";
@@ -112,7 +112,7 @@ public class PerReplicaStatesIntegrationTest extends SolrCloudTestCase {
 
       prs =
           PerReplicaStatesFetcher.fetch(
-              DocCollection.getCollectionPath(testCollection), cluster.getZkClient(), null);
+              DocCollection.getCollectionPath(testCollection), cluster.getZkClient());
       assertEquals(4, prs.states.size());
     } finally {
       cluster.shutdown();
@@ -142,8 +142,7 @@ public class PerReplicaStatesIntegrationTest extends SolrCloudTestCase {
       DocCollection c = cluster.getZkStateReader().getCollection(testCollection);
       String collectionPath = DocCollection.getCollectionPath(testCollection);
       PerReplicaStates prs =
-          PerReplicaStatesFetcher.fetch(
-              collectionPath, SolrCloudTestCase.cluster.getZkClient(), null);
+          PerReplicaStatesFetcher.fetch(collectionPath, SolrCloudTestCase.cluster.getZkClient());
       assertEquals(1, prs.states.size());
 
       JettySolrRunner jsr = cluster.startJettySolrRunner();
@@ -153,9 +152,7 @@ public class PerReplicaStatesIntegrationTest extends SolrCloudTestCase {
       CollectionAdminRequest.addReplicaToShard(testCollection, "shard1")
           .process(cluster.getSolrClient());
       cluster.waitForActiveCollection(testCollection, 1, 2);
-      prs =
-          PerReplicaStatesFetcher.fetch(
-              collectionPath, SolrCloudTestCase.cluster.getZkClient(), null);
+      prs = PerReplicaStatesFetcher.fetch(collectionPath, SolrCloudTestCase.cluster.getZkClient());
       assertEquals(2, prs.states.size());
       c = cluster.getZkStateReader().getCollection(testCollection);
       prs.states.forEachEntry((s, state) -> assertEquals(Replica.State.ACTIVE, state.state));
@@ -181,15 +178,13 @@ public class PerReplicaStatesIntegrationTest extends SolrCloudTestCase {
           log.info("after down node, state.json v: {}", c.getZNodeVersion());
         }
         prs =
-            PerReplicaStatesFetcher.fetch(
-                collectionPath, SolrCloudTestCase.cluster.getZkClient(), null);
+            PerReplicaStatesFetcher.fetch(collectionPath, SolrCloudTestCase.cluster.getZkClient());
         PerReplicaStates.State st = prs.get(replicaName);
         assertNotEquals(Replica.State.ACTIVE, st.state);
         jsr.start();
         cluster.waitForActiveCollection(testCollection, 1, 2);
         prs =
-            PerReplicaStatesFetcher.fetch(
-                collectionPath, SolrCloudTestCase.cluster.getZkClient(), null);
+            PerReplicaStatesFetcher.fetch(collectionPath, SolrCloudTestCase.cluster.getZkClient());
         prs.states.forEachEntry((s, state) -> assertEquals(Replica.State.ACTIVE, state.state));
       }
 
@@ -222,7 +217,7 @@ public class PerReplicaStatesIntegrationTest extends SolrCloudTestCase {
       PerReplicaStates prs1 =
           original =
               PerReplicaStatesFetcher.fetch(
-                  DocCollection.getCollectionPath(COLL), cluster.getZkClient(), null);
+                  DocCollection.getCollectionPath(COLL), cluster.getZkClient());
       log.info("prs1 : {}", prs1);
 
       CollectionAdminRequest.modifyCollection(
@@ -249,7 +244,7 @@ public class PerReplicaStatesIntegrationTest extends SolrCloudTestCase {
                 AtomicBoolean anyFail = new AtomicBoolean(false);
                 PerReplicaStates prs2 =
                     PerReplicaStatesFetcher.fetch(
-                        DocCollection.getCollectionPath(COLL), cluster.getZkClient(), null);
+                        DocCollection.getCollectionPath(COLL), cluster.getZkClient());
                 prs2.states.forEachEntry(
                     (r, newState) -> {
                       if (newState.getDuplicate() != null) anyFail.set(true);
@@ -262,7 +257,7 @@ public class PerReplicaStatesIntegrationTest extends SolrCloudTestCase {
       System.out.println(
           "prs2 : "
               + PerReplicaStatesFetcher.fetch(
-                  DocCollection.getCollectionPath(COLL), cluster.getZkClient(), null));
+                  DocCollection.getCollectionPath(COLL), cluster.getZkClient()));
       cluster.shutdown();
     }
   }


### PR DESCRIPTION
This is based on the existing change from #83 but go a bit deeper.

This removes the `PerReplicaStates` field and reference from `DocCollection` instance. `DocCollection` no longer has 2 states for replicas (one in `slices` field and one in `perReplicaStates` field), the `slices` is now source of truth. This has certain advantage:
1. `DocCollection` is completely immutable, there's no longer the `perReplicateStates/prs supplier` field which might mutate after `DocCollection` object instantiation.
2. `DocCollection` looks a bit cleaner, no longer need special handling for PRS
3. The single source truth in `slices` also makes it easier to maintain consistent state. In the existing `DocCollection` with accepts a prsSupplier, it sets the same instance of supplier to Slice and Replicas. And might do updates directly to the "prs" field of such supplier, which the changes will then suppose to make visible automatically to Slice and Replica. However, this could be problematic as Slice and Replica might keep other information that is generated of the "older" prs field, so extra logic needed to added to ensure things are "in sync" (for example this https://github.com/cowpaths/fullstory-solr/blob/main/solr/solrj/src/java/org/apache/solr/common/cloud/Slice.java#L290). 
4. This advantage only apply to the change in #83. We no longer need to make full copy of slice based on the provided PerReplicateStates when constructing the `DocCollection`. But of course, if we are building a Updated Collection with PRS changes, a full copy is still needed. This is unavoidable if we want immutability I suppose :/


The biggest change for removing the `PerReplicaStates` is that `DocCollection` used to keep track of such value, and it is required when fetching the PRS states with `PerReplicaStatesFetcher` (since it might return the existing object if it has not been changed, my guess is to save memory? and also to make sure we are updating the "correct" instance of `PerReplicaStates` so changes are visible to all the related Slice/Replica in memory). 

So the proposed change is to keep the `PerReplicaStates` fetched so far in the `PerReplicaStatesFetcher` instead.

Also since `DocCollection` no longer accepts the `PerReplicaStates` (or the supplier), that means whoever construct the `DocCollection` needs to "figure out the final state of the slices/replicas" before pass the slices to the ctor. Those methods need to call the `DocCollection#buildDocCollection` with the supplier for now.