### PR TITLE
default SOLR_SSL_PORT to SOLR_PORT

### DIFF
--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -1910,7 +1910,7 @@ if [[ "$SCRIPT_CMD" == "stop" && -z "${SOLR_PORT:-}" ]]; then
 fi
 
 : "${SOLR_PORT:=8983}"
-: "${SOLR_SSL_PORT:=8983}"
+: "${SOLR_SSL_PORT:=$SOLR_PORT}"
 
 if [ -n "${SOLR_PORT_ADVERTISE:-}" ]; then
   SOLR_OPTS+=("-Dsolr.port.advertise=$SOLR_PORT_ADVERTISE")


### PR DESCRIPTION
Quick update PR to #94, this allows running Solr HTTPS on ports other than `8983`. Before, if you set `-p 28983`, `SOLR_SSL_PORT` would still default to `8983`. If you're intending to start an HTTPS server, this is confusing, since `-p` only sets `SOLR_PORT` and not `SOLR_SSL_PORT`. Setting it here instead of in the `-p` switch case allows the user to set  `SOLR_SSL_PORT` via env. 