### PR TITLE
SOLR-17076: Optimize placement factory get all replica

### DIFF
--- a/solr/core/src/java/org/apache/solr/cluster/placement/plugins/OrderedNodePlacementPlugin.java
+++ b/solr/core/src/java/org/apache/solr/cluster/placement/plugins/OrderedNodePlacementPlugin.java
@@ -403,7 +403,9 @@ public abstract class OrderedNodePlacementPlugin implements PlacementPlugin {
   public abstract static class WeightedNode implements Comparable<WeightedNode> {
     private final Node node;
     private final Map<String, Map<String, Set<Replica>>> replicas;
-    private final Set<Replica> allReplicas; //a flattened list of all replicas, computing from the map could be costly
+
+    // a flattened list of all replicas, as computing from the map could be costly
+    private final Set<Replica> allReplicas;
 
     public WeightedNode(Node node) {
       this.node = node;

--- a/solr/core/src/java/org/apache/solr/cluster/placement/plugins/SimplePlacementFactory.java
+++ b/solr/core/src/java/org/apache/solr/cluster/placement/plugins/SimplePlacementFactory.java
@@ -129,7 +129,7 @@ public class SimplePlacementFactory
       int colReplicaCount =
           collectionReplicas.getOrDefault(replica.getShard().getCollection().getName(), 0);
       int shardReplicaCount = getReplicasForShardOnNode(replica.getShard()).size();
-      return getAllReplicasOnNode().size()
+      return getAllReplicaCount()
           + 1
           + colReplicaCount * SAME_COL_MULT
           + shardReplicaCount * SAME_SHARD_MULT;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SOLR-17076


# Description

`OrderedNodePlacementPlugin#getAllReplicasOnNode` can be slow in a cluster with lot of replicas. The effect could compound with new collection creation with many shards. 

# Solution

Introduced a new field `allReplicas` which keeps track of all the replicas added/removed in the Plugin. Return a copy of that set instead for `getAllReplicasOnNode`.

Also added a new convenient method `getAllReplicaCount` if only the count is needed

# Tests

A minor change, rely on existing unit test case

# Checklist

Please review the following and check all that apply:

- [x] I have reviewed the guidelines for [How to Contribute](https://wiki.apache.org/solr/HowToContribute) and my code conforms to the standards described there to the best of my ability.
- [x] I have created a Jira issue and added the issue ID to my pull request title.
- [ ] I have given Solr maintainers [access](https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to contribute to my PR branch. (optional but recommended)
- [x] I have developed this patch against the `main` branch.
- [ ] I have run `./gradlew check`.
- [ ] I have added tests for my changes.
- [ ] I have added documentation for the [Reference Guide](https://github.com/apache/solr/tree/main/solr/solr-ref-guide)
