### PR TITLE
SAI-4533 : Coordinator `ZkStateReader`'s watch and collection -> synthetic core mapping are not removed upon collection deletion

### DIFF
--- a/solr/core/src/java/org/apache/solr/servlet/CoordinatorHttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/CoordinatorHttpSolrCall.java
@@ -118,7 +118,16 @@ public class CoordinatorHttpSolrCall extends HttpSolrCall {
               .cores
               .getZkController()
               .getZkStateReader()
-              .registerDocCollectionWatcher(collectionName, collection -> collection == null);
+              .registerDocCollectionWatcher(
+                  collectionName,
+                  collection -> {
+                    if (collection == null) {
+                      factory.collectionVsCoreNameMapping.remove(collectionName);
+                      return true; // return true so watch will be removed
+                    } else {
+                      return false;
+                    }
+                  });
           if (log.isDebugEnabled()) {
             log.debug("coordinator node, returns synthetic core: {}", core.getName());
           }

--- a/solr/core/src/java/org/apache/solr/servlet/CoordinatorHttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/CoordinatorHttpSolrCall.java
@@ -112,7 +112,9 @@ public class CoordinatorHttpSolrCall extends HttpSolrCall {
         core = solrCall.getCoreByCollection(syntheticCollectionName, isPreferLeader);
         if (core != null) {
           factory.collectionVsCoreNameMapping.put(collectionName, core.getName());
-          solrCall.cores.getZkController().getZkStateReader().registerCore(collectionName);
+
+          //only remove on collection deletion, since watch from coordinator is collection specific
+          solrCall.cores.getZkController().getZkStateReader().registerDocCollectionWatcher(collectionName, collection -> collection == null);
           if (log.isDebugEnabled()) {
             log.debug("coordinator node, returns synthetic core: {}", core.getName());
           }

--- a/solr/core/src/java/org/apache/solr/servlet/CoordinatorHttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/CoordinatorHttpSolrCall.java
@@ -113,8 +113,12 @@ public class CoordinatorHttpSolrCall extends HttpSolrCall {
         if (core != null) {
           factory.collectionVsCoreNameMapping.put(collectionName, core.getName());
 
-          //only remove on collection deletion, since watch from coordinator is collection specific
-          solrCall.cores.getZkController().getZkStateReader().registerDocCollectionWatcher(collectionName, collection -> collection == null);
+          // only remove on collection deletion, since watch from coordinator is collection specific
+          solrCall
+              .cores
+              .getZkController()
+              .getZkStateReader()
+              .registerDocCollectionWatcher(collectionName, collection -> collection == null);
           if (log.isDebugEnabled()) {
             log.debug("coordinator node, returns synthetic core: {}", core.getName());
           }

--- a/solr/core/src/test/org/apache/solr/common/cloud/ZkStateReaderAccessor.java
+++ b/solr/core/src/test/org/apache/solr/common/cloud/ZkStateReaderAccessor.java
@@ -16,6 +16,7 @@
  */
 package org.apache.solr.common.cloud;
 
+import java.util.Collections;
 import java.util.Set;
 
 /** Helper class to access package-private methods from ZkStateReader. */
@@ -29,4 +30,9 @@ public class ZkStateReaderAccessor {
   public Set<DocCollectionWatcher> getStateWatchers(String collection) {
     return zkStateReader.getStateWatchers(collection);
   }
+
+  public Set<String> getWatchedCollections() {
+    return Collections.unmodifiableSet(zkStateReader.getCollectionWatches().keySet());
+  }
+
 }

--- a/solr/core/src/test/org/apache/solr/common/cloud/ZkStateReaderAccessor.java
+++ b/solr/core/src/test/org/apache/solr/common/cloud/ZkStateReaderAccessor.java
@@ -34,5 +34,4 @@ public class ZkStateReaderAccessor {
   public Set<String> getWatchedCollections() {
     return Collections.unmodifiableSet(zkStateReader.getCollectionWatches().keySet());
   }
-
 }

--- a/solr/core/src/test/org/apache/solr/search/TestCoordinatorRole.java
+++ b/solr/core/src/test/org/apache/solr/search/TestCoordinatorRole.java
@@ -25,6 +25,7 @@ import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -32,6 +33,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
@@ -42,11 +44,14 @@ import org.apache.solr.client.solrj.request.UpdateRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.cloud.MiniSolrCloudCluster;
 import org.apache.solr.cloud.SolrCloudTestCase;
+import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.cloud.DocCollection;
 import org.apache.solr.common.cloud.Replica;
+import org.apache.solr.common.cloud.ZkStateReader;
+import org.apache.solr.common.cloud.ZkStateReaderAccessor;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ShardParams;
 import org.apache.solr.common.util.ExecutorUtil;
@@ -475,5 +480,53 @@ public class TestCoordinatorRole extends SolrCloudTestCase {
     }
     assertTrue(found);
     return (String) docs.get(0).getFieldValue("_core_");
+  }
+
+  public void testWatch() throws Exception {
+    final int DATA_NODE_COUNT = 2;
+    MiniSolrCloudCluster cluster =
+            configureCluster(DATA_NODE_COUNT)
+                    .addConfig("conf1", configset("cloud-minimal")).configure();
+    final String TEST_COLLECTION = "c1";
+
+    try {
+      CloudSolrClient client = cluster.getSolrClient();
+      CollectionAdminRequest.createCollection(TEST_COLLECTION, "conf1", 1, 2)
+              .process(client);
+      cluster.waitForActiveCollection(TEST_COLLECTION, 1, 2);
+      System.setProperty(NodeRoles.NODE_ROLES_PROP, "coordinator:on");
+      JettySolrRunner coordinatorJetty;
+      try {
+        coordinatorJetty = cluster.startJettySolrRunner();
+      } finally {
+        System.clearProperty(NodeRoles.NODE_ROLES_PROP);
+      }
+
+      ZkStateReader zkStateReader = coordinatorJetty.getCoreContainer().getZkController().getZkStateReader();
+      ZkStateReaderAccessor zkWatchAccessor = new ZkStateReaderAccessor(zkStateReader);
+
+      //no watch at first
+      assertTrue(!zkWatchAccessor.getWatchedCollections().contains(TEST_COLLECTION));
+      new QueryRequest(new SolrQuery("*:*"))
+              .setPreferredNodes(List.of(coordinatorJetty.getNodeName()))
+              .process(client, TEST_COLLECTION);
+
+      //now it should be watching it after the query
+      assertTrue(zkWatchAccessor.getWatchedCollections().contains(TEST_COLLECTION));
+
+      CollectionAdminRequest.deleteReplica(TEST_COLLECTION, "shard1", 1).process(client);
+      cluster.waitForActiveCollection(TEST_COLLECTION, 1, 1);
+
+      //still one replica left, should not remove the watch
+      assertTrue(zkWatchAccessor.getWatchedCollections().contains(TEST_COLLECTION));
+
+      CollectionAdminRequest.deleteCollection(TEST_COLLECTION).process(client);
+      zkStateReader.waitForState(TEST_COLLECTION, 30, TimeUnit.SECONDS, Objects::isNull);
+
+      //watch should be removed after collection deletion
+      assertTrue(!zkWatchAccessor.getWatchedCollections().contains(TEST_COLLECTION));
+    } finally {
+      cluster.shutdown();
+    }
   }
 }

--- a/solr/core/src/test/org/apache/solr/search/TestCoordinatorRole.java
+++ b/solr/core/src/test/org/apache/solr/search/TestCoordinatorRole.java
@@ -515,12 +515,25 @@ public class TestCoordinatorRole extends SolrCloudTestCase {
 
       CollectionAdminRequest.deleteReplica(TEST_COLLECTION, "shard1", 1).process(client);
       cluster.waitForActiveCollection(TEST_COLLECTION, 1, 1);
+      new QueryRequest(new SolrQuery("*:*"))
+          .setPreferredNodes(List.of(coordinatorJetty.getNodeName()))
+          .process(client, TEST_COLLECTION); // ok no exception thrown
 
       // still one replica left, should not remove the watch
       assertTrue(zkWatchAccessor.getWatchedCollections().contains(TEST_COLLECTION));
 
       CollectionAdminRequest.deleteCollection(TEST_COLLECTION).process(client);
       zkStateReader.waitForState(TEST_COLLECTION, 30, TimeUnit.SECONDS, Objects::isNull);
+      assertNull(zkStateReader.getCollection(TEST_COLLECTION)); // check the cluster state
+
+      // ensure querying throws exception
+      assertExceptionThrownWithMessageContaining(
+          SolrException.class,
+          List.of("Collection not found"),
+          () ->
+              new QueryRequest(new SolrQuery("*:*"))
+                  .setPreferredNodes(List.of(coordinatorJetty.getNodeName()))
+                  .process(client, TEST_COLLECTION));
 
       // watch should be removed after collection deletion
       assertTrue(!zkWatchAccessor.getWatchedCollections().contains(TEST_COLLECTION));

--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java
@@ -2072,6 +2072,11 @@ public class ZkStateReader implements SolrCloseable {
     return watchers;
   }
 
+  /* package-private for testing*/
+  Map<String, StatefulCollectionWatch> getCollectionWatches() {
+    return Collections.unmodifiableMap(collectionWatches.statefulWatchesByCollectionName);
+  }
+
   public void registerCollectionPropsWatcher(
       final String collection, CollectionPropsWatcher propsWatcher) {
     AtomicBoolean watchSet = new AtomicBoolean(false);


### PR DESCRIPTION
## Description
Core registration in CoordinatorHttpCall [correctly registers](https://github.com/cowpaths/fullstory-solr/blob/fs/branch_9x/solr/core/src/java/org/apache/solr/servlet/CoordinatorHttpSolrCall.java#L115) watch in ZkStateReader , however there’s no code to remove such watch on collection deletion (state update).

 

For non coordinator node, it’s done at UnloadCoreOnDeleteWatcher ([code](https://github.com/cowpaths/fullstory-solr/blob/a693e20f1b3969d945a5ce19aedc254fb371af91/solr/core/src/java/org/apache/solr/cloud/ZkController.java#L2871)), 

Also the `factory.collectionVsCoreNameMapping` should have such collection entry removed; otherwise query would not throw the expected `SolrException` on collection not found.

## Solution
Use `ZkStateReader#registerDocCollectionWatcher` instead of `ZkStateReader#registerCore`, the `stateWatcher` should return `true` if the collection is removed.

Remove the collection entry from `factory.collectionVsCoreNameMapping` as well.

Take note that such replacement is fine as:
1.  We do not need the `CollectionWatch.coreRefCount` as for coordinator each collection should invoke `registerDocCollectionWatcher` at most once
2. Similar to `registerCore`, `StateWatcher#refreshAndWatch` should be invoked in `registerDocCollectionWatcher` as well
