### PR TITLE
SAI-4358: Fixed breakpoint cleanup in unit test case

### DIFF
--- a/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
@@ -786,7 +786,7 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
       assertTrue(prsZkNodeNotFoundExceptionThrown.get());
     } finally {
       // clear breakpoints
-      CommonTestInjection.setBreakpoint(ZkStateReader.class.getName() + "/beforePrsFetch", null);
+      CommonTestInjection.setBreakpoint(PerReplicaStatesFetcher.class.getName() + "/beforePrsFetch", null);
       CommonTestInjection.setBreakpoint(ZkStateReader.class.getName() + "/exercised", null);
     }
   }

--- a/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/overseer/ZkStateReaderTest.java
@@ -786,7 +786,8 @@ public class ZkStateReaderTest extends SolrTestCaseJ4 {
       assertTrue(prsZkNodeNotFoundExceptionThrown.get());
     } finally {
       // clear breakpoints
-      CommonTestInjection.setBreakpoint(PerReplicaStatesFetcher.class.getName() + "/beforePrsFetch", null);
+      CommonTestInjection.setBreakpoint(
+          PerReplicaStatesFetcher.class.getName() + "/beforePrsFetch", null);
       CommonTestInjection.setBreakpoint(ZkStateReader.class.getName() + "/exercised", null);
     }
   }


### PR DESCRIPTION
## Description
Found unit test case error as in https://github.com/cowpaths/fullstory-solr/actions/runs/5074467211/attempts/1

## Cause
This is due to the cherry pick missed the fact that the `/beforePrsFetch` breakpoint is now placed in `PerReplicaStateFetcher` instead of `ZkStateReader` therefore subsequent tests could still trigger the breakpoint as the cleanup had incorrect name (ie this label https://github.com/cowpaths/fullstory-solr/pull/103/files#diff-c92a116c89a724226fb6efbea4c4f90ab70b40a779e1c50155c8eca646520358R750 did not match this https://github.com/cowpaths/fullstory-solr/pull/103/files#diff-c92a116c89a724226fb6efbea4c4f90ab70b40a779e1c50155c8eca646520358R789 )