### PR TITLE
Ignore node exists exception

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/ZkController.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ZkController.java
@@ -1255,7 +1255,11 @@ public class ZkController implements Closeable {
                     zkClient.getZkACLProvider().getACLsToAdd(nodePath),
                     CreateMode.EPHEMERAL)));
 
-    zkClient.multi(ops, true);
+    try {
+      zkClient.multi(ops, true);
+    } catch (KeeperException.NodeExistsException e) {
+      //Ignore if the node is already created. this is OK
+    }
   }
 
   public void removeEphemeralLiveNode() throws KeeperException, InterruptedException {

--- a/solr/core/src/java/org/apache/solr/cloud/ZkController.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ZkController.java
@@ -1237,28 +1237,23 @@ public class ZkController implements Closeable {
     String nodePath = ZkStateReader.LIVE_NODES_ZKNODE + "/" + nodeName;
     log.info("Register node as live in ZooKeeper:{}", nodePath);
     Map<NodeRoles.Role, String> roles = cc.nodeRoles.getRoles();
-    List<Op> ops = new ArrayList<>(roles.size() + 1);
-    ops.add(
-        Op.create(
-            nodePath,
-            null,
-            zkClient.getZkACLProvider().getACLsToAdd(nodePath),
-            CreateMode.EPHEMERAL));
-
-    // Create the roles node as well
-    roles.forEach(
-        (role, mode) ->
-            ops.add(
-                Op.create(
-                    NodeRoles.getZNodeForRoleMode(role, mode) + "/" + nodeName,
-                    null,
-                    zkClient.getZkACLProvider().getACLsToAdd(nodePath),
-                    CreateMode.EPHEMERAL)));
 
     try {
-      zkClient.multi(ops, true);
+      zkClient.create(nodePath, null, CreateMode.EPHEMERAL, true);
     } catch (KeeperException.NodeExistsException e) {
-      //Ignore if the node is already created. this is OK
+      // ignore , it's already there
+    }
+
+    for (Map.Entry<NodeRoles.Role, String> e : roles.entrySet()) {
+      try {
+        zkClient.create(
+            NodeRoles.getZNodeForRoleMode(e.getKey(), e.getValue()) + "/" + nodeName,
+            null,
+            CreateMode.EPHEMERAL,
+            true);
+      } catch (KeeperException.NodeExistsException ex) {
+        // ignore , it already exists
+      }
     }
   }
 


### PR DESCRIPTION
On solr node startup, it tries to write roles on ZK. Looks like there is possibility that zk already have those roles for that node. if that’s the case then it should ignore node exists exception and continue.

This exception we got 
```
org.apache.zookeeper.KeeperException$NodeExistsException: KeeperErrorCode = NodeExists
        at org.apache.zookeeper.KeeperException.create(KeeperException.java:126) ~[zookeeper-3.8.1.jar:3.8.1]
        at org.apache.zookeeper.ZooKeeper.multiInternal(ZooKeeper.java:1778) ~[zookeeper-3.8.1.jar:3.8.1]
        at org.apache.zookeeper.ZooKeeper.multi(ZooKeeper.java:1650) ~[zookeeper-3.8.1.jar:3.8.1]
        at org.apache.solr.common.cloud.SolrZkClient.lambda$multi$11(SolrZkClient.java:753) ~[solr-solrj-zookeeper-9.3.0-9c14c39b6f0f081bb46108e04c753db48db24d6e.jar:9.3.0-9c14c39b6f0f081bb46108e04c753db48db24d6e 53ac0aef7984c53f29dfb04e83f4a98403ca5542 - circleci - 2023-10-16 17:23:03]
        at org.apache.solr.common.cloud.ZkCmdExecutor.retryOperation(ZkCmdExecutor.java:72) ~[solr-solrj-zookeeper-9.3.0-9c14c39b6f0f081bb46108e04c753db48db24d6e.jar:9.3.0-9c14c39b6f0f081bb46108e04c753db48db24d6e 53ac0aef7984c53f29dfb04e83f4a98403ca5542 - circleci - 2023-10-16 17:23:03]
        at org.apache.solr.common.cloud.SolrZkClient.multi(SolrZkClient.java:753) ~[solr-solrj-zookeeper-9.3.0-9c14c39b6f0f081bb46108e04c753db48db24d6e.jar:9.3.0-9c14c39b6f0f081bb46108e04c753db48db24d6e 53ac0aef7984c53f29dfb04e83f4a98403ca5542 - circleci - 2023-10-16 17:23:03]
        at org.apache.solr.cloud.ZkController.createEphemeralLiveNode(ZkController.java:1259) ~[solr-core-9.3.0-9c14c39b6f0f081bb46108e04c753db48db24d6e.jar:9.3.0-9c14c39b6f0f081bb46108e04c753db48db24d6e 53ac0aef7984c53f29dfb04e83f4a98403ca5542 - circleci - 2023-10-16 17:23:03]
        at org.apache.solr.cloud.ZkController.init(ZkController.java:1065) [solr-core-9.3.0-9c14c39b6f0f081bb46108e04c753db48db24d6e.jar:9.3.0-9c14c39b6f0f081bb46108e04c753db48db24d6e 53ac0aef7984c53f29dfb04e83f4a98403ca5542 - circleci - 2023-10-16 17:23:03]
        at org.apache.solr.cloud.ZkController.<init>(ZkController.java:430) [solr-core-9.3.0-9c14c39b6f0f081bb46108e04c753db48db24d6e.jar:9.3.0-9c14c39b6f0f081bb46108e04c753db48db24d6e 53ac0aef7984c53f29dfb04e83f4a98403ca5542 - circleci - 2023-10-16 17:23:03]
        at org.apache.solr.core.ZkContainer.initZooKeeper(ZkContainer.java:147) [solr-core-9.3.0-9c14c39b6f0f081bb46108e04c753db48db24d6e.jar:9.3.0-9c14c39b6f0f081bb46108e04c753db48db24d6e 53ac0aef7984c53f29dfb04e83f4a98403ca5542 - circleci - 2023-10-16 17:23:03]
        at org.apache.solr.core.CoreContainer.loadInternal(CoreContainer.java:805) [solr-core-9.3.0-9c14c39b6f0f081bb46108e04c753db48db24d6e.jar:9.3.0-9c14c39b6f0f081bb46108e04c753db48db24d6e 53ac0aef7984c53f29dfb04e83f4a98403ca5542 - circleci - 2023-10-16 17:23:03]
        at org.apache.solr.core.CoreContainer.load(CoreContainer.java:753) [solr-core-9.3.0-9c14c39b6f0f081bb46108e04c753db48db24d6e.jar:9.3.0-9c14c39b6f0f081bb46108e04c753db48db24d6e 53ac0aef7984c53f29dfb04e83f4a98403ca5542 - circleci - 2023-10-16 17:23:03]
        at org.apache.solr.servlet.CoreContainerProvider.createCoreContainer(CoreContainerProvider.java:427) [solr-core-9.3.0-9c14c39b6f0f081bb46108e04c753db48db24d6e.jar:9.3.0-9c14c39b6f0f081bb46108e04c753db48db24d6e 53ac0aef7984c53f29dfb04e83f4a98403ca5542 - circleci - 2023-10-16 17:23:03]
        at org.apache.solr.servlet.CoreContainerProvider.init(CoreContainerProvider.java:246) [solr-core-9.3.0-9c14c39b6f0f081bb46108e04c753db48db24d6e.jar:9.3.0-9c14c39b6f0f081bb46108e04c753db48db24d6e 53ac0aef7984c53f29dfb04e83f4a98403ca5542 - circleci - 2023-10-16 17:23:03]
        at org.apache.solr.servlet.CoreContainerProvider.contextInitialized(CoreContainerProvider.java:116) [solr-core-9.3.0-9c14c39b6f0f081bb46108e04c753db48db24d6e.jar:9.3.0-9c14c39b6f0f081bb46108e04c753db48db24d6e 53ac0aef7984c53f29dfb04e83f4a98403ca5542 - circleci - 2023-10-16 17:23:03]
        at org.eclipse.jetty.server.handler.ContextHandler.callContextInitialized(ContextHandler.java:1049) [jetty-server-10.0.15.jar:10.0.15]
        at org.eclipse.jetty.servlet.ServletContextHandler.callContextInitialized(ServletContextHandler.java:624) [jetty-servlet-10.0.15.jar:10.0.15]
        at org.eclipse.jetty.server.handler.ContextHandler.contextInitialized(ContextHandler.java:984) [jetty-server-10.0.15.jar:10.0.15]
        at org.eclipse.jetty.servlet.ServletHandler.initialize(ServletHandler.java:740) [jetty-servlet-10.0.15.jar:10.0.15]
        at org.eclipse.jetty.servlet.ServletContextHandler.startContext(ServletContextHandler.java:392) [jetty-servlet-10.0.15.jar:10.0.15]
        at org.eclipse.jetty.webapp.WebAppContext.startContext(WebAppContext.java:1304) [jetty-webapp-10.0.15.jar:10.0.15]
        at org.eclipse.jetty.server.handler.ContextHandler.doStart(ContextHandler.java:901) [jetty-server-10.0.15.jar:10.0.15]
        at org.eclipse.jetty.servlet.ServletContextHandler.doStart(ServletContextHandler.java:306) [jetty-servlet-10.0.15.jar:10.0.15]
        at org.eclipse.jetty.webapp.WebAppContext.doStart(WebAppContext.java:532) [jetty-webapp-10.0.15.jar:10.0.15]
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:93) [jetty-util-10.0.15.jar:10.0.15]
        at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:171) [jetty-util-10.0.15.jar:10.0.15]
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:121) [jetty-util-10.0.15.jar:10.0.15]
        at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:89) [jetty-server-10.0.15.jar:10.0.15]
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:93) [jetty-util-10.0.15.jar:10.0.15]
        at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:171) [jetty-util-10.0.15.jar:10.0.15]
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:114) [jetty-util-10.0.15.jar:10.0.15]
        at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:89) [jetty-server-10.0.15.jar:10.0.15]
```