### PR TITLE
an alternate approach to fixing tlog dir handling

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -224,7 +224,6 @@ public class SolrCore implements SolrInfoBean, Closeable {
   private volatile IndexSchema schema;
   private final NamedList<?> configSetProperties;
   private final String dataDir;
-  private final String ulogDir;
   private final UpdateHandler updateHandler;
   private final SolrCoreState solrCoreState;
 
@@ -393,10 +392,6 @@ public class SolrCore implements SolrInfoBean, Closeable {
 
   public String getDataDir() {
     return dataDir;
-  }
-
-  public String getUlogDir() {
-    return ulogDir;
   }
 
   public String getIndexDir() {
@@ -1105,7 +1100,6 @@ public class SolrCore implements SolrInfoBean, Closeable {
       }
 
       this.dataDir = initDataDir(dataDir, solrConfig, coreDescriptor);
-      this.ulogDir = initUpdateLogDir(coreDescriptor);
 
       if (log.isInfoEnabled()) {
         log.info("Opening new SolrCore at [{}], dataDir=[{}]", getInstancePath(), this.dataDir);
@@ -1551,14 +1545,6 @@ public class SolrCore implements SolrInfoBean, Closeable {
     } finally {
       IOUtils.closeQuietly(os);
     }
-  }
-
-  private String initUpdateLogDir(CoreDescriptor coreDescriptor) {
-    String updateLogDir = coreDescriptor.getUlogDir();
-    if (updateLogDir == null) {
-      updateLogDir = coreDescriptor.getInstanceDir().resolve(dataDir).toString();
-    }
-    return updateLogDir;
   }
 
   /**

--- a/solr/core/src/test/org/apache/solr/cloud/TestCloudRecovery.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestCloudRecovery.java
@@ -188,7 +188,7 @@ public class TestCloudRecovery extends SolrCloudTestCase {
     Map<String, byte[]> contentFiles = new HashMap<>();
     for (JettySolrRunner solrRunner : cluster.getJettySolrRunners()) {
       for (SolrCore solrCore : solrRunner.getCoreContainer().getCores()) {
-        File tlogFolder = new File(solrCore.getUlogDir(), UpdateLog.TLOG_NAME);
+        File tlogFolder = new File(solrCore.getUpdateHandler().getUpdateLog().getLogDir());
         String[] tLogFiles = tlogFolder.list();
         Arrays.sort(tLogFiles);
         String lastTLogFile = tlogFolder.getAbsolutePath() + "/" + tLogFiles[tLogFiles.length - 1];

--- a/solr/core/src/test/org/apache/solr/cloud/TestPullReplica.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestPullReplica.java
@@ -17,6 +17,7 @@
 package org.apache.solr.cloud;
 
 import com.carrotsearch.randomizedtesting.annotations.Repeat;
+import java.io.File;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
@@ -52,8 +53,10 @@ import org.apache.solr.common.cloud.Replica;
 import org.apache.solr.common.cloud.Slice;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.util.TimeSource;
+import org.apache.solr.core.CoreDescriptor;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.embedded.JettySolrRunner;
+import org.apache.solr.update.UpdateLog;
 import org.apache.solr.util.LogLevel;
 import org.apache.solr.util.TestInjection;
 import org.apache.solr.util.TimeOut;
@@ -221,6 +224,27 @@ public class TestPullReplica extends SolrCloudTestCase {
   }
 
   /**
+   * For some tests (when we want to check for <i>absence</i> of tlog dir), we need a standin for
+   * the common case where <code>core.getUpdateHandler().getUpdateLog() == null</code>. This method
+   * returns the actual tlog dir an {@link UpdateLog} is configured on the core's {@link
+   * org.apache.solr.update.UpdateHandler}; otherwise, falls back to the legacy behavior: if {@link
+   * CoreDescriptor#getUlogDir()} is specified, returns the <code>tlog</code> subdirectory of that;
+   * otherwise returns the <code>tlog</code> subdirectory within {@link SolrCore#getDataDir()}.
+   * (NOTE: the last of these is by far the most common default location of the tlog directory).
+   */
+  static File getHypotheticalTlogDir(SolrCore core) {
+    String tlogDir;
+    UpdateLog ulog = core.getUpdateHandler().getUpdateLog();
+    if (ulog != null) {
+      return new File(ulog.getLogDir());
+    } else if ((tlogDir = core.getCoreDescriptor().getUlogDir()) != null) {
+      return new File(tlogDir, UpdateLog.TLOG_NAME);
+    } else {
+      return new File(core.getDataDir(), UpdateLog.TLOG_NAME);
+    }
+  }
+
+  /**
    * Asserts that Update logs don't exist for replicas of type {@link
    * org.apache.solr.common.cloud.Replica.Type#PULL}
    */
@@ -233,10 +257,11 @@ public class TestPullReplica extends SolrCloudTestCase {
         try (SolrCore core =
             cluster.getReplicaJetty(r).getCoreContainer().getCore(r.getCoreName())) {
           assertNotNull(core);
+          File tlogDir = getHypotheticalTlogDir(core);
           assertFalse(
               "Update log should not exist for replicas of type Passive but file is present: "
-                  + core.getUlogDir(),
-              new java.io.File(core.getUlogDir()).exists());
+                  + tlogDir,
+              tlogDir.exists());
         }
       }
     }

--- a/solr/core/src/test/org/apache/solr/cloud/TestTlogReplica.java
+++ b/solr/core/src/test/org/apache/solr/cloud/TestTlogReplica.java
@@ -16,8 +16,11 @@
  */
 package org.apache.solr.cloud;
 
+import static org.apache.solr.cloud.TestPullReplica.getHypotheticalTlogDir;
+
 import com.carrotsearch.randomizedtesting.annotations.Repeat;
 import com.codahale.metrics.Meter;
+import java.io.File;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
@@ -142,9 +145,8 @@ public class TestTlogReplica extends SolrCloudTestCase {
         try {
           core = cluster.getReplicaJetty(r).getCoreContainer().getCore(r.getCoreName());
           assertNotNull(core);
-          assertTrue(
-              "Update log should exist for replicas of type Append",
-              new java.io.File(core.getUlogDir()).exists());
+          File tlogDir = getHypotheticalTlogDir(core);
+          assertTrue("Update log should exist for replicas of type Append", tlogDir.exists());
         } finally {
           core.close();
         }

--- a/solr/core/src/test/org/apache/solr/update/CustomTLogDirTest.java
+++ b/solr/core/src/test/org/apache/solr/update/CustomTLogDirTest.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.update;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.lucene.tests.mockfile.FilterPath;
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
+import org.apache.solr.util.EmbeddedSolrServerTestRule;
+import org.apache.solr.util.SolrClientTestRule;
+import org.junit.ClassRule;
+
+public class CustomTLogDirTest extends SolrTestCaseJ4 {
+
+  @ClassRule
+  public static final SolrClientTestRule solrClientTestRule =
+      new EmbeddedSolrServerTestRule() {
+        @Override
+        protected void before() {
+          solrClientTestRule.startSolr(LuceneTestCase.createTempDir());
+        }
+      };
+
+  private static final AtomicInteger collectionIdx = new AtomicInteger();
+
+  public void testExternal() throws Exception {
+    String collectionName = "coll" + collectionIdx.getAndIncrement();
+    SolrClient client = solrClientTestRule.getSolrClient(collectionName);
+
+    Path coreRootDir = ((EmbeddedSolrServer) client).getCoreContainer().getCoreRootDirectory();
+
+    Path instanceDir = FilterPath.unwrap(coreRootDir.resolve(collectionName));
+
+    Path ulogDir = LuceneTestCase.createTempDir();
+    // absolute path spec that falls outside of the instance and data dirs for the
+    // associated core, is assumed to already by namespaced by purpose (tlog). We
+    // expect it to be further namespaced by core name.
+    Path resolvedTlogDir = ulogDir.resolve(collectionName);
+    validateTlogPath(client, instanceDir, ulogDir, resolvedTlogDir);
+  }
+
+  public void testRelative() throws Exception {
+    String collectionName = "coll" + collectionIdx.getAndIncrement();
+    SolrClient client = solrClientTestRule.getSolrClient(collectionName);
+
+    Path coreRootDir = ((EmbeddedSolrServer) client).getCoreContainer().getCoreRootDirectory();
+
+    Path instanceDir = FilterPath.unwrap(coreRootDir.resolve(collectionName));
+
+    Path ulogDir = Path.of("relativeUlogDir");
+    // relative dir path spec is taken to be relative to instance dir, so we expect it
+    // to be namespaced by purpose within the core.
+    Path resolvedTlogDir = instanceDir.resolve(ulogDir).resolve("tlog");
+    validateTlogPath(client, instanceDir, ulogDir, resolvedTlogDir);
+  }
+
+  public void testIllegalRelative() throws Exception {
+    Path ulogDir = Path.of("../");
+
+    Path configSet = LuceneTestCase.createTempDir();
+    System.setProperty("solr.test.sys.prop2", "proptwo");
+    System.setProperty("solr.ulog.dir", ulogDir.toString()); // picked up from `solrconfig.xml`
+    SolrTestCaseJ4.copyMinConf(configSet.toFile(), null, "solrconfig.xml");
+
+    // relative dir path specs should not be able to "escape" the core-scoped instance dir;
+    // check that this config is unsuccessful
+    expectThrows(
+        Exception.class,
+        () ->
+            solrClientTestRule
+                .newCollection("illegal")
+                .withConfigSet(configSet.toString())
+                .create());
+  }
+
+  public void testAbsoluteSubdir() throws Exception {
+    String collectionName = "coll" + collectionIdx.getAndIncrement();
+    SolrClient client = solrClientTestRule.getSolrClient(collectionName);
+
+    Path coreRootDir = ((EmbeddedSolrServer) client).getCoreContainer().getCoreRootDirectory();
+
+    Path instanceDir = FilterPath.unwrap(coreRootDir.resolve(collectionName));
+
+    Path ulogDir = instanceDir.resolve("absoluteUlogDir");
+    // an absolute dir path spec, if it is contained within the instance dir, is taken
+    // to already be namespaced to the core. We expect the tlog dir to be namespaced by
+    // purpose (tlog) within core, just as is the case with relative path spec.
+    Path resolvedTlogDir = ulogDir.resolve("tlog");
+    validateTlogPath(client, instanceDir, ulogDir, resolvedTlogDir);
+  }
+
+  public void testDefault() throws Exception {
+    String collectionName = "coll" + collectionIdx.getAndIncrement();
+    SolrClient client = solrClientTestRule.getSolrClient(collectionName);
+
+    Path coreRootDir = ((EmbeddedSolrServer) client).getCoreContainer().getCoreRootDirectory();
+
+    Path instanceDir = FilterPath.unwrap(coreRootDir.resolve(collectionName));
+
+    // whether the normal default ulog dir spec `[instanceDir]/data` is configured
+    // implicitly or explicitly, we expect to find the tlog in the same place:
+    Path resolvedTlogDir = instanceDir.resolve("data/tlog");
+    validateTlogPath(client, instanceDir, null, resolvedTlogDir);
+  }
+
+  public void testExplicitDefault() throws Exception {
+    String collectionName = "coll" + collectionIdx.getAndIncrement();
+    SolrClient client = solrClientTestRule.getSolrClient(collectionName);
+
+    Path coreRootDir = ((EmbeddedSolrServer) client).getCoreContainer().getCoreRootDirectory();
+
+    Path instanceDir = FilterPath.unwrap(coreRootDir.resolve(collectionName));
+
+    Path ulogDir = instanceDir.resolve("data");
+    // whether the normal default ulog dir spec `[instanceDir]/data` is configured
+    // implicitly or explicitly, we expect to find the tlog in the same place:
+    Path resolvedTlogDir = instanceDir.resolve("data/tlog");
+    validateTlogPath(client, instanceDir, ulogDir, resolvedTlogDir);
+  }
+
+  private static void validateTlogPath(
+      SolrClient client, Path instanceDir, Path ulogDir, Path resolvedTlogDir) throws Exception {
+    Path configSet = LuceneTestCase.createTempDir();
+    System.setProperty("solr.test.sys.prop2", "proptwo");
+    if (ulogDir != null) {
+      System.setProperty("solr.ulog.dir", ulogDir.toString()); // picked up from `solrconfig.xml`
+    }
+    SolrTestCaseJ4.copyMinConf(configSet.toFile(), null, "solrconfig.xml");
+
+    String collectionName = instanceDir.getFileName().toString();
+
+    solrClientTestRule.newCollection(collectionName).withConfigSet(configSet.toString()).create();
+
+    // resolvedTlogDir = instanceDir.resolve("data/tlog"); // legacy impl _always_ resulted in this
+
+    // add some docs to populate tlog
+    client.add(sdoc("id", "1"));
+    client.add(sdoc("id", "2"));
+    client.add(sdoc("id", "3"));
+    client.commit();
+
+    File[] list =
+        resolvedTlogDir.toFile().listFiles((f) -> f.isFile() && f.getName().startsWith("tlog."));
+
+    assertNotNull(list);
+    assertEquals(1, list.length);
+  }
+}


### PR DESCRIPTION
This presents an alternative fix to that proposed in #130. I think I've tracked this bug down to a series of commits between 2012-2015, which corrupted the initial intended behavior. This PR attempts to restore the original intent.

No tests yet, but this really needs tests.