### PR TITLE
Handling Query Parsing Exceptions from Lucene queries

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -41,6 +41,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.StreamSupport;
 import org.apache.lucene.index.ExitableDirectoryReader;
+import org.apache.lucene.queryparser.surround.query.TooManyBasicQueries;
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.TotalHits;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.cloud.ZkController;
@@ -492,7 +494,7 @@ public class SearchHandler extends RequestHandlerBase
             .getResponseHeader()
             .asShallowMap()
             .put(SolrQueryResponse.RESPONSE_HEADER_PARTIAL_RESULTS_KEY, Boolean.TRUE);
-      } catch (IOException ex) {
+      } catch (IndexSearcher.TooManyClauses | TooManyBasicQueries ex) {
         // An IOException on a non-distributed request is typically an issue parsing the query at the lucene level
         throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, ex);
       } finally {

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -22,8 +22,6 @@ import static org.apache.solr.common.params.CommonParams.PATH;
 import static org.apache.solr.common.params.CommonParams.STATUS;
 
 import com.codahale.metrics.Counter;
-import com.google.common.collect.Iterators;
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.invoke.MethodHandles;
@@ -72,7 +70,6 @@ import org.apache.solr.schema.BloomStrField;
 import org.apache.solr.search.CursorMark;
 import org.apache.solr.search.SolrQueryTimeoutImpl;
 import org.apache.solr.search.SortSpec;
-import org.apache.solr.search.SyntaxError;
 import org.apache.solr.search.facet.FacetModule;
 import org.apache.solr.security.AuthorizationContext;
 import org.apache.solr.security.PermissionNameProvider;
@@ -495,7 +492,8 @@ public class SearchHandler extends RequestHandlerBase
             .asShallowMap()
             .put(SolrQueryResponse.RESPONSE_HEADER_PARTIAL_RESULTS_KEY, Boolean.TRUE);
       } catch (IndexSearcher.TooManyClauses | TooManyBasicQueries ex) {
-        // An IOException on a non-distributed request is typically an issue parsing the query at the lucene level
+        // An IOException on a non-distributed request is typically an issue parsing the query at
+        // the lucene level
         throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, ex);
       } finally {
         SolrQueryTimeoutImpl.reset();

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -22,6 +22,8 @@ import static org.apache.solr.common.params.CommonParams.PATH;
 import static org.apache.solr.common.params.CommonParams.STATUS;
 
 import com.codahale.metrics.Counter;
+import com.google.common.collect.Iterators;
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.invoke.MethodHandles;
@@ -68,6 +70,7 @@ import org.apache.solr.schema.BloomStrField;
 import org.apache.solr.search.CursorMark;
 import org.apache.solr.search.SolrQueryTimeoutImpl;
 import org.apache.solr.search.SortSpec;
+import org.apache.solr.search.SyntaxError;
 import org.apache.solr.search.facet.FacetModule;
 import org.apache.solr.security.AuthorizationContext;
 import org.apache.solr.security.PermissionNameProvider;
@@ -489,6 +492,9 @@ public class SearchHandler extends RequestHandlerBase
             .getResponseHeader()
             .asShallowMap()
             .put(SolrQueryResponse.RESPONSE_HEADER_PARTIAL_RESULTS_KEY, Boolean.TRUE);
+      } catch (IOException ex) {
+        // An IOException on a non-distributed request is typically an issue parsing the query at the lucene level
+        throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, ex);
       } finally {
         SolrQueryTimeoutImpl.reset();
       }

--- a/solr/core/src/test/org/apache/solr/handler/component/SearchHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/SearchHandlerTest.java
@@ -17,12 +17,26 @@
 package org.apache.solr.handler.component;
 
 import java.io.IOException;
+import java.rmi.Remote;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queries.spans.SpanTermQuery;
+import org.apache.lucene.queryparser.xml.QueryBuilderFactory;
+import org.apache.lucene.queryparser.xml.builders.BooleanQueryBuilder;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.TermInSetQuery;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.util.BytesRef;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.client.solrj.impl.BaseHttpSolrClient;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
@@ -30,6 +44,7 @@ import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.cloud.MiniSolrCloudCluster;
 import org.apache.solr.cloud.SolrCloudTestCase;
+import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.params.ModifiableSolrParams;
@@ -280,6 +295,69 @@ public class SearchHandlerTest extends SolrTestCaseJ4 {
       miniCluster.shutdown();
       unIgnoreException("no active servers hosting shard:");
       unIgnoreException("ZooKeeper is not connected");
+    }
+  }
+
+  @Test
+  public void testLuceneIOExceptionHandling() throws Exception {
+    MiniSolrCloudCluster miniCluster =
+            new MiniSolrCloudCluster(1, createTempDir(), buildJettyConfig("/solr"));
+
+    final CloudSolrClient cloudSolrClient = miniCluster.getSolrClient();
+
+    try {
+      assertNotNull(miniCluster.getZkServer());
+      List<JettySolrRunner> jettys = miniCluster.getJettySolrRunners();
+      assertEquals(1, jettys.size());
+      for (JettySolrRunner jetty : jettys) {
+        assertTrue(jetty.isRunning());
+      }
+
+      // create collection
+      String collectionName = "testLuceneIOExceptionHandling";
+      String configName = collectionName + "Config";
+      miniCluster.uploadConfigSet(
+              SolrTestCaseJ4.TEST_PATH().resolve("collection1/conf"), configName);
+
+      CollectionAdminRequest.createCollection(collectionName, configName, 2, 1)
+              .setPerReplicaState(SolrCloudTestCase.USE_PER_REPLICA_STATE)
+              .process(miniCluster.getSolrClient());
+
+      for (int i = 0; i < 5; i++) {
+        SolrInputDocument doc = new SolrInputDocument();
+        doc.addField("id", i);
+        doc.addField("title", "test" + i);
+        cloudSolrClient.add(collectionName, doc);
+      }
+      cloudSolrClient.commit(collectionName);
+
+      Collection<BytesRef> terms = new ArrayList<>();
+      for (int i = 0; i < 2000; i++) {
+        terms.add(newBytesRef("term" + i));
+      }
+      TermInSetQuery termInSetQuery = new TermInSetQuery("name", terms);
+      SolrQuery solrQuery = new SolrQuery(termInSetQuery.toString());
+      QueryRequest req = new QueryRequest(solrQuery);
+      req.setMethod(SolrRequest.METHOD.POST);
+      try {
+        req.process(cloudSolrClient, collectionName);
+      } catch (BaseHttpSolrClient.RemoteSolrException e) {
+        assertEquals(400, e.code());
+        assertTrue(e.getMessage().contains("org.apache.solr.search.SyntaxError"));
+      }
+
+      solrQuery = new SolrQuery("{!surround maxBasicQueries=1 df=title}99W(test1,test2,test3)");
+      req = new QueryRequest(solrQuery);
+      req.setMethod(SolrRequest.METHOD.POST);
+      try {
+        req.process(cloudSolrClient, collectionName);
+        fail("expected an exception for this request");
+      } catch (BaseHttpSolrClient.RemoteSolrException e) {
+        assertEquals(400, e.code());
+        assertTrue(e.getMessage().contains("Exceeded maximum of 1 basic queries."));
+      }
+    } finally {
+      miniCluster.shutdown();
     }
   }
 

--- a/solr/core/src/test/org/apache/solr/handler/component/SearchHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/SearchHandlerTest.java
@@ -291,6 +291,7 @@ public class SearchHandlerTest extends SolrTestCaseJ4 {
 
   @Test
   public void testLuceneIOExceptionHandling() throws Exception {
+    String initialMaxBooleanClauses = System.getProperty("solr.max.booleanClauses");
     System.setProperty("solr.max.booleanClauses", String.valueOf(1));
     MiniSolrCloudCluster miniCluster =
         new MiniSolrCloudCluster(1, createTempDir(), buildJettyConfig("/solr"));
@@ -360,7 +361,11 @@ public class SearchHandlerTest extends SolrTestCaseJ4 {
           e.getMessage()
               .contains("Query contains too many nested clauses; maxClauseCount is set to 1"));
     } finally {
-      System.clearProperty("solr.max.booleanClauses");
+      if (initialMaxBooleanClauses != null) {
+        System.setProperty("solr.max.booleanClauses", initialMaxBooleanClauses);
+      } else {
+        System.clearProperty("solr.max.booleanClauses");
+      }
       miniCluster.shutdown();
     }
   }

--- a/solr/core/src/test/org/apache/solr/handler/component/SearchHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/SearchHandlerTest.java
@@ -17,20 +17,11 @@
 package org.apache.solr.handler.component;
 
 import java.io.IOException;
-import java.rmi.Remote;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-
-import org.apache.lucene.index.Term;
-import org.apache.lucene.queries.spans.SpanTermQuery;
-import org.apache.lucene.queryparser.xml.QueryBuilderFactory;
-import org.apache.lucene.queryparser.xml.builders.BooleanQueryBuilder;
-import org.apache.lucene.search.BooleanClause;
-import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.TermInSetQuery;
-import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.util.BytesRef;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.SolrClient;
@@ -302,7 +293,7 @@ public class SearchHandlerTest extends SolrTestCaseJ4 {
   public void testLuceneIOExceptionHandling() throws Exception {
     System.setProperty("solr.max.booleanClauses", String.valueOf(1));
     MiniSolrCloudCluster miniCluster =
-            new MiniSolrCloudCluster(1, createTempDir(), buildJettyConfig("/solr"));
+        new MiniSolrCloudCluster(1, createTempDir(), buildJettyConfig("/solr"));
 
     final CloudSolrClient cloudSolrClient = miniCluster.getSolrClient();
 
@@ -318,11 +309,11 @@ public class SearchHandlerTest extends SolrTestCaseJ4 {
       String collectionName = "testLuceneIOExceptionHandling";
       String configName = collectionName + "Config";
       miniCluster.uploadConfigSet(
-              SolrTestCaseJ4.TEST_PATH().resolve("collection1/conf"), configName);
+          SolrTestCaseJ4.TEST_PATH().resolve("collection1/conf"), configName);
 
       CollectionAdminRequest.createCollection(collectionName, configName, 2, 1)
-              .setPerReplicaState(SolrCloudTestCase.USE_PER_REPLICA_STATE)
-              .process(miniCluster.getSolrClient());
+          .setPerReplicaState(SolrCloudTestCase.USE_PER_REPLICA_STATE)
+          .process(miniCluster.getSolrClient());
 
       for (int i = 0; i < 5; i++) {
         SolrInputDocument doc = new SolrInputDocument();
@@ -366,7 +357,9 @@ public class SearchHandlerTest extends SolrTestCaseJ4 {
         fail("expected an exception for this request");
       } catch (BaseHttpSolrClient.RemoteSolrException e) {
         assertEquals(400, e.code());
-        assertTrue(e.getMessage().contains("Query contains too many nested clauses; maxClauseCount is set to 1"));
+        assertTrue(
+            e.getMessage()
+                .contains("Query contains too many nested clauses; maxClauseCount is set to 1"));
       }
     } finally {
       System.clearProperty("solr.max.booleanClauses");

--- a/solr/core/src/test/org/apache/solr/handler/component/SearchHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/SearchHandlerTest.java
@@ -334,9 +334,7 @@ public class SearchHandlerTest extends SolrTestCaseJ4 {
       BaseHttpSolrClient.RemoteSolrException e =
           assertThrows(
               BaseHttpSolrClient.RemoteSolrException.class,
-              () -> {
-                req.process(cloudSolrClient, collectionName);
-              });
+              () -> req.process(cloudSolrClient, collectionName));
       assertEquals(400, e.code());
       assertTrue(e.getMessage().contains("org.apache.solr.search.SyntaxError"));
 
@@ -346,9 +344,7 @@ public class SearchHandlerTest extends SolrTestCaseJ4 {
       e =
           assertThrows(
               BaseHttpSolrClient.RemoteSolrException.class,
-              () -> {
-                req2.process(cloudSolrClient, collectionName);
-              });
+              () -> req2.process(cloudSolrClient, collectionName));
       assertEquals(400, e.code());
       assertTrue(e.getMessage().contains("Exceeded maximum of 1 basic queries."));
 
@@ -358,9 +354,7 @@ public class SearchHandlerTest extends SolrTestCaseJ4 {
       e =
           assertThrows(
               BaseHttpSolrClient.RemoteSolrException.class,
-              () -> {
-                req3.process(cloudSolrClient, collectionName);
-              });
+              () -> req3.process(cloudSolrClient, collectionName));
       assertEquals(400, e.code());
       assertTrue(
           e.getMessage()

--- a/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
@@ -104,6 +104,7 @@ public class MiniSolrCloudCluster {
       "<solr>\n"
           + "\n"
           + "  <str name=\"shareSchema\">${shareSchema:false}</str>\n"
+           + " <int name=\"maxBooleanClauses\">${solr.max.booleanClauses:1024}</int>\n"
           + "  <str name=\"allowPaths\">${solr.allowPaths:}</str>\n"
           + "  <str name=\"configSetBaseDir\">${configSetBaseDir:configsets}</str>\n"
           + "  <str name=\"coreRootDirectory\">${coreRootDirectory:.}</str>\n"

--- a/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
@@ -104,7 +104,7 @@ public class MiniSolrCloudCluster {
       "<solr>\n"
           + "\n"
           + "  <str name=\"shareSchema\">${shareSchema:false}</str>\n"
-          + " <int name=\"maxBooleanClauses\">${solr.max.booleanClauses:1024}</int>\n"
+          + "  <int name=\"maxBooleanClauses\">${solr.max.booleanClauses:1024}</int>\n"
           + "  <str name=\"allowPaths\">${solr.allowPaths:}</str>\n"
           + "  <str name=\"configSetBaseDir\">${configSetBaseDir:configsets}</str>\n"
           + "  <str name=\"coreRootDirectory\">${coreRootDirectory:.}</str>\n"

--- a/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
+++ b/solr/test-framework/src/java/org/apache/solr/cloud/MiniSolrCloudCluster.java
@@ -104,7 +104,7 @@ public class MiniSolrCloudCluster {
       "<solr>\n"
           + "\n"
           + "  <str name=\"shareSchema\">${shareSchema:false}</str>\n"
-           + " <int name=\"maxBooleanClauses\">${solr.max.booleanClauses:1024}</int>\n"
+          + " <int name=\"maxBooleanClauses\">${solr.max.booleanClauses:1024}</int>\n"
           + "  <str name=\"allowPaths\">${solr.allowPaths:}</str>\n"
           + "  <str name=\"configSetBaseDir\">${configSetBaseDir:configsets}</str>\n"
           + "  <str name=\"coreRootDirectory\">${coreRootDirectory:.}</str>\n"


### PR DESCRIPTION
These exceptions for non-distributed requests seem to be exclusively issues with invalid queries, such as Surround queries that exceed the max number of basic queries.

https://github.com/cowpaths/lucene/blob/2cbf261032dc8aca56c846971c090c991ac594a6/lucene/queryparser/src/java/org/apache/lucene/queryparser/surround/query/TooManyBasicQueries.java
