### PR TITLE
SAI-4421: Fix for missing attributes from cluster api call for PRS collection in 9.2

### DIFF
--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -84,7 +84,7 @@ public class ZkStateReader implements SolrCloseable {
   public static final String STATE_PROP = "state";
   // if this flag equals to false and the replica does not exist in cluster state, set state op
   // become no op (default is true)
-  public static final String FORCE_SET_STATE_PROP = "force_set_state";
+  public static final String FORCE_SET_STATE_PROP = Replica.ReplicaStateProps.FORCE_SET_STATE;
   /** SolrCore name. */
   public static final String CORE_NAME_PROP = "core";
 

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/DocCollection.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/DocCollection.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -32,6 +31,7 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.BiPredicate;
 import java.util.function.Supplier;
+import org.apache.solr.common.MapWriter;
 import org.apache.solr.common.cloud.Replica.ReplicaStateProps;
 import org.noggit.JSONWriter;
 import org.slf4j.Logger;
@@ -327,10 +327,12 @@ public class DocCollection extends ZkNodeProps implements Iterable<Slice> {
 
   @Override
   public void write(JSONWriter jsonWriter) {
-    LinkedHashMap<String, Object> all = new LinkedHashMap<>(slices.size() + 1);
-    all.putAll(propMap);
-    all.put(CollectionStateProps.SHARDS, slices);
-    jsonWriter.write(all);
+    jsonWriter.write(
+        (MapWriter)
+            ew -> {
+              propMap.forEach(ew.getBiConsumer());
+              ew.put(CollectionStateProps.SHARDS, slices);
+            });
   }
 
   public Replica getReplica(String coreNodeName) {

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/Replica.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/Replica.java
@@ -373,7 +373,7 @@ public class Replica extends ZkNodeProps implements MapWriter {
 
   @Override
   public void writeMap(MapWriter.EntryWriter ew) throws IOException {
-    ew.put(name, _allPropsWriter());
+    _allPropsWriter().writeMap(ew);
   }
 
   private static final Map<String, State> STATES = new HashMap<>();

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/Replica.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/Replica.java
@@ -16,19 +16,14 @@
  */
 package org.apache.solr.common.cloud;
 
-import static org.apache.solr.common.ConditionalMapWriter.NON_NULL_VAL;
-import static org.apache.solr.common.ConditionalMapWriter.dedupeKeyPredicate;
-
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.BiPredicate;
 import org.apache.solr.common.MapWriter;
 import org.apache.solr.common.util.Utils;
 import org.noggit.JSONWriter;
@@ -392,30 +387,27 @@ public class Replica extends ZkNodeProps implements MapWriter {
   }
 
   private MapWriter _allPropsWriter() {
-    BiPredicate<CharSequence, Object> p = dedupeKeyPredicate(new HashSet<>()).and(NON_NULL_VAL);
-    return writer -> {
-      // XXX this is why this class should be immutable - it's a mess !!!
-
-      // propMap takes precedence because it's mutable and we can't control its
-      // contents, so a third party may override some declared fields
+    return w -> {
+      w.putIfNotNull(ReplicaStateProps.CORE_NAME, core)
+          .putIfNotNull(ReplicaStateProps.NODE_NAME, node)
+          .putIfNotNull(ReplicaStateProps.TYPE, type.toString())
+          .putIfNotNull(ReplicaStateProps.STATE, getState().toString().toLowerCase(Locale.ROOT))
+          .putIfNotNull(ReplicaStateProps.LEADER, () -> isLeader() ? "true" : null)
+          .putIfNotNull(
+              ReplicaStateProps.FORCE_SET_STATE, propMap.get(ReplicaStateProps.FORCE_SET_STATE))
+          .putIfNotNull(ReplicaStateProps.BASE_URL, propMap.get(ReplicaStateProps.BASE_URL));
       for (Map.Entry<String, Object> e : propMap.entrySet()) {
-        writer.put(e.getKey(), e.getValue(), p);
+        if (!ReplicaStateProps.WELL_KNOWN_PROPS.contains(e.getKey())) {
+          w.putIfNotNull(e.getKey(), e.getValue());
+        }
       }
-
-      writer
-          .put(ReplicaStateProps.CORE_NAME, core, p)
-          .put(ReplicaStateProps.NODE_NAME, node, p)
-          .put(ReplicaStateProps.TYPE, type.toString(), p)
-          .put(ReplicaStateProps.STATE, shard, p);
     };
   }
 
   @Override
   public void write(JSONWriter jsonWriter) {
-    Map<String, Object> map = new LinkedHashMap<>();
     // this serializes also our declared properties
-    _allPropsWriter().toMap(map);
-    jsonWriter.write(map);
+    jsonWriter.write(_allPropsWriter());
   }
 
   @Override
@@ -437,5 +429,9 @@ public class Replica extends ZkNodeProps implements MapWriter {
     String NODE_NAME = "node_name";
     String BASE_URL = "base_url";
     String PROPERTY_PREFIX = "property.";
+    String FORCE_SET_STATE = "force_set_state";
+    Set<String> WELL_KNOWN_PROPS =
+        Set.of(
+            LEADER, STATE, CORE_NAME, CORE_NODE_NAME, TYPE, NODE_NAME, BASE_URL, FORCE_SET_STATE);
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/Replica.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/Replica.java
@@ -78,13 +78,16 @@ public class Replica extends ZkNodeProps implements MapWriter {
      */
     public final String shortName;
 
+    public final String longName;
+
     State(String c) {
       this.shortName = c;
+      this.longName = super.toString().toLowerCase(Locale.ROOT);
     }
 
     @Override
     public String toString() {
-      return super.toString().toLowerCase(Locale.ROOT);
+      return longName;
     }
 
     /** Converts the state string to a State instance. */
@@ -391,7 +394,7 @@ public class Replica extends ZkNodeProps implements MapWriter {
       w.putIfNotNull(ReplicaStateProps.CORE_NAME, core)
           .putIfNotNull(ReplicaStateProps.NODE_NAME, node)
           .putIfNotNull(ReplicaStateProps.TYPE, type.toString())
-          .putIfNotNull(ReplicaStateProps.STATE, getState().toString().toLowerCase(Locale.ROOT))
+          .putIfNotNull(ReplicaStateProps.STATE, getState().toString())
           .putIfNotNull(ReplicaStateProps.LEADER, () -> isLeader() ? "true" : null)
           .putIfNotNull(
               ReplicaStateProps.FORCE_SET_STATE, propMap.get(ReplicaStateProps.FORCE_SET_STATE))


### PR DESCRIPTION
## Description
https://fullstory.atlassian.net/browse/SAI-4421

It's found during benchmarking that solr-bench failed to restart Solr due to replicas not marked as leader/active from the cluster api call for PRS enabled collections.

This only happens in 9.2

## Cause
it appears that removing the readPrs() call in this change [SOLR-16580: Avoid making copies of DocCollection for PRS updates (#1242) · cowpaths/fullstory-solr@c4f4023](https://github.com/cowpaths/fullstory-solr/commit/c4f40233a718d60262ffc2610a02dfccdde7f641#diff-3cf27848269b8f72d6270cb4e36892fd67a270ea09d1531e97a48ad7c8355419L154)  stopped putting “leader” and “status” info from the replica state into the propMap of Replica. Such propMap is essential as the ClusterStatus handler has some pretty odd logic here [fullstory-solr/ClusterStatus.java at c4f40233a718d60262ffc2610a02dfccdde7f641 · cowpaths/fullstory-solr](https://github.com/cowpaths/fullstory-solr/blob/c4f40233a718d60262ffc2610a02dfccdde7f641/solr/core/src/java/org/apache/solr/handler/admin/ClusterStatus.java#L180-L183)  which serialize the DocCollection (which the underlying Replica has the PrsSupplier field) and immediately deserialize it back to a Map (which lost the PrsSupplier info), and after this point the Repica state and leadership info is lost.

## Solution
The fix is provided by Noble as in 
https://github.com/apache/solr/pull/1549
https://issues.apache.org/jira/browse/SOLR-16741

The solution changes the `_allPropsWriter` in `org.apache.solr.common.cloud.Replica` to include leader and state by making calls to `isLeader()` and `getState()` instead of getting them from the `propMap` which no longer has those 2 values in 9.2.

This is just a cherry pick of the commits from https://github.com/apache/solr/pull/1549 to our `fs/branch_9_2` branch

## Tests
Briefly tested locally (via solrman to ensure it sees the correct replica states). And with solrperf (performance tests run correctly on a new fs-solr hash with this cherry pick: https://github.com/cowpaths/fs-solr/commit/4ca5a5d05be9276d625eadea258fd210ef25f0aa)