### PR TITLE
indentation test fix

### DIFF
--- a/solr/core/src/test/org/apache/solr/jersey/PostRequestLoggingFilterTest.java
+++ b/solr/core/src/test/org/apache/solr/jersey/PostRequestLoggingFilterTest.java
@@ -132,7 +132,7 @@ public class PostRequestLoggingFilterTest extends SolrTestCaseJ4 {
     final var requestBodyStr = PostRequestLoggingFilter.buildRequestBodyString(mockContext);
 
     assertEquals(
-        "{  \"name\":\"someReplicaName\",  \"type\":\"NRT\",  \"async\":\"someAsyncId\"}",
+        "{\"name\":\"someReplicaName\",\"type\":\"NRT\",\"async\":\"someAsyncId\"}",
         requestBodyStr);
   }
 }


### PR DESCRIPTION
This is a followup to #131, I think? Test fails reliably; e.g.:
```
gradlew :solr:core:test --tests "org.apache.solr.jersey.PostRequestLoggingFilterTest.testRequestBodyRepresentedAsJsonWhenFound" -Ptests.jvms=5 "-Ptests.jvmargs=-XX:TieredStopAtLevel=1 -XX:+UseParallelGC -XX:ActiveProcessorCount=1 -XX:ReservedCodeCacheSize=120m" -Ptests.seed=3607EC61D430207E -Ptests.file.encoding=US-ASCII
```