### PR TITLE
SAI-4528 : Missing rid in `SearchHandler` log

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -356,8 +356,8 @@ public class SearchHandler extends RequestHandlerBase
       log.info("Start Forwarded Search Query");
       SolrParams filteredParams = removeVerboseParams(req.getParams());
       rsp.getToLog()
-              .asShallowMap(false)
-              .put("params", "{" + filteredParams + "}"); // replace "params" with the filtered version
+          .asShallowMap(false)
+          .put("params", "{" + filteredParams + "}"); // replace "params" with the filtered version
     } else {
       // Then it is the first time this req hitting Solr - not a req distributed by another higher
       // level req.

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -335,16 +335,29 @@ public class SearchHandler extends RequestHandlerBase
 
   @Override
   public void handleRequestBody(SolrQueryRequest req, SolrQueryResponse rsp) throws Exception {
-    if (req.getParams().getBool(ShardParams.IS_SHARD, false)) {
+    boolean isShard = req.getParams().getBool(ShardParams.IS_SHARD, false);
+    if (isShard) {
+      int purpose = req.getParams().getInt(ShardParams.SHARDS_PURPOSE, 0);
+      SolrPluginUtils.forEachRequestPurpose(
+          purpose, n -> shardPurposes.computeIfAbsent(n, name -> new Counter()).inc());
+    }
+
+    List<SearchComponent> components = getComponents();
+    ResponseBuilder rb = newResponseBuilder(req, rsp, components);
+    if (rb.requestInfo != null) {
+      rb.requestInfo.setResponseBuilder(rb);
+    }
+
+    rb.isDistrib = isDistrib(req);
+    tagRequestWithRequestId(rb);
+
+    if (isShard) {
       // log a simple message on start
       log.info("Start Forwarded Search Query");
       SolrParams filteredParams = removeVerboseParams(req.getParams());
       rsp.getToLog()
-          .asShallowMap(false)
-          .put("params", "{" + filteredParams + "}"); // replace "params" with the filtered version
-      int purpose = req.getParams().getInt(ShardParams.SHARDS_PURPOSE, 0);
-      SolrPluginUtils.forEachRequestPurpose(
-          purpose, n -> shardPurposes.computeIfAbsent(n, name -> new Counter()).inc());
+              .asShallowMap(false)
+              .put("params", "{" + filteredParams + "}"); // replace "params" with the filtered version
     } else {
       // Then it is the first time this req hitting Solr - not a req distributed by another higher
       // level req.
@@ -357,15 +370,6 @@ public class SearchHandler extends RequestHandlerBase
         log.info("Start External Search Query: {}", req.getParamString());
       }
     }
-
-    List<SearchComponent> components = getComponents();
-    ResponseBuilder rb = newResponseBuilder(req, rsp, components);
-    if (rb.requestInfo != null) {
-      rb.requestInfo.setResponseBuilder(rb);
-    }
-
-    rb.isDistrib = isDistrib(req);
-    tagRequestWithRequestId(rb);
 
     boolean dbg = req.getParams().getBool(CommonParams.DEBUG_QUERY, false);
     rb.setDebug(dbg);


### PR DESCRIPTION
## Description
It's found in Solr 9 that rid is not longer printed in the log:

#### Solr 8
`2023-06-29 16:37:16.415 INFO (qtp315072539-4821603) [c:174G8N s:shard8 r:core_node37 x:174G8N_shard8_replica_n9 rid:-140545029] o.a.s.h.c.SearchHandler Start External Search Query: distrib=false&indent=off&ids=1ehpolbvvgg!1u59sgp3400_6mt4c25hd2k7_swztpmxsqakh_0&ids=1ehpolbvvgg!1u59sgp3400_6mt4c25hd2k7_swztpmxsqakh&ids=1ehpolbvvgg!1u59sgp3400_6mt4c25hd2k7&ids=1ehpolbvvgg!_&ids=1ehpolbvvgg!1u59sgp3400&wat=&wt=json`

####Solr 9
`2023-06-29 16:38:15.320 INFO (qtp2083217543-60870) [10VQQM shard4 core_node14 10VQQM_shard4_replica_n13 ] o.a.s.h.c.SearchHandler Start External Search Query: distrib=false&indent=off&ids=1r8u3smrj7k!1h90us13ojk_1lisn4m8x6o_bdrh46lya923_0&ids=1r8u3smrj7k!1h90us13ojk_1lisn4m8x6o_bdrh46lya923&ids=1r8u3smrj7k!1h90us13ojk_1lisn4m8x6o&ids=1r8u3smrj7k!_&ids=1r8u3smrj7k!1h90us13ojk&wat=&wt=json`

## Cause
In Solr 9, we accepted [the change to set `rid` to MDC ](https://issues.apache.org/jira/browse/SOLR-15790), however, the ordering is a bit different now. In Solr 8, we used to generate/extract rid and set to MDC at the beginning of `SearchHandler#handleRequestBody`, and then call `tagRequestWithRequestId` later, while in Solr 9, `tagRequestWithRequestId` does it all - generate/extract rid, setting to MDC etc.

Therefore in Solr 9, if we log the info message at the beginning as we did in Solr 8, then those messages would no longer have rid as `tagRequestWithRequestId` is called afterwards


## Solution
In order to minimize re-ordering of method calls in Solr 9, we will move the log message to after `SearchHandler#handleRequestBody` is called

## Tests
Tested locally on SearchHandler, with and without explicit `rid` and confirmed that the log is correct