### PR TITLE
SAI-4604 : Add proper metrics around distributed request delay / http2 client bandwidth

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
@@ -18,6 +18,7 @@ package org.apache.solr.handler.component;
 
 import static org.apache.solr.util.stats.InstrumentedHttpListenerFactory.KNOWN_METRIC_NAME_STRATEGIES;
 
+import com.codahale.metrics.Meter;
 import java.lang.invoke.MethodHandles;
 import java.util.Iterator;
 import java.util.List;
@@ -94,6 +95,8 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory
   private SolrMetricsContext solrMetricsContext;
 
   private String scheme = null;
+
+  private Meter delayedRequests;
 
   private InstrumentedHttpListenerFactory.NameStrategy metricNameStrategy;
 
@@ -287,7 +290,13 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory
             .withMaxConnectionsPerHost(maxConnectionsPerHost)
             .build();
     this.defaultClient.addListenerFactory(this.httpListenerFactory);
-    this.loadbalancer = new LBHttp2SolrClient.Builder(defaultClient).build();
+    this.loadbalancer =
+        new LBHttp2SolrClient.Builder(defaultClient)
+            .setDelayedRequestListener(
+                n -> {
+                  if (delayedRequests != null) delayedRequests.mark(n);
+                })
+            .build();
 
     initReplicaListTransformers(getParameter(args, "replicaRouting", null, sb));
 
@@ -410,6 +419,7 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory
   public void initializeMetrics(SolrMetricsContext parentContext, String scope) {
     solrMetricsContext = parentContext.getChildContext(this);
     String expandedScope = SolrMetricManager.mkName(scope, SolrInfoBean.Category.QUERY.name());
+    delayedRequests = solrMetricsContext.meter("delayedInterNodeRequests", expandedScope);
     httpListenerFactory.initializeMetrics(solrMetricsContext, expandedScope);
     commExecutor =
         MetricUtils.instrumentedExecutorService(

--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
@@ -19,7 +19,6 @@ package org.apache.solr.handler.component;
 import static org.apache.solr.util.stats.InstrumentedHttpListenerFactory.KNOWN_METRIC_NAME_STRATEGIES;
 
 import com.codahale.metrics.Histogram;
-import com.codahale.metrics.Meter;
 import java.lang.invoke.MethodHandles;
 import java.util.Iterator;
 import java.util.List;

--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
@@ -300,7 +300,7 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory
                   if (it > DELAY_WARN_THRESHOLD) {
                     long millis = TimeUnit.MILLISECONDS.convert(it, TimeUnit.NANOSECONDS);
                     log.info("Remote shard request delayed by {} milliseconds", millis);
-                    if(delayedRequests != null) {
+                    if (delayedRequests != null) {
                       delayedRequests.update(millis);
                     }
                   }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/LBHttp2SolrClient.java
@@ -91,7 +91,7 @@ public class LBHttp2SolrClient extends LBSolrClient {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private final Http2SolrClient solrClient;
 
-  private final LongConsumer delayedRequestlistener;
+  private final LongConsumer delayedRequestListener;
 
   /**
    * @deprecated Use {@link LBHttp2SolrClient.Builder} instead
@@ -100,14 +100,14 @@ public class LBHttp2SolrClient extends LBSolrClient {
   public LBHttp2SolrClient(Http2SolrClient solrClient, String... baseSolrUrls) {
     super(Arrays.asList(baseSolrUrls));
     this.solrClient = solrClient;
-    this.delayedRequestlistener = null;
+    this.delayedRequestListener = null;
   }
 
   private LBHttp2SolrClient(
-      Http2SolrClient solrClient, List<String> baseSolrUrls, LongConsumer delayedRequestlistener) {
+      Http2SolrClient solrClient, List<String> baseSolrUrls, LongConsumer delayedRequestListener) {
     super(baseSolrUrls);
     this.solrClient = solrClient;
-    this.delayedRequestlistener = delayedRequestlistener;
+    this.delayedRequestListener = delayedRequestListener;
   }
 
   @Override
@@ -284,8 +284,8 @@ public class LBHttp2SolrClient extends LBSolrClient {
                   long delay = TimeUnit.MILLISECONDS.convert(delayed, TimeUnit.NANOSECONDS);
                   log.info(
                       "Remote shard request to {} delayed by {} milliseconds", req.servers, delay);
-                  if (delayedRequestlistener != null) {
-                    delayedRequestlistener.accept(delay);
+                  if (delayedRequestListener != null) {
+                    delayedRequestListener.accept(delay);
                   }
                 }
                 AsyncListener.super.onStart();
@@ -360,8 +360,8 @@ public class LBHttp2SolrClient extends LBSolrClient {
       this.baseSolrUrls = baseSolrUrls;
     }
 
-    public Builder setDelayedRequestListener(LongConsumer delayedRequestListener) {
-      this.delayedRequestListener = delayedRequestListener;
+    public Builder setDelayedRequestListener(LongConsumer listener) {
+      this.delayedRequestListener = listener;
       return this;
     }
 


### PR DESCRIPTION

The new metric for delayed requests added to path `[metrics].[solr.node].[QUERY.httpShardHandler.delayedInterNodeRequests]`
looks as follows
```
  "QUERY.httpShardHandler.delayedInterNodeRequests":{
"count":0,
"min":0.0,
"max":0.0,
"mean":0.0,
"median":0.0,
"stddev":0.0,
"p75":0.0,
"p95":0.0,
"p99":0.0,
"p999":0.0},
```