### PR TITLE
SAI-4635 : Log refCount and core name if refCount of SolrCore is > 1 after SolrDispatchFilter finishes processing

### DIFF
--- a/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
@@ -49,6 +49,7 @@ import org.apache.solr.common.util.ExecutorUtil;
 import org.apache.solr.common.util.SuppressForbidden;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.NodeRoles;
+import org.apache.solr.core.SolrCore;
 import org.apache.solr.handler.api.V2ApiUtils;
 import org.apache.solr.logging.MDCLoggingContext;
 import org.apache.solr.logging.MDCSnapshot;
@@ -275,6 +276,18 @@ public class SolrDispatchFilter extends BaseSolrFilter implements PathExcluder {
       }
     } finally {
       call.destroy();
+      SolrCore core = call.getCore();
+      if (core != null) {
+        int coreRefCount = core.getOpenCount();
+        if (coreRefCount > 1) {
+          if (log.isInfoEnabled())
+            log.info(
+                "Core {} has ref count of {} . It's still used by other logic even if the current servlet request {} finishes",
+                core.getName(),
+                coreRefCount,
+                call.getReq().getServletPath());
+        }
+      }
       ExecutorUtil.setServerThreadFlag(null);
     }
   }


### PR DESCRIPTION
## Description
This is a follow-up on https://fullstory.atlassian.net/browse/SAI-4635 investigation which the source core failed to unload after a solrman move.

This is triggered by the `RefCount` of the `SolrCore` got stuck at > 1, hence preventing the unload. By code inspection, we could not find any trivial cause of such a "leak". However, this could also be caused by hanging core specific calls that holds such ref.

## Solution
We currently only know such `RefCount` issue when we attempt to unload such core, hence it's hard to track when did that start happening.

Therefore we are adding some simple logging when upon SolrDispatcherFilter completion, the `refCount` still gets stuck at > 1. Take note that some occurrences of that does not necessarily indicate an issue (a long running query CAN hold such refcount for a while etc), however when unload failures happen, we can then at least track back **WHEN** did we started having a continuously elevated ref count and hopefully find out the actual cause of such issue from the log.

Additionally, we have considered just printing the same debug info on each core specific request start. However, this could be a bit too noisy for such an issue with rare occurrence. (twice in last few months https://fullstory.atlassian.net/browse/SAI-4635 and https://fullstory.atlassian.net/browse/SAI-4454