### PR TITLE
Handling BAD_REQUEST exceptions as failures even with shard.tolerant as true

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -27,6 +27,7 @@ import java.io.StringWriter;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -38,7 +39,6 @@ import java.util.Spliterators;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.StreamSupport;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.lucene.index.ExitableDirectoryReader;
 import org.apache.lucene.queryparser.surround.query.TooManyBasicQueries;
 import org.apache.lucene.search.IndexSearcher;
@@ -93,8 +93,8 @@ public class SearchHandler extends RequestHandlerBase
 
   protected static final String SHARD_HANDLER_SUFFIX = "[shard]";
 
-  private static final SolrException.ErrorCode[] NONTOLERANT_ERROR_CODES =
-      new SolrException.ErrorCode[] {SolrException.ErrorCode.BAD_REQUEST};
+  private static final Collection<SolrException.ErrorCode> NONTOLERANT_ERROR_CODES =
+      List.of(SolrException.ErrorCode.BAD_REQUEST);
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
@@ -577,8 +577,7 @@ public class SearchHandler extends RequestHandlerBase
               log.warn("Shard request failed : {}", srsp);
               // If things are not tolerant, abort everything and rethrow
               if (!tolerant
-                  || ArrayUtils.contains(
-                      NONTOLERANT_ERROR_CODES,
+                  || NONTOLERANT_ERROR_CODES.contains(
                       SolrException.ErrorCode.getErrorCode(srsp.getRspCode()))) {
                 shardHandler1.cancelAll();
                 if (srsp.getException() instanceof SolrException) {

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -27,7 +27,6 @@ import java.io.StringWriter;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -93,8 +92,8 @@ public class SearchHandler extends RequestHandlerBase
 
   protected static final String SHARD_HANDLER_SUFFIX = "[shard]";
 
-  private static final Collection<SolrException.ErrorCode> NONTOLERANT_ERROR_CODES =
-      List.of(SolrException.ErrorCode.BAD_REQUEST);
+  private static final Set<SolrException.ErrorCode> NONTOLERANT_ERROR_CODES =
+      Set.of(SolrException.ErrorCode.BAD_REQUEST);
 
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/solr/core/src/java/org/apache/solr/handler/component/ShardResponse.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/ShardResponse.java
@@ -81,6 +81,10 @@ public final class ShardResponse {
     this.rspCode = rspCode;
   }
 
+  public int getRspCode() {
+    return rspCode;
+  }
+
   void setNodeName(String nodeName) {
     this.nodeName = nodeName;
   }

--- a/solr/core/src/test/org/apache/solr/handler/component/SearchHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/SearchHandlerTest.java
@@ -360,6 +360,19 @@ public class SearchHandlerTest extends SolrTestCaseJ4 {
       assertTrue(
           e.getMessage()
               .contains("Query contains too many nested clauses; maxClauseCount is set to 1"));
+
+      solrQuery = new SolrQuery("{!surround maxBasicQueries=1000 df=title}10W(tes*,test*)");
+      solrQuery.add(ShardParams.SHARDS_TOLERANT, "true");
+      final QueryRequest req4 = new QueryRequest(solrQuery);
+      req4.setMethod(SolrRequest.METHOD.POST);
+      e =
+          assertThrows(
+              BaseHttpSolrClient.RemoteSolrException.class,
+              () -> req4.process(cloudSolrClient, collectionName));
+      assertEquals(400, e.code());
+      assertTrue(
+          e.getMessage()
+              .contains("Query contains too many nested clauses; maxClauseCount is set to 1"));
     } finally {
       if (initialMaxBooleanClauses != null) {
         System.setProperty("solr.max.booleanClauses", initialMaxBooleanClauses);


### PR DESCRIPTION
This will ensure that distributed requests are considered failing requests if any shard fails with a BAD_REQUEST (400) error indicating that that request is not something that can just succeed on retry.