### PR TITLE
introduce first-class cache for OrdinalMaps

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/SolrConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrConfig.java
@@ -78,6 +78,7 @@ import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.schema.IndexSchemaFactory;
 import org.apache.solr.search.CacheConfig;
 import org.apache.solr.search.CaffeineCache;
+import org.apache.solr.search.OrdMapRegenerator;
 import org.apache.solr.search.QParserPlugin;
 import org.apache.solr.search.SolrCache;
 import org.apache.solr.search.ValueSourceParser;
@@ -306,6 +307,8 @@ public class SolrConfig implements MapSerializable {
       //    filtOptCacheSize = getInt("query/boolTofilterOptimizer/@cacheSize",32);
       //    filtOptThreshold = getFloat("query/boolTofilterOptimizer/@threshold",.05f);
 
+      updateHandlerInfo = loadUpdatehandlerInfo(); // must do this before configuring ordMapCache
+
       useFilterForSortedQuery = get("query").get("useFilterForSortedQuery").boolVal(false);
       queryResultWindowSize = Math.max(1, get("query").get("queryResultWindowSize").intVal(1));
       queryResultMaxDocsCached =
@@ -329,6 +332,13 @@ public class SolrConfig implements MapSerializable {
         conf = new CacheConfig(CaffeineCache.class, args, null);
       }
       fieldValueCacheConfig = conf;
+      conf = CacheConfig.getConfig(this, get("query").get("ordMapCache"), "query/ordMapCache");
+      if (conf != null) {
+        OrdMapRegenerator.configureRegenerator(this, conf);
+        ordMapCacheConfig = conf;
+      } else {
+        ordMapCacheConfig = OrdMapRegenerator.getDefaultCacheConfig(this);
+      }
       useColdSearcher = get("query").get("useColdSearcher").boolVal(false);
       dataDir = get("dataDir").txt();
       if (dataDir != null && dataDir.length() == 0) dataDir = null;
@@ -355,8 +365,6 @@ public class SolrConfig implements MapSerializable {
         }
       }
       this.userCacheConfigs = Collections.unmodifiableMap(userCacheConfigs);
-
-      updateHandlerInfo = loadUpdatehandlerInfo();
 
       final var requestParsersNode = get("requestDispatcher").get("requestParsers");
 
@@ -675,6 +683,7 @@ public class SolrConfig implements MapSerializable {
   //  public final int filtOptCacheSize;
   //  public final float filtOptThreshold;
   // SolrIndexSearcher - caches configurations
+  public final CacheConfig ordMapCacheConfig;
   public final CacheConfig filterCacheConfig;
   public final CacheConfig queryResultCacheConfig;
   public final CacheConfig documentCacheConfig;

--- a/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
+++ b/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
@@ -165,7 +165,7 @@ public class CaffeineCache<K, V> extends SolrCacheBase
       builder.maximumWeight(maxRamBytes);
       builder.weigher(
           (k, v) -> (int) (RamUsageEstimator.sizeOfObject(k) + RamUsageEstimator.sizeOfObject(v)));
-    } else {
+    } else if (maxSize < Integer.MAX_VALUE) {
       builder.maximumSize(maxSize);
     }
     Cache<K, V> newCache;

--- a/solr/core/src/java/org/apache/solr/search/OrdMapRegenerator.java
+++ b/solr/core/src/java/org/apache/solr/search/OrdMapRegenerator.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search;
+
+import static org.apache.solr.common.params.CommonParams.NAME;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.OrdinalMap;
+import org.apache.lucene.index.SortedDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.util.packed.PackedInts;
+import org.apache.solr.core.SolrConfig;
+import org.apache.solr.util.IOFunction;
+
+/** Cache regenerator that builds OrdinalMap instances against the new searcher. */
+public class OrdMapRegenerator implements CacheRegenerator {
+
+  private static final long DEFAULT_REGEN_KEEPALIVE_NANOS = TimeUnit.MINUTES.toNanos(2);
+  private static final OrdMapRegenerator DEFAULT_INSTANCE =
+      new OrdMapRegenerator(DEFAULT_REGEN_KEEPALIVE_NANOS);
+
+  private final long regenKeepAliveNanos;
+
+  public OrdMapRegenerator() {
+    this(DEFAULT_REGEN_KEEPALIVE_NANOS);
+    // default ctor in case someone specifies this class via standard `"regen"=[className]` syntax
+  }
+
+  private OrdMapRegenerator(long regenKeepAliveNanos) {
+    this.regenKeepAliveNanos = regenKeepAliveNanos;
+  }
+
+  public static class OrdinalMapValue implements Supplier<OrdinalMap> {
+    private final OrdinalMap ordinalMap;
+    private long accessTimestampNanos;
+
+    private OrdinalMapValue(OrdinalMap ordinalMap, long accessTimestampNanos) {
+      this.ordinalMap = ordinalMap;
+      this.accessTimestampNanos = accessTimestampNanos;
+    }
+
+    @Override
+    public OrdinalMap get() {
+      accessTimestampNanos = System.nanoTime();
+      return ordinalMap;
+    }
+  }
+
+  public static OrdinalMapValue wrapValue(OrdinalMap ordinalMap) {
+    return new OrdinalMapValue(ordinalMap, 0);
+  }
+
+  public static CacheConfig getDefaultCacheConfig(SolrConfig solrConfig) {
+    // for back-compat, default to an effectively unlimited-sized cache with no regeneration
+    Map<String, String> args = new HashMap<>();
+    args.put(NAME, "ordMapCache");
+    args.put("size", Integer.toString(Integer.MAX_VALUE)); // effectively unlimited
+    args.put("initialSize", "10");
+    CacheConfig c = new CacheConfig(CaffeineCache.class, args, null);
+    configureRegenerator(solrConfig, c);
+    return c;
+  }
+
+  public static void configureRegenerator(SolrConfig solrConfig, CacheConfig config) {
+    if (config.getRegenerator() != null) {
+      return;
+    }
+    String keepAliveConfig = (String) config.toMap(Collections.emptyMap()).get("regenKeepAlive");
+    final long regenKeepAliveNanos;
+    if (keepAliveConfig == null || keepAliveConfig.isEmpty()) {
+      long osiNanos;
+      if (solrConfig == null || (osiNanos = getOpenSearcherIntervalNanos(solrConfig)) == -1) {
+        regenKeepAliveNanos = DEFAULT_REGEN_KEEPALIVE_NANOS;
+      } else {
+        regenKeepAliveNanos = osiNanos << 1;
+      }
+    } else {
+      int lastIdx = keepAliveConfig.length() - 1;
+      String sub = keepAliveConfig.substring(0, lastIdx);
+      switch (keepAliveConfig.charAt(lastIdx)) {
+        case 's':
+          regenKeepAliveNanos = TimeUnit.SECONDS.toNanos(Long.parseLong(sub));
+          break;
+        case 'm':
+          regenKeepAliveNanos = TimeUnit.MINUTES.toNanos(Long.parseLong(sub));
+          break;
+        case 'h':
+          regenKeepAliveNanos = TimeUnit.HOURS.toNanos(Long.parseLong(sub));
+          break;
+        case 'd':
+          regenKeepAliveNanos = TimeUnit.DAYS.toNanos(Long.parseLong(sub));
+          break;
+        case '%':
+          int keepAlivePct = Integer.parseInt(sub);
+          if (keepAlivePct < 0) {
+            throw new IllegalArgumentException(
+                "regenKeepAlive % must be positive; found " + keepAlivePct);
+          }
+          long osiNanos;
+          if (solrConfig == null || (osiNanos = getOpenSearcherIntervalNanos(solrConfig)) == -1) {
+            throw new IllegalArgumentException(
+                "regenKeepAlive % must only be configured in conjunction with autoCommit time");
+          } else {
+            regenKeepAliveNanos = (osiNanos * keepAlivePct) / 100;
+          }
+          break;
+        default:
+          regenKeepAliveNanos = TimeUnit.MILLISECONDS.toNanos(Long.parseLong(keepAliveConfig));
+          break;
+      }
+    }
+    if (regenKeepAliveNanos == DEFAULT_REGEN_KEEPALIVE_NANOS) {
+      config.setRegenerator(DEFAULT_INSTANCE);
+      return;
+    }
+    config.setRegenerator(new OrdMapRegenerator(regenKeepAliveNanos));
+  }
+
+  private static long getOpenSearcherIntervalNanos(SolrConfig solrConfig) {
+    SolrConfig.UpdateHandlerInfo uinfo = solrConfig.getUpdateHandlerInfo();
+    if (uinfo == null) {
+      return -1;
+    } else if (uinfo.autoSoftCommmitMaxTime != -1) {
+      if (uinfo.openSearcher && uinfo.autoCommmitMaxTime != -1) {
+        return TimeUnit.MILLISECONDS.toNanos(
+            Math.min(uinfo.autoCommmitMaxTime, uinfo.autoSoftCommmitMaxTime));
+      } else {
+        return TimeUnit.MILLISECONDS.toNanos(uinfo.autoSoftCommmitMaxTime);
+      }
+    } else if (uinfo.openSearcher && uinfo.autoCommmitMaxTime != -1) {
+      return TimeUnit.MILLISECONDS.toNanos(uinfo.autoCommmitMaxTime);
+    } else {
+      return -1;
+    }
+  }
+
+  @Override
+  public <K, V> boolean regenerateItem(
+      SolrIndexSearcher newSearcher,
+      SolrCache<K, V> newCache,
+      SolrCache<K, V> oldCache,
+      K oldKey,
+      V oldVal)
+      throws IOException {
+    DirectoryReader in = newSearcher.getIndexReader();
+    IndexReader.CacheHelper cacheHelper = in.getReaderCacheHelper();
+    if (cacheHelper == null) {
+      return false;
+    }
+
+    final List<LeafReaderContext> leaves = in.leaves();
+    final int size = leaves.size();
+
+    if (size < 2) {
+      // we don't need OrdinalMaps for these trivial cases
+      return false;
+    }
+
+    final long extantTimestamp = ((OrdinalMapValue) oldVal).accessTimestampNanos;
+    if (System.nanoTime() - extantTimestamp > regenKeepAliveNanos) {
+      // it has been long enough since this was last accessed that we don't want to carry it forward
+      return true;
+    }
+
+    final String field = (String) oldKey;
+    boolean anyReal = false;
+    final SortedDocValues[] sdvs = new SortedDocValues[size];
+    final SortedSetDocValues[] ssdvs = new SortedSetDocValues[size];
+    DocValuesType type = null;
+    for (int i = 0; i < size; i++) {
+      LeafReaderContext context = leaves.get(i);
+      final LeafReader reader = context.reader();
+      final FieldInfo fieldInfo = reader.getFieldInfos().fieldInfo(field);
+      if (fieldInfo == null) {
+        sdvs[i] = DocValues.emptySorted();
+        ssdvs[i] = DocValues.emptySortedSet();
+      } else {
+        DocValuesType leafType = fieldInfo.getDocValuesType();
+        if (type == null) {
+          type = leafType;
+        } else if (leafType != type) {
+          throw new IllegalStateException("mixed docValues types " + type + " and " + leafType);
+        }
+        switch (leafType) {
+          case SORTED:
+            SortedDocValues sdv = reader.getSortedDocValues(field);
+            if (sdv == null) {
+              sdv = DocValues.emptySorted();
+            } else {
+              anyReal = true;
+            }
+            sdvs[i] = sdv;
+            break;
+          case SORTED_SET:
+            SortedSetDocValues ssdv = reader.getSortedSetDocValues(field);
+            if (ssdv == null) {
+              ssdv = DocValues.emptySortedSet();
+            } else {
+              anyReal = true;
+            }
+            ssdvs[i] = ssdv;
+            break;
+          default:
+            throw new IllegalStateException("unexpected docValues type: " + leafType);
+        }
+      }
+    }
+    if (!anyReal) {
+      // All empty for this field, but should still warm others
+      return true;
+    }
+
+    IndexReader.CacheKey readerKey = cacheHelper.getKey();
+    final IOFunction<? super String, ? extends Supplier<OrdinalMap>> producer;
+    switch (type) {
+      case SORTED:
+        producer =
+            (notUsed) ->
+                new OrdinalMapValue(
+                    OrdinalMap.build(readerKey, sdvs, PackedInts.DEFAULT), extantTimestamp);
+        break;
+      case SORTED_SET:
+        producer =
+            (notUsed) ->
+                new OrdinalMapValue(
+                    OrdinalMap.build(readerKey, ssdvs, PackedInts.DEFAULT), extantTimestamp);
+        break;
+      default:
+        throw new IllegalStateException();
+    }
+
+    @SuppressWarnings("unchecked")
+    SolrCache<String, Supplier<OrdinalMap>> c = (SolrCache<String, Supplier<OrdinalMap>>) newCache;
+    c.computeIfAbsent(field, producer);
+    return true;
+  }
+}

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -376,7 +376,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     this.queryResultMaxDocsCached = solrConfig.queryResultMaxDocsCached;
     this.useFilterForSortedQuery = solrConfig.useFilterForSortedQuery;
 
-    ordMapCache = solrConfig.ordMapCacheConfig.newInstance();
+    ordMapCache = solrConfig.ordMapCacheConfig.newInstance(core);
     assert ordMapCache != null;
     this.leafReader = SlowCompositeReaderWrapper.wrap(this.reader, ordMapCache);
 

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -107,6 +107,7 @@ import org.apache.solr.request.SolrRequestInfo;
 import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.schema.IndexSchema;
 import org.apache.solr.schema.SchemaField;
+import org.apache.solr.search.OrdMapRegenerator.OrdinalMapValue;
 import org.apache.solr.search.facet.UnInvertedField;
 import org.apache.solr.search.stats.StatsCache;
 import org.apache.solr.search.stats.StatsSource;
@@ -156,6 +157,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
 
   private final boolean cachingEnabled;
   private final SolrCache<Query, DocSet> filterCache;
+  private final SolrCache<String, OrdinalMapValue> ordMapCache;
   private final SolrCache<QueryResultKey, DocList> queryResultCache;
   private final SolrCache<String, UnInvertedField> fieldValueCache;
   private final LongAdder fullSortCount = new LongAdder();
@@ -341,7 +343,6 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     this.directoryFactory = directoryFactory;
     this.reader = (DirectoryReader) super.readerContext.reader();
     this.rawReader = r;
-    this.leafReader = SlowCompositeReaderWrapper.wrap(this.reader);
     this.core = core;
     this.statsCache = core.createStatsCache();
     this.schema = schema;
@@ -375,11 +376,16 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     this.queryResultMaxDocsCached = solrConfig.queryResultMaxDocsCached;
     this.useFilterForSortedQuery = solrConfig.useFilterForSortedQuery;
 
+    ordMapCache = solrConfig.ordMapCacheConfig.newInstance();
+    assert ordMapCache != null;
+    this.leafReader = SlowCompositeReaderWrapper.wrap(this.reader, ordMapCache);
+
     this.docFetcher = new SolrDocumentFetcher(this, solrConfig, enableCache);
 
     this.cachingEnabled = enableCache;
     if (cachingEnabled) {
       final ArrayList<SolrCache> clist = new ArrayList<>();
+      clist.add(ordMapCache);
       fieldValueCache =
           solrConfig.fieldValueCacheConfig == null
               ? null
@@ -616,6 +622,10 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     return StreamSupport.stream(getFieldInfos().spliterator(), false)
         .map(fieldInfo -> fieldInfo.name)
         .collect(Collectors.toUnmodifiableList());
+  }
+
+  public SolrCache<String, OrdinalMapValue> getOrdMapCache() {
+    return ordMapCache;
   }
 
   public SolrCache<Query, DocSet> getFilterCache() {

--- a/solr/core/src/java/org/apache/solr/search/facet/UnInvertedField.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/UnInvertedField.java
@@ -202,7 +202,8 @@ public class UnInvertedField extends DocTermOrds {
       // TODO: it's wasteful to create one of these each time
       // but DocTermOrds will throw an exception if it thinks the field has doc values (which is
       // faked by UnInvertingReader)
-      LeafReader r = SlowCompositeReaderWrapper.wrap(searcher.getRawReader());
+      LeafReader r =
+          SlowCompositeReaderWrapper.wrap(searcher.getRawReader(), searcher.getOrdMapCache());
       uninvert(r, r.getLiveDocs(), prefix == null ? null : new BytesRef(prefix));
     } catch (IllegalStateException ise) {
       throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, ise);

--- a/solr/core/src/java/org/apache/solr/search/function/OrdFieldSource.java
+++ b/solr/core/src/java/org/apache/solr/search/function/OrdFieldSource.java
@@ -93,14 +93,14 @@ public class OrdFieldSource extends ValueSource {
         for (LeafReaderContext raw : leaves) {
           hidingLeaves[upto++] = NumericHidingLeafReader.wrap(raw.reader(), field);
         }
-        r = SlowCompositeReaderWrapper.wrap(new MultiReader(hidingLeaves));
+        r = SlowCompositeReaderWrapper.wrap(new MultiReader(hidingLeaves), is.getOrdMapCache());
       } else {
         // reuse ordinalmap
         r = ((SolrIndexSearcher) o).getSlowAtomicReader();
       }
     } else {
       IndexReader topReader = ReaderUtil.getTopLevelContext(readerContext).reader();
-      r = SlowCompositeReaderWrapper.wrap(topReader);
+      r = SlowCompositeReaderWrapper.wrap(topReader, SlowCompositeReaderWrapper.NO_CACHED_ORDMAPS);
     }
     // if it's e.g. tokenized/multivalued, emulate old behavior of single-valued fc
     final SortedDocValues sindex =

--- a/solr/core/src/java/org/apache/solr/search/function/ReverseOrdFieldSource.java
+++ b/solr/core/src/java/org/apache/solr/search/function/ReverseOrdFieldSource.java
@@ -91,14 +91,14 @@ public class ReverseOrdFieldSource extends ValueSource {
         for (LeafReaderContext raw : leaves) {
           hidingLeaves[upto++] = NumericHidingLeafReader.wrap(raw.reader(), field);
         }
-        r = SlowCompositeReaderWrapper.wrap(new MultiReader(hidingLeaves));
+        r = SlowCompositeReaderWrapper.wrap(new MultiReader(hidingLeaves), is.getOrdMapCache());
       } else {
         // reuse ordinalmap
         r = ((SolrIndexSearcher) o).getSlowAtomicReader();
       }
     } else {
       IndexReader topReader = ReaderUtil.getTopLevelContext(readerContext).reader();
-      r = SlowCompositeReaderWrapper.wrap(topReader);
+      r = SlowCompositeReaderWrapper.wrap(topReader, SlowCompositeReaderWrapper.NO_CACHED_ORDMAPS);
     }
     // if it's e.g. tokenized/multivalued, emulate old behavior of single-valued fc
     final SortedDocValues sindex =

--- a/solr/core/src/java/org/apache/solr/update/VersionInfo.java
+++ b/solr/core/src/java/org/apache/solr/update/VersionInfo.java
@@ -297,7 +297,9 @@ public class VersionInfo {
     assert !versionField.getType().isPointField();
 
     final String versionFieldName = versionField.getName();
-    final LeafReader leafReader = SlowCompositeReaderWrapper.wrap(searcher.getIndexReader());
+    final LeafReader leafReader =
+        SlowCompositeReaderWrapper.wrap(
+            searcher.getIndexReader(), SlowCompositeReaderWrapper.NO_CACHED_ORDMAPS);
     final Terms versionTerms = leafReader.terms(versionFieldName);
     final Long max = (versionTerms != null) ? LegacyNumericUtils.getMaxLong(versionTerms) : null;
     if (null != max) {

--- a/solr/core/src/test/org/apache/solr/index/TestSlowCompositeReaderWrapper.java
+++ b/solr/core/src/test/org/apache/solr/index/TestSlowCompositeReaderWrapper.java
@@ -120,7 +120,7 @@ public class TestSlowCompositeReaderWrapper extends SolrTestCase {
     assertTrue(reader.leaves().size() > 1);
     @SuppressWarnings("unchecked")
     SolrCache<String, OrdinalMapValue> ordMapCache =
-        OrdMapRegenerator.getDefaultCacheConfig(null).newInstance();
+        OrdMapRegenerator.getDefaultCacheConfig(null).newInstance(null);
     SlowCompositeReaderWrapper slowWrapper =
         (SlowCompositeReaderWrapper) SlowCompositeReaderWrapper.wrap(reader, ordMapCache);
     assertEquals(0, slowWrapper.cachedOrdMaps.size());

--- a/solr/core/src/test/org/apache/solr/schema/TestPointFields.java
+++ b/solr/core/src/test/org/apache/solr/schema/TestPointFields.java
@@ -5751,7 +5751,8 @@ public class TestPointFields extends SolrTestCaseJ4 {
               // our own SlowCompositeReader to check DocValues on disk w/o the UninvertingReader
               // added by SolrIndexSearcher
               final LeafReader leafReaderForCheckingDVs =
-                  SlowCompositeReaderWrapper.wrap(searcher.getRawReader());
+                  SlowCompositeReaderWrapper.wrap(
+                      searcher.getRawReader(), searcher.getOrdMapCache());
 
               if (sf.indexed()) {
                 assertEquals(

--- a/solr/core/src/test/org/apache/solr/search/TestOrdMapCache.java
+++ b/solr/core/src/test/org/apache/solr/search/TestOrdMapCache.java
@@ -1,0 +1,361 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
+import org.apache.solr.metrics.SolrMetricManager;
+import org.apache.solr.util.EmbeddedSolrServerTestRule;
+import org.apache.solr.util.SolrClientTestRule;
+import org.junit.ClassRule;
+
+public class TestOrdMapCache extends SolrTestCaseJ4 {
+
+  @ClassRule
+  public static final SolrClientTestRule solrClientTestRule =
+      new EmbeddedSolrServerTestRule() {
+        @Override
+        protected void before() throws Throwable {
+          startSolr(LuceneTestCase.createTempDir());
+        }
+      };
+
+  private static final String ORD_MAP_CACHE_METRIC_NAME = "CACHE.searcher.ordMapCache";
+
+  private static Map<String, ?> getOrdMapCacheMetrics(SolrClient client, String collectionName) {
+    @SuppressWarnings("unchecked")
+    SolrMetricManager.GaugeWrapper<Map<String, ?>> metrics =
+        (SolrMetricManager.GaugeWrapper<Map<String, ?>>)
+            ((EmbeddedSolrServer) client)
+                .getCoreContainer()
+                .getMetricManager()
+                .getMetrics(
+                    "solr.core.".concat(collectionName),
+                    (metricName, metric) -> ORD_MAP_CACHE_METRIC_NAME.equals(metricName))
+                .get(ORD_MAP_CACHE_METRIC_NAME);
+    return metrics.getValue();
+  }
+
+  public void testDefaultBehavior() throws Exception {
+    String name = "default";
+    Path configSet = LuceneTestCase.createTempDir();
+    SolrTestCaseJ4.copyMinConf(configSet.toFile());
+
+    solrClientTestRule.newCollection(name).withConfigSet(configSet.toString()).create();
+
+    SolrClient client = solrClientTestRule.getSolrClient(name);
+    Map<String, ?> metrics;
+
+    client.add(sdoc("id", "1"));
+    client.commit();
+
+    // initial sanity-check
+    assertEquals(0, getOrdMapCacheMetrics(client, name).get("size"));
+
+    client.query(
+        params("q", "*:*", "facet", "true", "facet.field", "id")); // would trigger ordmap build
+
+    // for 1-seg index, no ordmap will actually be built
+    assertEquals(0, getOrdMapCacheMetrics(client, name).get("size"));
+
+    client.add(sdoc("id", "2"));
+    client.commit();
+
+    client.query(params("q", "*:*", "facet", "true", "facet.field", "id")); // trigger ordmap build
+
+    // for 2-seg index, ordmap will actually be built
+    metrics = getOrdMapCacheMetrics(client, name);
+    assertEquals(1, metrics.get("size"));
+    assertEquals(1L, metrics.get("lookups"));
+    assertEquals(1L, metrics.get("inserts"));
+    assertEquals(0L, metrics.get("hits"));
+
+    client.add(sdoc("id", "3"));
+    client.commit();
+
+    // expect ordmap to not be auto-warmed
+    metrics = getOrdMapCacheMetrics(client, name);
+    assertEquals(0, metrics.get("size"));
+    assertEquals(1L, metrics.get("cumulative_lookups"));
+    assertEquals(1L, metrics.get("cumulative_inserts"));
+    assertEquals(0L, metrics.get("cumulative_hits"));
+
+    client.query(
+        params("q", "*:*", "facet", "true", "facet.field", "id")); // will get auto-warmed ordmap
+
+    metrics = getOrdMapCacheMetrics(client, name);
+    assertEquals(1, metrics.get("size"));
+    assertEquals(2L, metrics.get("cumulative_lookups"));
+    assertEquals(2L, metrics.get("cumulative_inserts"));
+    assertEquals(0L, metrics.get("cumulative_hits"));
+  }
+
+  public void testLongKeepAlive() throws Exception {
+    String name = "longKeepAlive";
+    String keepAlive;
+    switch (random().nextInt(5)) {
+      case 0:
+        keepAlive = "60000";
+        break;
+      case 1:
+        keepAlive = "60s";
+        break;
+      case 2:
+        keepAlive = "1m";
+        break;
+      case 3:
+        keepAlive = "1h";
+        break;
+      case 4:
+        keepAlive = "1d";
+        break;
+      default:
+        throw new IllegalStateException();
+    }
+    keepAlive = "regenKeepAlive=\"" + keepAlive + "\"\n";
+    Path configSet = LuceneTestCase.createTempDir();
+    SolrTestCaseJ4.copyMinConf(configSet.toFile());
+    // insert a special ordMapCache configuration
+    Path solrConfig = configSet.resolve("conf/solrconfig.xml");
+    Files.writeString(
+        solrConfig,
+        Files.readString(solrConfig)
+            .replace(
+                "</config>",
+                "<query>\n"
+                    + "<ordMapCache\n"
+                    + "      class=\"solr.CaffeineCache\"\n"
+                    + "      size=\"1\"\n"
+                    + "      autowarmCount=\"100%\"\n"
+                    + keepAlive
+                    + "      initialSize=\"1\"/>\n"
+                    + "</query></config>"));
+
+    solrClientTestRule.newCollection(name).withConfigSet(configSet.toString()).create();
+
+    SolrClient client = solrClientTestRule.getSolrClient(name);
+    Map<String, ?> metrics;
+
+    client.add(sdoc("id", "1"));
+    client.commit();
+
+    // initial sanity-check
+    assertEquals(0, getOrdMapCacheMetrics(client, name).get("size"));
+
+    client.query(
+        params("q", "*:*", "facet", "true", "facet.field", "id")); // would trigger ordmap build
+
+    // for 1-seg index, no ordmap will actually be built
+    assertEquals(0, getOrdMapCacheMetrics(client, name).get("size"));
+
+    client.add(sdoc("id", "2"));
+    client.commit();
+
+    client.query(params("q", "*:*", "facet", "true", "facet.field", "id")); // trigger ordmap build
+
+    // for 2-seg index, ordmap will actually be built
+    metrics = getOrdMapCacheMetrics(client, name);
+    assertEquals(1, metrics.get("size"));
+    assertEquals(1L, metrics.get("lookups"));
+    assertEquals(1L, metrics.get("inserts"));
+    assertEquals(0L, metrics.get("hits"));
+
+    client.add(sdoc("id", "3"));
+    client.commit();
+
+    // expect ordmap to be auto-warmed
+    metrics = getOrdMapCacheMetrics(client, name);
+    assertEquals(1, metrics.get("size"));
+    assertEquals(1L, metrics.get("cumulative_lookups"));
+    assertEquals(1L, metrics.get("cumulative_inserts"));
+    assertEquals(0L, metrics.get("cumulative_hits"));
+
+    client.query(
+        params("q", "*:*", "facet", "true", "facet.field", "id")); // will get auto-warmed ordmap
+
+    metrics = getOrdMapCacheMetrics(client, name);
+    assertEquals(1, metrics.get("size"));
+    assertEquals(2L, metrics.get("cumulative_lookups"));
+    assertEquals(1L, metrics.get("cumulative_inserts"));
+    assertEquals(1L, metrics.get("cumulative_hits"));
+  }
+
+  public void testShortKeepAlive() throws Exception {
+    String name = "shortKeepAlive";
+    Path configSet = LuceneTestCase.createTempDir();
+    SolrTestCaseJ4.copyMinConf(configSet.toFile());
+    // insert a special ordMapCache configuration
+    Path solrConfig = configSet.resolve("conf/solrconfig.xml");
+    Files.writeString(
+        solrConfig,
+        Files.readString(solrConfig)
+            .replace(
+                "</config>",
+                "<query>\n"
+                    + "<ordMapCache\n"
+                    + "      class=\"solr.CaffeineCache\"\n"
+                    + "      size=\"1\"\n"
+                    + "      autowarmCount=\"100%\"\n"
+                    + "      regenKeepAlive=\"500\"\n"
+                    + "      initialSize=\"1\"/>\n"
+                    + "</query></config>"));
+
+    solrClientTestRule.newCollection(name).withConfigSet(configSet.toString()).create();
+
+    SolrClient client = solrClientTestRule.getSolrClient(name);
+    Map<String, ?> metrics;
+
+    client.add(sdoc("id", "1"));
+    client.commit();
+
+    // initial sanity-check
+    assertEquals(0, getOrdMapCacheMetrics(client, name).get("size"));
+
+    client.query(
+        params("q", "*:*", "facet", "true", "facet.field", "id")); // would trigger ordmap build
+
+    // for 1-seg index, no ordmap will actually be built
+    assertEquals(0, getOrdMapCacheMetrics(client, name).get("size"));
+
+    client.add(sdoc("id", "2"));
+    client.commit();
+
+    client.query(params("q", "*:*", "facet", "true", "facet.field", "id")); // trigger ordmap build
+
+    // for 2-seg index, ordmap will actually be built
+    metrics = getOrdMapCacheMetrics(client, name);
+    assertEquals(1, metrics.get("size"));
+    assertEquals(1L, metrics.get("lookups"));
+    assertEquals(1L, metrics.get("inserts"));
+    assertEquals(0L, metrics.get("hits"));
+
+    client.add(sdoc("id", "3"));
+    client.commit();
+
+    // expect ordmap to be auto-warmed
+    metrics = getOrdMapCacheMetrics(client, name);
+    assertEquals(1, metrics.get("size"));
+    assertEquals(1L, metrics.get("cumulative_lookups"));
+    assertEquals(1L, metrics.get("cumulative_inserts"));
+    assertEquals(0L, metrics.get("cumulative_hits"));
+
+    client.query(
+        params("q", "*:*", "facet", "true", "facet.field", "id")); // will get auto-warmed ordmap
+
+    metrics = getOrdMapCacheMetrics(client, name);
+    assertEquals(1, metrics.get("size"));
+    assertEquals(2L, metrics.get("cumulative_lookups"));
+    assertEquals(1L, metrics.get("cumulative_inserts"));
+    assertEquals(1L, metrics.get("cumulative_hits"));
+
+    Thread.sleep(300);
+
+    client.add(sdoc("id", "4"));
+    client.commit();
+
+    // entry should still be auto-warmed at this point
+    metrics = getOrdMapCacheMetrics(client, name);
+    assertEquals(1, metrics.get("size"));
+    assertEquals(2L, metrics.get("cumulative_lookups"));
+    assertEquals(1L, metrics.get("cumulative_inserts"));
+    assertEquals(1L, metrics.get("cumulative_hits"));
+
+    // wait long enough that the entry should no longer be auto-warmed
+    Thread.sleep(300);
+
+    client.add(sdoc("id", "5"));
+    client.commit();
+
+    // we waited beyond keepAlive; expect ordmap to be empty
+    metrics = getOrdMapCacheMetrics(client, name);
+    assertEquals(0, metrics.get("size"));
+    assertEquals(2L, metrics.get("cumulative_lookups"));
+    assertEquals(1L, metrics.get("cumulative_inserts"));
+    assertEquals(1L, metrics.get("cumulative_hits"));
+
+    client.query(params("q", "*:*", "facet", "true", "facet.field", "id")); // will re-build ordmap
+
+    metrics = getOrdMapCacheMetrics(client, name);
+    assertEquals(1, metrics.get("size"));
+    assertEquals(3L, metrics.get("cumulative_lookups"));
+    assertEquals(2L, metrics.get("cumulative_inserts"));
+    assertEquals(1L, metrics.get("cumulative_hits"));
+  }
+
+  public void testSizeLimited() throws Exception {
+    String name = "sizeLimited";
+    Path configSet = LuceneTestCase.createTempDir();
+    SolrTestCaseJ4.copyMinConf(configSet.toFile());
+    // insert a special ordMapCache configuration
+    Path solrConfig = configSet.resolve("conf/solrconfig.xml");
+    Files.writeString(
+        solrConfig,
+        Files.readString(solrConfig)
+            .replace(
+                "</config>",
+                "<query>\n"
+                    + "<ordMapCache\n"
+                    + "      class=\"solr.CaffeineCache\"\n"
+                    + "      size=\"1\"\n"
+                    + "      initialSize=\"1\"/>\n"
+                    + "</query></config>"));
+
+    solrClientTestRule.newCollection(name).withConfigSet(configSet.toString()).create();
+
+    SolrClient client = solrClientTestRule.getSolrClient(name);
+    Map<String, ?> metrics;
+
+    client.add(sdoc("id", "1", "other", "1"));
+    client.commit();
+
+    // initial sanity-check
+    assertEquals(0, getOrdMapCacheMetrics(client, name).get("size"));
+
+    client.query(
+        params("q", "*:*", "facet", "true", "facet.field", "id")); // would trigger ordmap build
+
+    // for 1-seg index, no ordmap will actually be built
+    assertEquals(0, getOrdMapCacheMetrics(client, name).get("size"));
+
+    client.add(sdoc("id", "2", "other", "2"));
+    client.commit();
+
+    client.query(params("q", "*:*", "facet", "true", "facet.field", "id")); // trigger ordmap build
+
+    // for 2-seg index, ordmap will actually be built
+    metrics = getOrdMapCacheMetrics(client, name);
+    assertEquals(1, metrics.get("size"));
+    assertEquals(1L, metrics.get("lookups"));
+    assertEquals(1L, metrics.get("inserts"));
+    assertEquals(0L, metrics.get("hits"));
+
+    client.query(
+        params("q", "*:*", "facet", "true", "facet.field", "other")); // trigger ordmap build/evict
+
+    // no actual hits, just evict/insert (thrashing)
+    metrics = getOrdMapCacheMetrics(client, name);
+    assertEquals(1, metrics.get("size"));
+    assertEquals(2L, metrics.get("lookups"));
+    assertEquals(2L, metrics.get("inserts"));
+    assertEquals(0L, metrics.get("hits"));
+  }
+}

--- a/solr/core/src/test/org/apache/solr/uninverting/TestDocTermOrds.java
+++ b/solr/core/src/test/org/apache/solr/uninverting/TestDocTermOrds.java
@@ -69,7 +69,8 @@ public class TestDocTermOrds extends SolrTestCase {
     final DirectoryReader ir = DirectoryReader.open(dir);
     TestUtil.checkReader(ir);
 
-    final LeafReader composite = SlowCompositeReaderWrapper.wrap(ir);
+    final LeafReader composite =
+        SlowCompositeReaderWrapper.wrap(ir, SlowCompositeReaderWrapper.NO_CACHED_ORDMAPS);
     TestUtil.checkReader(composite);
 
     // check the leaves
@@ -114,7 +115,8 @@ public class TestDocTermOrds extends SolrTestCase {
     final IndexReader r = w.getReader();
     w.close();
 
-    final LeafReader ar = SlowCompositeReaderWrapper.wrap(r);
+    final LeafReader ar =
+        SlowCompositeReaderWrapper.wrap(r, SlowCompositeReaderWrapper.NO_CACHED_ORDMAPS);
     TestUtil.checkReader(ar);
     final DocTermOrds dto = new DocTermOrds(ar, ar.getLiveDocs(), "field");
     SortedSetDocValues iter = dto.iterator(ar);
@@ -218,7 +220,8 @@ public class TestDocTermOrds extends SolrTestCase {
     if (VERBOSE) {
       System.out.println("TEST: top reader");
     }
-    LeafReader slowR = SlowCompositeReaderWrapper.wrap(r);
+    LeafReader slowR =
+        SlowCompositeReaderWrapper.wrap(r, SlowCompositeReaderWrapper.NO_CACHED_ORDMAPS);
     TestUtil.checkReader(slowR);
     verify(slowR, idToOrds, termsArray, null);
 
@@ -307,7 +310,8 @@ public class TestDocTermOrds extends SolrTestCase {
       System.out.println("TEST: reader=" + r);
     }
 
-    LeafReader slowR = SlowCompositeReaderWrapper.wrap(r);
+    LeafReader slowR =
+        SlowCompositeReaderWrapper.wrap(r, SlowCompositeReaderWrapper.NO_CACHED_ORDMAPS);
     TestUtil.checkReader(slowR);
     for (String prefix : prefixesArray) {
 

--- a/solr/core/src/test/org/apache/solr/uninverting/TestDocTermOrdsUninvertLimit.java
+++ b/solr/core/src/test/org/apache/solr/uninverting/TestDocTermOrdsUninvertLimit.java
@@ -83,7 +83,8 @@ public class TestDocTermOrdsUninvertLimit extends SolrTestCase {
 
     final IndexReader r = DirectoryReader.open(dir);
     try {
-      final LeafReader ar = SlowCompositeReaderWrapper.wrap(r);
+      final LeafReader ar =
+          SlowCompositeReaderWrapper.wrap(r, SlowCompositeReaderWrapper.NO_CACHED_ORDMAPS);
       TestUtil.checkReader(ar);
       final DocTermOrds dto = new DocTermOrds(ar, ar.getLiveDocs(), "field"); // bigTerms turned off
       if (SHOULD_TRIGGER) {

--- a/solr/core/src/test/org/apache/solr/uninverting/TestFieldCache.java
+++ b/solr/core/src/test/org/apache/solr/uninverting/TestFieldCache.java
@@ -304,7 +304,8 @@ public class TestFieldCache extends SolrTestCase {
             dir, newIndexWriterConfig(new MockAnalyzer(random())).setMaxBufferedDocs(500));
     writer.close();
     IndexReader r = DirectoryReader.open(dir);
-    LeafReader reader = SlowCompositeReaderWrapper.wrap(r);
+    LeafReader reader =
+        SlowCompositeReaderWrapper.wrap(r, SlowCompositeReaderWrapper.NO_CACHED_ORDMAPS);
     TestUtil.checkReader(reader);
     FieldCache.DEFAULT.getTerms(reader, "foobar");
     FieldCache.DEFAULT.getTermsIndex(reader, "foobar");

--- a/solr/core/src/test/org/apache/solr/uninverting/TestFieldCacheVsDocValues.java
+++ b/solr/core/src/test/org/apache/solr/uninverting/TestFieldCacheVsDocValues.java
@@ -170,7 +170,8 @@ public class TestFieldCacheVsDocValues extends SolrTestCase {
 
         DirectoryReader r = DirectoryReader.open(w);
 
-        try (LeafReader ar = SlowCompositeReaderWrapper.wrap(r)) {
+        try (LeafReader ar =
+            SlowCompositeReaderWrapper.wrap(r, SlowCompositeReaderWrapper.NO_CACHED_ORDMAPS)) {
           TestUtil.checkReader(ar);
 
           BinaryDocValues s = FieldCache.DEFAULT.getTerms(ar, "field");

--- a/solr/core/src/test/org/apache/solr/uninverting/TestLegacyFieldCache.java
+++ b/solr/core/src/test/org/apache/solr/uninverting/TestLegacyFieldCache.java
@@ -91,7 +91,7 @@ public class TestLegacyFieldCache extends SolrTestCase {
       writer.addDocument(doc);
     }
     IndexReader r = writer.getReader();
-    reader = SlowCompositeReaderWrapper.wrap(r);
+    reader = SlowCompositeReaderWrapper.wrap(r, SlowCompositeReaderWrapper.NO_CACHED_ORDMAPS);
     TestUtil.checkReader(reader);
     writer.close();
   }
@@ -177,7 +177,8 @@ public class TestLegacyFieldCache extends SolrTestCase {
             dir, newIndexWriterConfig(new MockAnalyzer(random())).setMaxBufferedDocs(500));
     writer.close();
     IndexReader r = DirectoryReader.open(dir);
-    LeafReader reader = SlowCompositeReaderWrapper.wrap(r);
+    LeafReader reader =
+        SlowCompositeReaderWrapper.wrap(r, SlowCompositeReaderWrapper.NO_CACHED_ORDMAPS);
     TestUtil.checkReader(reader);
     FieldCache.DEFAULT.getTerms(reader, "foobar");
     FieldCache.DEFAULT.getTermsIndex(reader, "foobar");

--- a/solr/core/src/test/org/apache/solr/uninverting/TestUninvertingReader.java
+++ b/solr/core/src/test/org/apache/solr/uninverting/TestUninvertingReader.java
@@ -310,7 +310,8 @@ public class TestUninvertingReader extends SolrTestCase {
     }
 
     // check the composite of all leaves: exact expectation of set size
-    final LeafReader composite = SlowCompositeReaderWrapper.wrap(ir);
+    final LeafReader composite =
+        SlowCompositeReaderWrapper.wrap(ir, SlowCompositeReaderWrapper.NO_CACHED_ORDMAPS);
     TestUtil.checkReader(composite);
 
     for (String f : MULTI_VALUES) {
@@ -339,7 +340,8 @@ public class TestUninvertingReader extends SolrTestCase {
     final DirectoryReader ir = UninvertingReader.wrap(DirectoryReader.open(dir), UNINVERT_MAP);
     TestUtil.checkReader(ir);
 
-    final LeafReader composite = SlowCompositeReaderWrapper.wrap(ir);
+    final LeafReader composite =
+        SlowCompositeReaderWrapper.wrap(ir, SlowCompositeReaderWrapper.NO_CACHED_ORDMAPS);
     TestUtil.checkReader(composite);
 
     for (String f : UNINVERT_MAP.keySet()) {

--- a/solr/solr-ref-guide/modules/configuration-guide/pages/caches-warming.adoc
+++ b/solr/solr-ref-guide/modules/configuration-guide/pages/caches-warming.adoc
@@ -135,6 +135,34 @@ The filter cache is a good candidate for enabling `async` computation.
 ----
 
 
+=== OrdMap Cache
+
+This is a low-level cache that holds mappings between global ordinals and per-segment ordinals for string docValues.
+It is an essential component of functionality like faceting and join queries, and an implicit default instance of this cache will be configured if no explicit configuration is provided.
+
+The `ordMapCache` usually contains relatively few values -- at most one value is created per field per searcher, and values are created on-demand in response to an operation that requires global<=>segment ordinal mappings for a given field.
+
+The behavior of the implicit default cache is equivalent to legacy behavior, which opaquely cached these values in an unbounded map, newly created for each searcher, in response to queries. In fact, indirect warming of the cached ordinal maps is often one of the most important functions of `filterCache` warming queries.
+
+Manually configuring the `ordMapCache` provides finer grained control, including the ability to:
+1. place constraints on resource usage (max size or bytes)
+2. directly autowarm the `ordMapCache`
+
+`ordMapCache` is configured similarly to other caches, but with the additional config parameter `regenKeepAlive`. During autowarming, cache entry metadata is used to avoid auto-warming `ordMapCache` entries that have not been accessed within a specified amount of time. This is important for `ordMapCache`, because due to its often-unlimited enforced size, and its often-quite-small size in practice, entries will not be replaced in the same way that they would be for other caches that have higher turnover. `regenKeepAlive` solves this by allowing entries to "age out" if they are unused.
+`regenKeepAlive` may be specified in milliseconds, seconds, minutes, hours, or days (e.g., `60000`, `60s`, `1m`, `1h`, `1d`). `regenKeepAlive` may also be specified as a percentage of the effective autoCommit interval.
+
+As a low-level cache, `ordMapCache` is warmed before other caches.
+
+[source,xml]
+----
+<ordMapCache class="solr.CaffeineCache"
+             size="100"
+             initialSize="10"
+             autowarmCount="100%"
+             regenKeepAlive="110%"/>
+----
+
+
 === Query Result Cache
 
 The `queryResultCache` holds the results of previous searches: ordered lists of document IDs (DocList) based on a query, a sort, and the range of documents requested.


### PR DESCRIPTION
building on recent upstream work that stores OrdinalMaps in a ConcurrentHashMap, here we make OrdinalMap caching configurable within the standard Solr caching framework. This allows, e.g., OrdinalMap caches to be directly warmed, etc...

A couple of things to note:
1. technicality: `fs/branch_9x` upon which this is based seems currently to be failing, so we should merge from `fs/branch_9x` after merging cowpaths/fullstory-solr#118 to get meaningful CI results for this PR. EDIT: DONE
2. We will likely want to rework this PR to incorporate changes from https://github.com/apache/solr/pull/1351, for cleaner configuration of node-level caches. Notes about some affected workarounds are left in detailed portions of commit messages.