### PR TITLE
Experimental change to not care about cversion for Watched collections with persistent recursive watch

### DIFF
--- a/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/PerReplicaStatesFetcher.java
+++ b/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/PerReplicaStatesFetcher.java
@@ -38,11 +38,14 @@ public class PerReplicaStatesFetcher {
     try {
       assert CommonTestInjection.injectBreakpoint(
           PerReplicaStatesFetcher.class.getName() + "/beforePrsFetch");
-      if (current != null) {
-        Stat stat = zkClient.exists(current.path, null, true);
-        if (stat == null) return new PerReplicaStates(path, 0, Collections.emptyList());
-        if (current.cversion == stat.getCversion()) return current; // not modifiedZkStateReaderTest
-      }
+//      if (current != null) {
+//        Stat stat = zkClient.exists(current.path, null, true);
+//        if (stat == null) return new PerReplicaStates(path, 0, Collections.emptyList());
+//        if (current.cversion == stat.getCversion()) return current; // not modifiedZkStateReaderTest
+//      }
+
+      //TODO for tests, let's just always fetch it for now (since we don't have cversion info).
+      // We can limit whoever calls this
       Stat stat = new Stat();
       List<String> children = zkClient.getChildren(path, null, stat, true);
       return new PerReplicaStates(path, stat.getCversion(), Collections.unmodifiableList(children));

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/DocCollection.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/DocCollection.java
@@ -283,7 +283,7 @@ public class DocCollection extends ZkNodeProps implements Iterable<Slice> {
 
   public int getChildNodesVersion() {
     PerReplicaStates prs = prsSupplier == null ? null : prsSupplier.get();
-    return prs == null ? 0 : prs.cversion;
+    return prs == null ? 0 : prs.cversion == null ? 0 : prs.cversion;
   }
 
   public boolean isModified(int dataVersion, int childVersion) {


### PR DESCRIPTION
## Description
An experimental branch/PR to explore using persistent recursive watch without maintain the versioning of PRS entries (whether it's cversion or pzxid as proposed in #105 )

There are various challenges in #105, and one of the biggest issues was to keep the versioning of PRS entries. So this PR explores whether it's possible to ignore such versioning for "watched" collections. As watched collections are supposed be updated by watched events/notification (and that ONLY after the initial fetch), therefore versioning is not important to watched collections

This branch passed both test cases in  `PerReplicaStatesIntegrationTest` and `TestPerReplicaStates`. Ran `PerReplicaStatesIntegrationTest#testZkNodeVersions` (exclude the non PRS collection) and captured metrics similar to https://fullstory.atlassian.net/browse/SAI-4544?focusedCommentId=259534. 

It's found that this PR improves (ie reduce fetches) for collection creation, add/remove replica. but for node restart, it's pretty much the same as 9.2. This is probably due to the fact that most fetches for restart are actually triggered from `ZkStateReader#waitForState` (https://github.com/cowpaths/fullstory-solr/blob/74984f500e1e1dad071040494f48d7cc52023f20/solr/solrj-zookeeper/src/java/org/apache/solr/common/cloud/ZkStateReader.java#L1955-L1965) which for each core, register/unregister Doc collection listener multiple times. 
