### PR TITLE
SAI-4525 : Simple placement plugin does not work as intended

### DIFF
--- a/solr/core/src/java/org/apache/solr/cluster/placement/plugins/SimplePlacementFactory.java
+++ b/solr/core/src/java/org/apache/solr/cluster/placement/plugins/SimplePlacementFactory.java
@@ -102,9 +102,7 @@ public class SimplePlacementFactory
 
               ReplicaCount replicaCount =
                   nodeVsShardCount.computeIfAbsent(assignedNode, ReplicaCount::new);
-              replicaCount.totalReplicas++;
-              replicaCount.collectionReplicas.merge(
-                  request.getCollection().getName(), 1, Integer::sum);
+              replicaCount.addReplica(request.getCollection().getName());
             }
           }
         }
@@ -131,7 +129,7 @@ public class SimplePlacementFactory
           for (Replica replica : shard.replicas()) {
             ReplicaCount count = nodeVsShardCount.get(replica.getNode());
             if (count != null) {
-              count.addReplica(collection.getName(), shard.getShardName());
+              count.addReplica(collection.getName());
             }
           }
         }
@@ -154,9 +152,10 @@ public class SimplePlacementFactory
       return (collectionReplicas.getOrDefault(collection, 0) * 5) + totalReplicas;
     }
 
-    public void addReplica(String collection, String shard) {
+    public void addReplica(String collection) {
       // Used to "weigh" whether this node should be used later.
       collectionReplicas.merge(collection, 1, Integer::sum);
+      totalReplicas++;
     }
 
     public Node node() {


### PR DESCRIPTION
## Description
We experienced solr replica placement concentration on C91 for node 100-103 while we "pre-shard" c91 (that adds empty collections to C91 with certain shard count)

## Cause
In Solr 8, the core on other collections [are counted correctly ](https://github.com/fullstorydev/lucene-solr/blob/release/8.8/solr/core/src/java/org/apache/solr/cloud/api/collections/Assign.java#L444), while in Solr 9, the logic [here](https://github.com/cowpaths/fullstory-solr/blob/fs/branch_9x/solr/core/src/java/org/apache/solr/cluster/placement/plugins/SimplePlacementFactory.java#L134) adds the replica to the map but does not increment the totalReplicas field, which is probably a bug

## Solution
Always call `ReplicaCount#addReplica` for all counting cases:
1. Counting existing replicas for all nodes
2. Adding an extra replica to the target node

, and in such method, always increment the `totalReplicas` field of `ReplicaCount`


## Remarks
I have not changed the weight formula in 9 in this PR:
>The weight formula has changed : Solr 8 https://github.com/fullstorydev/lucene-solr/blob/release/8.8/solr/core/src/java/org/apache/solr/cloud/api/collections/Assign.java#L320 vs Solr 9 https://github.com/cowpaths/fullstory-solr/blob/fs/branch_9x/solr/core/src/java/org/apache/solr/cluster/placement/plugins/SimplePlacementFactory.java#L154)
