### PR TITLE
Fixed unit test case failure due to metric changes

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/UpdateRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/UpdateRequestHandler.java
@@ -138,17 +138,13 @@ public class UpdateRequestHandler extends ContentStreamHandlerBase
 
   @Override
   public HandlerMetrics getMetricsForThisRequest(SolrQueryRequest req) {
-    // using exactly the same logic in 8.x to preserve the behavior
-    boolean isDistrib =
-        req.getParams()
-            .getBool(
-                CommonParams.DISTRIB,
-                req.getCore() != null
-                    ? req.getCore().getCoreContainer().isZooKeeperAware()
-                    : false);
-    if (!isDistrib) {
+    // this is specific to FS client, we always set DISTRIB flag for all requests going straight to
+    // the core
+    Boolean distrib = req.getParams().getBool(CommonParams.DISTRIB);
+    if (distrib != null && !distrib) {
       return this.metricsLocal;
-    } else {
+    } else { // all updates not from our client (ie distrib should be null, whether it's
+      // re-distributed or not) should use this metrics
       return this.metrics;
     }
   }

--- a/solr/core/src/test/org/apache/solr/core/RequestHandlersTest.java
+++ b/solr/core/src/test/org/apache/solr/core/RequestHandlersTest.java
@@ -128,7 +128,7 @@ public class RequestHandlersTest extends SolrTestCaseJ4 {
     Map<String, Object> updateStats = updateHandler.getSolrMetricsContext().getMetricsSnapshot();
     Map<String, Object> termStats = termHandler.getSolrMetricsContext().getMetricsSnapshot();
 
-    Long updateTime = (Long) updateStats.get("UPDATE./update[local].totalTime");
+    Long updateTime = (Long) updateStats.get("UPDATE./update.totalTime");
     Long termTime = (Long) termStats.get("QUERY./terms.totalTime");
 
     assertNotEquals("RequestHandlers should not share statistics!", updateTime, termTime);


### PR DESCRIPTION
## Description
There is a unit test case failure after change in #95 

https://github.com/cowpaths/fullstory-solr/actions/runs/4881276600/jobs/8709971562?pr=98

## Cause
For non cloud based update request, the code logic would identify as isDistrib = false, hence incrementing the `update[local]` metrics instead of the expected `update` metrics in the unit test case

## Solution
Using `distrib=false` in specific to our FS client https://github.com/cowpaths/mn/blob/6b6148200d1fdf416ed7a00e04888d5b9dbd64de/projects/fullstory/go/src/fs/solr/solrcloud/client.go#L427  (in fact from code search and debugging, distrib does not affect the update flow)

In order to keep the existing behavior we will ONLY send the update requests with explicit `distrib=false` to our "local" update metrics, and everything else should just fall into the default update metrics.

## Test
Verified that the test case no longer failed
```
./gradlew :solr:solrj:test --tests "org.apache.solr.client.solrj.request.TestCoreAdmin.testCoreSwap" -Ptests.jvms=1 "-Ptests.jvmargs=-XX:TieredStopAtLevel=1 -XX:+UseParallelGC -XX:ActiveProcessorCount=1 -XX:ReservedCodeCacheSize=120m" -Ptests.seed=62C50F0779639ECC -Ptests.file.encoding=ISO-8859-1
```

Going to deploy to playpen c91 to ensure the update metrics are correct (still going to the "local" grafana metrics)