### PR TITLE
support dynamic ngram disable (after pattern of SolrQueryTimeoutImpl)

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/MoreLikeThisHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/MoreLikeThisHandler.java
@@ -56,6 +56,7 @@ import org.apache.solr.handler.component.ResponseBuilder;
 import org.apache.solr.request.SimpleFacets;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
+import org.apache.solr.schema.BloomStrField;
 import org.apache.solr.schema.SchemaField;
 import org.apache.solr.search.DocIterator;
 import org.apache.solr.search.DocList;
@@ -99,6 +100,7 @@ public class MoreLikeThisHandler extends RequestHandlerBase {
     SolrParams params = req.getParams();
 
     SolrQueryTimeoutImpl.set(req);
+    BloomStrField.init(req);
     try {
 
       // Set field flags

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -62,6 +62,7 @@ import org.apache.solr.pkg.PackageListeners;
 import org.apache.solr.pkg.SolrPackageLoader;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
+import org.apache.solr.schema.BloomStrField;
 import org.apache.solr.search.CursorMark;
 import org.apache.solr.search.SolrQueryTimeoutImpl;
 import org.apache.solr.search.SortSpec;
@@ -437,6 +438,7 @@ public class SearchHandler extends RequestHandlerBase
       // a normal non-distributed request
 
       SolrQueryTimeoutImpl.set(req);
+      BloomStrField.init(req);
       try {
         // The semantics of debugging vs not debugging are different enough that
         // it makes sense to have two control loops

--- a/solr/core/src/java/org/apache/solr/schema/BloomStrField.java
+++ b/solr/core/src/java/org/apache/solr/schema/BloomStrField.java
@@ -60,13 +60,16 @@ public final class BloomStrField extends StrField implements SchemaAware {
 
   public static final String BLOOM_FIELD_BASE_SUFFIX_MULTI = "0NgramM"; // multiValued
 
-  public static final boolean DEFAULT_DISABLE_NGRAMS = "true".equals(System.getProperty("disableNgrams"));
-  private static final ThreadLocal<Boolean> DISABLE_NGRAMS = new ThreadLocal<>() {
-    @Override
-    protected Boolean initialValue() {
-      return DEFAULT_DISABLE_NGRAMS;
-    }
-  };
+  private static final boolean DEFAULT_DISABLE_NGRAMS =
+      "true".equals(System.getProperty("disableNgrams"));
+
+  private static final ThreadLocal<Boolean> DISABLE_NGRAMS =
+      new ThreadLocal<>() {
+        @Override
+        protected Boolean initialValue() {
+          return DEFAULT_DISABLE_NGRAMS;
+        }
+      };
 
   public static void init(SolrQueryRequest req) {
     boolean disableNgrams = req.getParams().getBool("disableNgrams", DEFAULT_DISABLE_NGRAMS);

--- a/solr/core/src/java/org/apache/solr/schema/BloomStrField.java
+++ b/solr/core/src/java/org/apache/solr/schema/BloomStrField.java
@@ -32,6 +32,7 @@ import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.LeafReader;
+import org.apache.solr.request.SolrQueryRequest;
 
 /**
  * A specialized StrField variant that facilitates configuration of a ngram subfield (populated at
@@ -58,6 +59,23 @@ public final class BloomStrField extends StrField implements SchemaAware {
   public static final String BLOOM_FIELD_BASE_SUFFIX = "0NgramS"; // single-valued
 
   public static final String BLOOM_FIELD_BASE_SUFFIX_MULTI = "0NgramM"; // multiValued
+
+  public static final boolean DEFAULT_DISABLE_NGRAMS = "true".equals(System.getProperty("disableNgrams"));
+  private static final ThreadLocal<Boolean> DISABLE_NGRAMS = new ThreadLocal<>() {
+    @Override
+    protected Boolean initialValue() {
+      return DEFAULT_DISABLE_NGRAMS;
+    }
+  };
+
+  public static void init(SolrQueryRequest req) {
+    boolean disableNgrams = req.getParams().getBool("disableNgrams", DEFAULT_DISABLE_NGRAMS);
+    DISABLE_NGRAMS.set(disableNgrams);
+  }
+
+  public static boolean disableNgrams() {
+    return DISABLE_NGRAMS.get();
+  }
 
   private IndexSchema schema;
   private FieldType bloomFieldType;

--- a/solr/core/src/java/org/apache/solr/schema/BloomStrField.java
+++ b/solr/core/src/java/org/apache/solr/schema/BloomStrField.java
@@ -60,24 +60,24 @@ public final class BloomStrField extends StrField implements SchemaAware {
 
   public static final String BLOOM_FIELD_BASE_SUFFIX_MULTI = "0NgramM"; // multiValued
 
-  private static final boolean DEFAULT_DISABLE_NGRAMS =
-      "true".equals(System.getProperty("disableNgrams"));
+  private static final boolean DEFAULT_ENABLE_NGRAMS =
+      !"false".equals(System.getProperty("enableNgrams"));
 
-  private static final ThreadLocal<Boolean> DISABLE_NGRAMS =
+  private static final ThreadLocal<Boolean> ENABLE_NGRAMS =
       new ThreadLocal<>() {
         @Override
         protected Boolean initialValue() {
-          return DEFAULT_DISABLE_NGRAMS;
+          return DEFAULT_ENABLE_NGRAMS;
         }
       };
 
   public static void init(SolrQueryRequest req) {
-    boolean disableNgrams = req.getParams().getBool("disableNgrams", DEFAULT_DISABLE_NGRAMS);
-    DISABLE_NGRAMS.set(disableNgrams);
+    boolean enableNgrams = req.getParams().getBool("enableNgrams", DEFAULT_ENABLE_NGRAMS);
+    ENABLE_NGRAMS.set(enableNgrams);
   }
 
-  public static boolean disableNgrams() {
-    return DISABLE_NGRAMS.get();
+  public static boolean enableNgrams() {
+    return ENABLE_NGRAMS.get();
   }
 
   private IndexSchema schema;

--- a/solr/modules/analytics/src/java/org/apache/solr/handler/AnalyticsHandler.java
+++ b/solr/modules/analytics/src/java/org/apache/solr/handler/AnalyticsHandler.java
@@ -36,6 +36,7 @@ import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.AnalyticsShardResponseWriter;
 import org.apache.solr.response.AnalyticsShardResponseWriter.AnalyticsResponse;
 import org.apache.solr.response.SolrQueryResponse;
+import org.apache.solr.schema.BloomStrField;
 import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.search.DocSet;
 import org.apache.solr.search.QParser;
@@ -76,6 +77,7 @@ public class AnalyticsHandler extends RequestHandlerBase
   public void handleRequestBody(SolrQueryRequest req, SolrQueryResponse rsp) throws Exception {
 
     SolrQueryTimeoutImpl.set(req);
+    BloomStrField.init(req);
     try {
       DocSet docs;
       try {


### PR DESCRIPTION
This lays the groundwork for (at least temporarily) being able to disable special ngram handling, for performance impact evaluation and possible quick rollback if necessary.