### PR TITLE
SAI-4531: Correct(override) MDC info for CoordinatorHttpSolrCall

### DIFF
--- a/solr/core/src/java/org/apache/solr/servlet/CoordinatorHttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/CoordinatorHttpSolrCall.java
@@ -130,7 +130,6 @@ public class CoordinatorHttpSolrCall extends HttpSolrCall {
   /**
    * Overrides the MDC context as the core set was synthetic core, which does not reflect the collection
    * being operated on
-   * @param collectionName
    */
   private static void setMDCLoggingContext(String collectionName) {
     MDCLoggingContext.setCollection(collectionName);

--- a/solr/core/src/java/org/apache/solr/servlet/CoordinatorHttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/CoordinatorHttpSolrCall.java
@@ -38,6 +38,7 @@ import org.apache.solr.common.util.Utils;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.CoreDescriptor;
 import org.apache.solr.core.SolrCore;
+import org.apache.solr.logging.MDCLoggingContext;
 import org.apache.solr.request.DelegatedSolrQueryRequest;
 import org.apache.solr.request.LocalSolrQueryRequest;
 import org.apache.solr.request.SolrQueryRequest;
@@ -76,7 +77,9 @@ public class CoordinatorHttpSolrCall extends HttpSolrCall {
       Factory factory, HttpSolrCall solrCall, String collectionName, boolean isPreferLeader) {
     String syntheticCoreName = factory.collectionVsCoreNameMapping.get(collectionName);
     if (syntheticCoreName != null) {
-      return solrCall.cores.getCore(syntheticCoreName);
+      SolrCore syntheticCore =  solrCall.cores.getCore(syntheticCoreName);
+      setMDCLoggingContext(collectionName);
+      return syntheticCore;
     } else {
       ZkStateReader zkStateReader = solrCall.cores.getZkController().getZkStateReader();
       ClusterState clusterState = zkStateReader.getClusterState();
@@ -117,10 +120,25 @@ public class CoordinatorHttpSolrCall extends HttpSolrCall {
             log.debug("coordinator node, returns synthetic core: {}", core.getName());
           }
         }
+        setMDCLoggingContext(collectionName);
         return core;
       }
       return null;
     }
+  }
+
+  /**
+   * Overrides the MDC context as the core set was synthetic core, which does not reflect the collection
+   * being operated on
+   * @param collectionName
+   */
+  private static void setMDCLoggingContext(String collectionName) {
+    MDCLoggingContext.setCollection(collectionName);
+
+    //below is irrelevant for call to coordinator
+    MDCLoggingContext.setCoreName(null);
+    MDCLoggingContext.setShard(null);
+    MDCLoggingContext.setCoreName(null);
   }
 
   private static void addReplica(String syntheticCollectionName, CoreContainer cores) {

--- a/solr/core/src/java/org/apache/solr/servlet/CoordinatorHttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/CoordinatorHttpSolrCall.java
@@ -77,7 +77,7 @@ public class CoordinatorHttpSolrCall extends HttpSolrCall {
       Factory factory, HttpSolrCall solrCall, String collectionName, boolean isPreferLeader) {
     String syntheticCoreName = factory.collectionVsCoreNameMapping.get(collectionName);
     if (syntheticCoreName != null) {
-      SolrCore syntheticCore =  solrCall.cores.getCore(syntheticCoreName);
+      SolrCore syntheticCore = solrCall.cores.getCore(syntheticCoreName);
       setMDCLoggingContext(collectionName);
       return syntheticCore;
     } else {
@@ -128,13 +128,13 @@ public class CoordinatorHttpSolrCall extends HttpSolrCall {
   }
 
   /**
-   * Overrides the MDC context as the core set was synthetic core, which does not reflect the collection
-   * being operated on
+   * Overrides the MDC context as the core set was synthetic core, which does not reflect the
+   * collection being operated on
    */
   private static void setMDCLoggingContext(String collectionName) {
     MDCLoggingContext.setCollection(collectionName);
 
-    //below is irrelevant for call to coordinator
+    // below is irrelevant for call to coordinator
     MDCLoggingContext.setCoreName(null);
     MDCLoggingContext.setShard(null);
     MDCLoggingContext.setCoreName(null);


### PR DESCRIPTION
## Description
It's found that in Solr 9.x, coordinator (QA) node does not tag the currect solr collection/shard/replica info in the log message, it instead logs the synthetic collection info :

```
2023-06-30 00:40:58.307 INFO  (qtp751608431-62) [.sys.COORDINATOR-COLL-_FS7 shard1 core_node2 .sys.COORDINATOR-COLL-_FS7_shard1_replica_n1 2345] o.a.s.h.c.SearchHandler Start External Search Query: q=*:*&indent=true&q.op=OR&rid=2345&useParams=
```

## Cause
 It appears that Solr 9.x uses a single SolrCore instance for all cores that share the same configset. While this design has the advantage of drastically cut down # of SolrCore instance (from 1 Core proxy per Core in 8.8 to basically 1 instance (for _FS7), and most of the logic that uses such core does work (as they are configset specific), some other logics that expect to extract information for SolrCore seems hard to get it right with this design.

In this case, `MDCLoggingContext#setCore` would be setting the same core instance for all collections with the same config, therefore unable to distinguish calls by collection specific info.

## Solution
Set the MDC collection with the collection name and shard/replica to empty string within `CoordinatorHttpSolrCall#getCore`, this would override the info set by `MDCLoggingContext#setCore` invoked from `SolreCore#open`

This is a quick workaround that has least impact to current design, see remarks for other options.

## Remarks
We can also consider adding back the `SolrCoreProxy` class, but in this case take that single instance of `SolrCore` from the synthetic collection as ctor param. Perhaps we should also take a `CoreDescriptor` (that contains the `CloudDescriptor`) that is specific to the actual collection.

This proxy is just a thin wrapper so memory footprint should be minimal, not sure about the extra `CoreDescriptor`/`CloudDescriptor`, but I assume it should not be too bad? 😄 

