### PR TITLE
Updating streaming parser to better handle nested quotes

### DIFF
--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/CloudSolrStream.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/CloudSolrStream.java
@@ -184,11 +184,7 @@ public class CloudSolrStream extends TupleStream implements Expressible {
 
     for (Entry<String, String[]> param : params.getMap().entrySet()) {
       for (String val : param.getValue()) {
-        // SOLR-8409: Escaping the " is a special case.
-        // Do note that in any other BASE streams with parameters where a " might come into play
-        // that this same replacement needs to take place.
-        expression.addParameter(
-            new StreamExpressionNamedParameter(param.getKey(), val.replace("\"", "\\\"")));
+        expression.addParameter(new StreamExpressionNamedParameter(param.getKey(), val));
       }
     }
 

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionNamedParameter.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionNamedParameter.java
@@ -102,19 +102,20 @@ public class StreamExpressionNamedParameter implements StreamExpressionParameter
    */
   private static final Pattern ESCAPE_QUOTES = Pattern.compile("(\\\\)?\"");
 
-  private static final Function<MatchResult, String> REPLACEMENT_FUNCTION = (m) -> {
-    if (m.start(1) == -1) {
-      // the quote was _not_ already escaped, so replace it with a simple escaped quote
-      // (single literal doublequote preceded by a single literal backslash), for a
-      // final result: `\"`.
-      return "\\\\\"";
-    } else {
-      // the quote was already escaped, so escape it at the _Solr syntax_ level by
-      // preceding the existing `\"` with an extra literal backslash `\\`, for final
-      // result: `\\\"`.
-      return "\\\\\\\\\\\\\"";
-    }
-  };
+  private static final Function<MatchResult, String> REPLACEMENT_FUNCTION =
+      (m) -> {
+        if (m.start(1) == -1) {
+          // the quote was _not_ already escaped, so replace it with a simple escaped quote
+          // (single literal doublequote preceded by a single literal backslash), for a
+          // final result: `\"`.
+          return "\\\\\"";
+        } else {
+          // the quote was already escaped, so escape it at the _Solr syntax_ level by
+          // preceding the existing `\"` with an extra literal backslash `\\`, for final
+          // result: `\\\"`.
+          return "\\\\\\\\\\\\\"";
+        }
+      };
 
   @Override
   public boolean equals(Object other) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionNamedParameter.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionNamedParameter.java
@@ -17,6 +17,9 @@
 package org.apache.solr.client.solrj.io.stream.expr;
 
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.regex.MatchResult;
+import java.util.regex.Pattern;
 
 /** Provides a named parameter */
 public class StreamExpressionNamedParameter implements StreamExpressionParameter {
@@ -85,14 +88,33 @@ public class StreamExpressionNamedParameter implements StreamExpressionParameter
 
     if (requiresQuote) {
       sb.append("\"");
-    }
-    sb.append(parameter.toString());
-    if (requiresQuote) {
+      sb.append(ESCAPE_QUOTES.matcher(parameter.toString()).replaceAll(REPLACEMENT_FUNCTION));
       sb.append("\"");
+    } else {
+      sb.append(parameter.toString());
     }
 
     return sb.toString();
   }
+
+  /**
+   * single literal doublequote, possibly already escaped by a preceding single literal backslash
+   */
+  private static final Pattern ESCAPE_QUOTES = Pattern.compile("(\\\\)?\"");
+
+  private static final Function<MatchResult, String> REPLACEMENT_FUNCTION = (m) -> {
+    if (m.start(1) == -1) {
+      // the quote was _not_ already escaped, so replace it with a simple escaped quote
+      // (single literal doublequote preceded by a single literal backslash), for a
+      // final result: `\"`.
+      return "\\\\\"";
+    } else {
+      // the quote was already escaped, so escape it at the _Solr syntax_ level by
+      // preceding the existing `\"` with an extra literal backslash `\\`, for final
+      // result: `\\\"`.
+      return "\\\\\\\\\\\\\"";
+    }
+  };
 
   @Override
   public boolean equals(Object other) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionNamedParameter.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionNamedParameter.java
@@ -17,7 +17,6 @@
 package org.apache.solr.client.solrj.io.stream.expr;
 
 import java.util.Objects;
-import java.util.function.Function;
 import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 
@@ -88,7 +87,10 @@ public class StreamExpressionNamedParameter implements StreamExpressionParameter
 
     if (requiresQuote) {
       sb.append("\"");
-      sb.append(ESCAPE_QUOTES.matcher(parameter.toString()).replaceAll(REPLACEMENT_FUNCTION));
+      sb.append(
+          ESCAPE_QUOTES
+              .matcher(parameter.toString())
+              .replaceAll(StreamExpressionNamedParameter::escapeQuoteMatch));
       sb.append("\"");
     } else {
       sb.append(parameter.toString());
@@ -102,20 +104,19 @@ public class StreamExpressionNamedParameter implements StreamExpressionParameter
    */
   private static final Pattern ESCAPE_QUOTES = Pattern.compile("(\\\\)?\"");
 
-  private static final Function<MatchResult, String> REPLACEMENT_FUNCTION =
-      (m) -> {
-        if (m.start(1) == -1) {
-          // the quote was _not_ already escaped, so replace it with a simple escaped quote
-          // (single literal doublequote preceded by a single literal backslash), for a
-          // final result: `\"`.
-          return "\\\\\"";
-        } else {
-          // the quote was already escaped, so escape it at the _Solr syntax_ level by
-          // preceding the existing `\"` with an extra literal backslash `\\`, for final
-          // result: `\\\"`.
-          return "\\\\\\\\\\\\\"";
-        }
-      };
+  private static String escapeQuoteMatch(MatchResult m) {
+    if (m.start(1) == -1) {
+      // the quote was _not_ already escaped, so replace it with a simple escaped quote
+      // (single literal doublequote preceded by a single literal backslash), for a
+      // final result: `\"`.
+      return "\\\\\"";
+    } else {
+      // the quote was already escaped, so escape it at the _Solr syntax_ level by
+      // preceding the existing `\"` with an extra literal backslash `\\`, for final
+      // result: `\\\"`.
+      return "\\\\\\\\\\\\\"";
+    }
+  }
 
   @Override
   public boolean equals(Object other) {

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionParser.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionParser.java
@@ -22,11 +22,16 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /** Takes a prefix notation expression and returns a tokenized expression */
 public class StreamExpressionParser {
 
   static char[] wordChars = {'_', '.', '-'};
+
+  // Regex pattern to find `:\"<somequery>\"` in expression and replace with `:"<somequery>"` to work with query parsing
+  static Pattern quotedFieldPattern = Pattern.compile("(?<!\\\\\\\\):\\\\\\\".*?\\\\\\\"");
 
   static {
     Arrays.sort(wordChars);
@@ -123,9 +128,11 @@ public class StreamExpressionParser {
         }
       }
 
-      // if contain \" replace with "
-      if (parameter.contains("\\\"")) {
-        parameter = parameter.replace("\\\"", "\"");
+      // if contain \" wrapping replace with "
+      Matcher matcher = quotedFieldPattern.matcher(parameter);
+      while (matcher.find()) {
+        String matchResult = matcher.group();
+        parameter = parameter.replace(matchResult, matchResult.replace("\\\"", "\""));
         if (0 == parameter.length()) {
           throw new IllegalArgumentException(
               String.format(Locale.ROOT, "'%s' is not a proper named parameter clause", working));

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionParser.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionParser.java
@@ -22,6 +22,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Function;
+import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -29,10 +31,6 @@ import java.util.regex.Pattern;
 public class StreamExpressionParser {
 
   static char[] wordChars = {'_', '.', '-'};
-
-  // Regex pattern to find `:\"<somequery>\"` in expression and replace with `:"<somequery>"` to
-  // work with query parsing
-  static Pattern quotedFieldPattern = Pattern.compile("(?<!\\\\\\\\):\\\\\\\".*?\\\\\\\"");
 
   static {
     Arrays.sort(wordChars);
@@ -101,6 +99,23 @@ public class StreamExpressionParser {
     return expression;
   }
 
+  /**
+   * simple escaped doublequote `\"`, possibly escaped at the Solr syntax level by a preceding
+   * literal backslash `\\\"`.
+   */
+  private static final Pattern ESCAPED_QUOTE = Pattern.compile("(\\\\\\\\)?\\\\\"");
+
+  private static final Function<MatchResult, String> REPLACEMENT_FUNCTION = (m) -> {
+    if (m.start(1) == -1) {
+      // the quote was simply escaped, so replace it with a simple unescaped quote
+      return "\"";
+    } else {
+      // the quote was nested-escaped, so we strip escaping at the _Solr syntax_ level,
+      // leaving a simply-escaped quote -- `\\\"` => `\"`
+      return "\\\\\"";
+    }
+  };
+
   private static StreamExpressionNamedParameter generateNamedParameterExpression(String clause) {
     String working = clause.trim();
 
@@ -127,16 +142,22 @@ public class StreamExpressionParser {
           throw new IllegalArgumentException(
               String.format(Locale.ROOT, "'%s' is not a proper named parameter clause", working));
         }
-      }
 
-      // if contain \" wrapping replace with "
-      Matcher matcher = quotedFieldPattern.matcher(parameter);
-      while (matcher.find()) {
-        String matchResult = matcher.group();
-        parameter = parameter.replace(matchResult, matchResult.replace("\\\"", "\""));
-        if (0 == parameter.length()) {
-          throw new IllegalArgumentException(
-              String.format(Locale.ROOT, "'%s' is not a proper named parameter clause", working));
+        // if contain \" unwrap one level of escaping
+        if (parameter.contains("\\\"")) {
+          Matcher m = ESCAPED_QUOTE.matcher(parameter);
+          StringBuilder sb = new StringBuilder(parameter.length());
+          boolean hasMatch = m.find(); // position the matcher
+          assert hasMatch;
+          do {
+            m.appendReplacement(sb, REPLACEMENT_FUNCTION.apply(m));
+          } while (m.find());
+          m.appendTail(sb);
+          parameter = sb.toString();
+          if (0 == parameter.length()) {
+            throw new IllegalArgumentException(
+                String.format(Locale.ROOT, "'%s' is not a proper named parameter clause", working));
+          }
         }
       }
 

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionParser.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionParser.java
@@ -105,16 +105,17 @@ public class StreamExpressionParser {
    */
   private static final Pattern ESCAPED_QUOTE = Pattern.compile("(\\\\\\\\)?\\\\\"");
 
-  private static final Function<MatchResult, String> REPLACEMENT_FUNCTION = (m) -> {
-    if (m.start(1) == -1) {
-      // the quote was simply escaped, so replace it with a simple unescaped quote
-      return "\"";
-    } else {
-      // the quote was nested-escaped, so we strip escaping at the _Solr syntax_ level,
-      // leaving a simply-escaped quote -- `\\\"` => `\"`
-      return "\\\\\"";
-    }
-  };
+  private static final Function<MatchResult, String> REPLACEMENT_FUNCTION =
+      (m) -> {
+        if (m.start(1) == -1) {
+          // the quote was simply escaped, so replace it with a simple unescaped quote
+          return "\"";
+        } else {
+          // the quote was nested-escaped, so we strip escaping at the _Solr syntax_ level,
+          // leaving a simply-escaped quote -- `\\\"` => `\"`
+          return "\\\\\"";
+        }
+      };
 
   private static StreamExpressionNamedParameter generateNamedParameterExpression(String clause) {
     String working = clause.trim();

--- a/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionParser.java
+++ b/solr/solrj-streaming/src/java/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionParser.java
@@ -30,7 +30,8 @@ public class StreamExpressionParser {
 
   static char[] wordChars = {'_', '.', '-'};
 
-  // Regex pattern to find `:\"<somequery>\"` in expression and replace with `:"<somequery>"` to work with query parsing
+  // Regex pattern to find `:\"<somequery>\"` in expression and replace with `:"<somequery>"` to
+  // work with query parsing
   static Pattern quotedFieldPattern = Pattern.compile("(?<!\\\\\\\\):\\\\\\\".*?\\\\\\\"");
 
   static {

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamDecoratorTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamDecoratorTest.java
@@ -3713,7 +3713,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
     assertEquals(tuples.get(0).getString("b"), "2");
     assertEquals(tuples.get(0).getString("c"), "3");
 
-    assertEquals(tuples.get(1).getString("a"), "hello, world");
+    assertEquals(tuples.get(1).getString("a"), "\\\"hello, world\\\"");
     assertEquals(tuples.get(1).getString("b"), "9000");
     assertEquals(tuples.get(1).getString("c"), "20");
 

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamDecoratorTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamDecoratorTest.java
@@ -3713,7 +3713,7 @@ public class StreamDecoratorTest extends SolrCloudTestCase {
     assertEquals(tuples.get(0).getString("b"), "2");
     assertEquals(tuples.get(0).getString("c"), "3");
 
-    assertEquals(tuples.get(1).getString("a"), "\\\"hello, world\\\"");
+    assertEquals(tuples.get(1).getString("a"), "hello, world");
     assertEquals(tuples.get(1).getString("b"), "9000");
     assertEquals(tuples.get(1).getString("c"), "20");
 

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamExpressionToExpessionTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamExpressionToExpessionTest.java
@@ -580,11 +580,11 @@ public class StreamExpressionToExpessionTest extends SolrTestCase {
     String originalExpressionString =
         "search(collection1,fl=\"id,first\",sort=\"first asc\",q={!bool filter=\"presentTitles:\\\"chief, executive officer\\\"\" filter=\"age:[36 TO *]\")";
     try (CloudSolrStream firstStream =
-             new CloudSolrStream(StreamExpressionParser.parse(originalExpressionString), factory)) {
+        new CloudSolrStream(StreamExpressionParser.parse(originalExpressionString), factory)) {
       String firstExpressionString = firstStream.toExpression(factory).toString();
 
       try (CloudSolrStream secondStream =
-               new CloudSolrStream(StreamExpressionParser.parse(firstExpressionString), factory)) {
+          new CloudSolrStream(StreamExpressionParser.parse(firstExpressionString), factory)) {
         String secondExpressionString = secondStream.toExpression(factory).toString();
 
         assertTrue(

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamExpressionToExpessionTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/StreamExpressionToExpessionTest.java
@@ -574,6 +574,30 @@ public class StreamExpressionToExpessionTest extends SolrTestCase {
   }
 
   @Test
+  public void testCloudSolrStreamWithNestedEscapedQuote() throws Exception {
+
+    // Analogous to `testCloudSolrStreamWithEscapedQuote()`, but accounts for nested escaped quotes
+    String originalExpressionString =
+        "search(collection1,fl=\"id,first\",sort=\"first asc\",q={!bool filter=\"presentTitles:\\\"chief, executive officer\\\"\" filter=\"age:[36 TO *]\")";
+    try (CloudSolrStream firstStream =
+             new CloudSolrStream(StreamExpressionParser.parse(originalExpressionString), factory)) {
+      String firstExpressionString = firstStream.toExpression(factory).toString();
+
+      try (CloudSolrStream secondStream =
+               new CloudSolrStream(StreamExpressionParser.parse(firstExpressionString), factory)) {
+        String secondExpressionString = secondStream.toExpression(factory).toString();
+
+        assertTrue(
+            firstExpressionString.contains(
+                "q=\"{!bool filter=\\\"presentTitles:\\\\\\\"chief, executive officer\\\\\\\"\\\" filter=\\\"age:[36 TO *]\\\"\""));
+        assertTrue(
+            secondExpressionString.contains(
+                "q=\"{!bool filter=\\\"presentTitles:\\\\\\\"chief, executive officer\\\\\\\"\\\" filter=\\\"age:[36 TO *]\\\"\""));
+      }
+    }
+  }
+
+  @Test
   public void testFeaturesSelectionStream() throws Exception {
     String expr =
         "featuresSelection(collection1, q=\"*:*\", featureSet=\"first\", field=\"tv_text\", outcome=\"out_i\", numTerms=4, positiveLabel=2)";

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionParserTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionParserTest.java
@@ -127,38 +127,58 @@ public class StreamExpressionParserTest extends SolrTestCase {
     assertEquals(expected, actual);
 
     actual =
-            StreamExpressionParser.parse("search(collection1, fl=\"id,first\", sort=\"first asc\", q=\"presentTitles:\\\"chief executive officer\\\" AND age:[36 TO *]\")");
-    expected = new StreamExpression("search")
+        StreamExpressionParser.parse(
+            "search(collection1, fl=\"id,first\", sort=\"first asc\", q=\"presentTitles:\\\"chief executive officer\\\" AND age:[36 TO *]\")");
+    expected =
+        new StreamExpression("search")
             .withParameter(new StreamExpressionValue("collection1"))
             .withParameter(new StreamExpressionNamedParameter("fl").withParameter("id,first"))
             .withParameter(new StreamExpressionNamedParameter("sort").withParameter("first asc"))
-            .withParameter(new StreamExpressionNamedParameter("q").withParameter("presentTitles:\"chief executive officer\" AND age:[36 TO *]"));
+            .withParameter(
+                new StreamExpressionNamedParameter("q")
+                    .withParameter("presentTitles:\"chief executive officer\" AND age:[36 TO *]"));
     assertEquals(expected, actual);
 
     actual =
-            StreamExpressionParser.parse("search(collection1, q=*:*, fq=fieldA:\"string\\\"withquote\", sort=\"fieldA desc, fieldB asc, fieldC asc\")");
-    expected = new StreamExpression("search")
+        StreamExpressionParser.parse(
+            "search(collection1, q=*:*, fq=fieldA:\"string\\\"withquote\", sort=\"fieldA desc, fieldB asc, fieldC asc\")");
+    expected =
+        new StreamExpression("search")
             .withParameter(new StreamExpressionValue("collection1"))
             .withParameter(new StreamExpressionNamedParameter("q").withParameter("*:*"))
-            .withParameter(new StreamExpressionNamedParameter("fq").withParameter("fieldA:\"string\\\"withquote\""))
             .withParameter(
-                    new StreamExpressionNamedParameter("sort")
-                            .withParameter("fieldA desc, fieldB asc, fieldC asc"));
+                new StreamExpressionNamedParameter("fq")
+                    .withParameter("fieldA:\"string\\\"withquote\""))
+            .withParameter(
+                new StreamExpressionNamedParameter("sort")
+                    .withParameter("fieldA desc, fieldB asc, fieldC asc"));
     assertEquals(expected, actual);
 
-    actual = StreamExpressionParser.parse("search(collection1, q=\"*:*\", sort=\"fieldA desc, fieldB asc, fieldC asc\")");
-    expected = new StreamExpression("search")
+    actual =
+        StreamExpressionParser.parse(
+            "search(collection1, q=\"*:*\", sort=\"fieldA desc, fieldB asc, fieldC asc\")");
+    expected =
+        new StreamExpression("search")
             .withParameter(new StreamExpressionValue("collection1"))
             .withParameter(new StreamExpressionNamedParameter("q").withParameter("*:*"))
-            .withParameter(new StreamExpressionNamedParameter("sort").withParameter("fieldA desc, fieldB asc, fieldC asc"));
-    assertEquals(expected,actual);
+            .withParameter(
+                new StreamExpressionNamedParameter("sort")
+                    .withParameter("fieldA desc, fieldB asc, fieldC asc"));
+    assertEquals(expected, actual);
 
-    //SOLR-10894 seems to be fixed, at least at this level
-    actual = StreamExpressionParser.parse("search(collection1, q=summary:\"\\\"This is a summary\\\"\\+\", sort=\"fieldA desc, fieldB asc, fieldC asc\")");
-    expected = new StreamExpression("search")
+    // SOLR-10894 seems to be fixed, at least at this level
+    actual =
+        StreamExpressionParser.parse(
+            "search(collection1, q=summary:\"\\\"This is a summary\\\"\\+\", sort=\"fieldA desc, fieldB asc, fieldC asc\")");
+    expected =
+        new StreamExpression("search")
             .withParameter(new StreamExpressionValue("collection1"))
-            .withParameter(new StreamExpressionNamedParameter("q").withParameter("summary:\"\\\"This is a summary\\\"\\+\""))
-            .withParameter(new StreamExpressionNamedParameter("sort").withParameter("fieldA desc, fieldB asc, fieldC asc"));
-    assertEquals(expected,actual);
+            .withParameter(
+                new StreamExpressionNamedParameter("q")
+                    .withParameter("summary:\"\\\"This is a summary\\\"\\+\""))
+            .withParameter(
+                new StreamExpressionNamedParameter("sort")
+                    .withParameter("fieldA desc, fieldB asc, fieldC asc"));
+    assertEquals(expected, actual);
   }
 }

--- a/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionParserTest.java
+++ b/solr/solrj-streaming/src/test/org/apache/solr/client/solrj/io/stream/expr/StreamExpressionParserTest.java
@@ -125,5 +125,40 @@ public class StreamExpressionParserTest extends SolrTestCase {
                             .withParameter("fieldC")
                             .withParameter("fieldD")));
     assertEquals(expected, actual);
+
+    actual =
+            StreamExpressionParser.parse("search(collection1, fl=\"id,first\", sort=\"first asc\", q=\"presentTitles:\\\"chief executive officer\\\" AND age:[36 TO *]\")");
+    expected = new StreamExpression("search")
+            .withParameter(new StreamExpressionValue("collection1"))
+            .withParameter(new StreamExpressionNamedParameter("fl").withParameter("id,first"))
+            .withParameter(new StreamExpressionNamedParameter("sort").withParameter("first asc"))
+            .withParameter(new StreamExpressionNamedParameter("q").withParameter("presentTitles:\"chief executive officer\" AND age:[36 TO *]"));
+    assertEquals(expected, actual);
+
+    actual =
+            StreamExpressionParser.parse("search(collection1, q=*:*, fq=fieldA:\"string\\\"withquote\", sort=\"fieldA desc, fieldB asc, fieldC asc\")");
+    expected = new StreamExpression("search")
+            .withParameter(new StreamExpressionValue("collection1"))
+            .withParameter(new StreamExpressionNamedParameter("q").withParameter("*:*"))
+            .withParameter(new StreamExpressionNamedParameter("fq").withParameter("fieldA:\"string\\\"withquote\""))
+            .withParameter(
+                    new StreamExpressionNamedParameter("sort")
+                            .withParameter("fieldA desc, fieldB asc, fieldC asc"));
+    assertEquals(expected, actual);
+
+    actual = StreamExpressionParser.parse("search(collection1, q=\"*:*\", sort=\"fieldA desc, fieldB asc, fieldC asc\")");
+    expected = new StreamExpression("search")
+            .withParameter(new StreamExpressionValue("collection1"))
+            .withParameter(new StreamExpressionNamedParameter("q").withParameter("*:*"))
+            .withParameter(new StreamExpressionNamedParameter("sort").withParameter("fieldA desc, fieldB asc, fieldC asc"));
+    assertEquals(expected,actual);
+
+    //SOLR-10894 seems to be fixed, at least at this level
+    actual = StreamExpressionParser.parse("search(collection1, q=summary:\"\\\"This is a summary\\\"\\+\", sort=\"fieldA desc, fieldB asc, fieldC asc\")");
+    expected = new StreamExpression("search")
+            .withParameter(new StreamExpressionValue("collection1"))
+            .withParameter(new StreamExpressionNamedParameter("q").withParameter("summary:\"\\\"This is a summary\\\"\\+\""))
+            .withParameter(new StreamExpressionNamedParameter("sort").withParameter("fieldA desc, fieldB asc, fieldC asc"));
+    assertEquals(expected,actual);
   }
 }


### PR DESCRIPTION
This uses a regular expression with lookbehind to replace only `:\"` with `:"` and applicable end quote to ensure that we still can handle queries like `fieldA:\"someterms\"` but also handle `fieldA:"some\"terms"`.

The regular expression approach is probably not the most performant, but it is relatively simple and we could explore in the future getting streaming expression parsing more in sync with parsing of normal queries.