### PR TITLE
Adding ability to get fields via glob patterns for export handler

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/export/ExportWriter.java
+++ b/solr/core/src/java/org/apache/solr/handler/export/ExportWriter.java
@@ -847,7 +847,7 @@ public class ExportWriter implements SolrCore.RawWriter, Closeable {
     for (String field : fields) {
       try {
         if (field.contains("*")) {
-          expandedFields.addAll(getGlobFields(field, searcher, fieldsProcessed));
+          getGlobFields(field, searcher, fieldsProcessed, expandedFields);
         } else {
           if (fieldsProcessed.add(field)) {
             expandedFields.add(searcher.getSchema().getField(field));
@@ -858,7 +858,7 @@ public class ExportWriter implements SolrCore.RawWriter, Closeable {
       }
     }
 
-    return new ArrayList<>(expandedFields);
+    return expandedFields;
   }
 
   /**
@@ -869,20 +869,20 @@ public class ExportWriter implements SolrCore.RawWriter, Closeable {
    * @param fieldsProcessed the set of field names already processed to avoid duplicating
    * @return a list of fields that match a given glob pattern
    */
-  private List<SchemaField> getGlobFields(
-      String fieldPattern, SolrIndexSearcher searcher, Set<String> fieldsProcessed) {
-    List<SchemaField> schemaFields = new ArrayList<>();
+  private void getGlobFields(
+      String fieldPattern,
+      SolrIndexSearcher searcher,
+      Set<String> fieldsProcessed,
+      List<SchemaField> expandedFields) {
     for (FieldInfo fi : searcher.getFieldInfos()) {
       if (FilenameUtils.wildcardMatch(fi.getName(), fieldPattern)) {
         SchemaField schemaField = searcher.getSchema().getField(fi.getName());
         if (fieldsProcessed.add(fi.getName())
             && schemaField.hasDocValues()
             && schemaField.useDocValuesAsStored()) {
-          schemaFields.add(schemaField);
+          expandedFields.add(schemaField);
         }
       }
     }
-
-    return schemaFields;
   }
 }

--- a/solr/core/src/java/org/apache/solr/handler/export/ExportWriter.java
+++ b/solr/core/src/java/org/apache/solr/handler/export/ExportWriter.java
@@ -867,7 +867,7 @@ public class ExportWriter implements SolrCore.RawWriter, Closeable {
    * @param fieldPattern the glob pattern to match
    * @param searcher an index search to access schema info
    * @param fieldsProcessed the set of field names already processed to avoid duplicating
-   * @return a list of fields that match a given glob pattern
+   * @param expandedFields the list of fields to add expanded field names into
    */
   private void getGlobFields(
       String fieldPattern,

--- a/solr/core/src/java/org/apache/solr/handler/export/ExportWriter.java
+++ b/solr/core/src/java/org/apache/solr/handler/export/ExportWriter.java
@@ -85,8 +85,6 @@ import org.apache.solr.search.SyntaxError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.validation.Schema;
-
 /**
  * Prepares and writes the documents requested by /export requests
  *
@@ -833,13 +831,17 @@ public class ExportWriter implements SolrCore.RawWriter, Closeable {
   }
 
   /**
-   * Creates a complete field list using the provided field list by expanding any glob patterns into field names
+   * Creates a complete field list using the provided field list by expanding any glob patterns into
+   * field names
+   *
    * @param fields the original set of fields provided
    * @param searcher an index searcher to access schema info
    * @return a complete list of fields included any fields matching glob patterns
-   * @throws IOException if a provided field does not exist or cannot be retrieved from the schema info
+   * @throws IOException if a provided field does not exist or cannot be retrieved from the schema
+   *     info
    */
-  private List<SchemaField> expandFieldList(String[] fields, SolrIndexSearcher searcher) throws IOException {
+  private List<SchemaField> expandFieldList(String[] fields, SolrIndexSearcher searcher)
+      throws IOException {
     List<SchemaField> expandedFields = new ArrayList<>(fields.length);
     Set<String> fieldsProcessed = new HashSet<>();
     for (String field : fields) {
@@ -861,17 +863,21 @@ public class ExportWriter implements SolrCore.RawWriter, Closeable {
 
   /**
    * Create a list of schema fields that match a given glob pattern
+   *
    * @param fieldPattern the glob pattern to match
    * @param searcher an index search to access schema info
    * @param fieldsProcessed the set of field names already processed to avoid duplicating
    * @return a list of fields that match a given glob pattern
    */
-  private List<SchemaField> getGlobFields(String fieldPattern, SolrIndexSearcher searcher, Set<String> fieldsProcessed) {
+  private List<SchemaField> getGlobFields(
+      String fieldPattern, SolrIndexSearcher searcher, Set<String> fieldsProcessed) {
     List<SchemaField> schemaFields = new ArrayList<>();
     for (FieldInfo fi : searcher.getFieldInfos()) {
       if (FilenameUtils.wildcardMatch(fi.getName(), fieldPattern)) {
         SchemaField schemaField = searcher.getSchema().getField(fi.getName());
-        if (fieldsProcessed.add(fi.getName()) && schemaField.hasDocValues() && schemaField.useDocValuesAsStored()) {
+        if (fieldsProcessed.add(fi.getName())
+            && schemaField.hasDocValues()
+            && schemaField.useDocValuesAsStored()) {
           schemaFields.add(schemaField);
         }
       }


### PR DESCRIPTION
Currently the Solr stream and export handlers are not able to use glob patterns for fields, similar to how we can for the select handler. For example, passing `fl=*` or `fl=*_bool` to the export handler will not work.

In order to be able to use the export handler with a schema having dynamic fields, we will need the ability to support glob patterns. This implementation finds fields in the schema that match the given pattern and only includes them for export if they are both `docValues=true` and `useDocValuesAsStored=true`, otherwise they are skipped.