### PR TITLE
DynamicComplementPrefixQuery: we must explicitly check for limitLength < 0 or we may get NPE

### DIFF
--- a/solr/core/src/java/org/apache/solr/query/DynamicComplementPrefixQuery.java
+++ b/solr/core/src/java/org/apache/solr/query/DynamicComplementPrefixQuery.java
@@ -205,7 +205,8 @@ public class DynamicComplementPrefixQuery extends MultiTermQuery {
       } else {
         candidate = tenum.next();
       }
-      if (limitLength != candidate.length
+      if (limitLength < 0
+          || limitLength != candidate.length
           || determinant
               != Byte.toUnsignedInt(candidate.bytes[candidate.offset + determinantIdx])) {
         return candidate;


### PR DESCRIPTION
Fixes NPE introduced by #126 