### PR TITLE
PoC Bucketed rate limit

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -177,6 +177,10 @@ public class CoreContainer {
 
   final SolrCores solrCores;
 
+  public SolrMetricsContext getSolrMetricsContext() {
+    return solrMetricsContext;
+  }
+
   public static class CoreLoadFailure {
 
     public final CoreDescriptor cd;

--- a/solr/core/src/java/org/apache/solr/core/RateLimiterConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/RateLimiterConfig.java
@@ -20,7 +20,9 @@ package org.apache.solr.core;
 import static org.apache.solr.servlet.RateLimitManager.DEFAULT_CONCURRENT_REQUESTS;
 import static org.apache.solr.servlet.RateLimitManager.DEFAULT_SLOT_ACQUISITION_TIMEOUT_MS;
 
+import java.util.List;
 import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.client.solrj.request.beans.RateLimiterPayload;
 
 public class RateLimiterConfig {
   public static final String RL_CONFIG_KEY = "rate-limiters";
@@ -31,6 +33,7 @@ public class RateLimiterConfig {
   public int allowedRequests;
   public boolean isSlotBorrowingEnabled;
   public int guaranteedSlotsThreshold;
+  public List<RateLimiterPayload.ReadBucketConfig> readBuckets;
 
   public RateLimiterConfig(SolrRequest.SolrRequestType requestType) {
     this.requestType = requestType;

--- a/solr/core/src/java/org/apache/solr/servlet/BucketedQueryRateLimiter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/BucketedQueryRateLimiter.java
@@ -92,8 +92,8 @@ public class BucketedQueryRateLimiter extends RequestRateLimiter implements Solr
       return ew -> {
         ew.put("queueLength", guaranteedSlotsPool.getQueueLength());
         ew.put("available", guaranteedSlotsPool.availablePermits());
-        ew.put("tries", tries);
-        ew.put("success", success);
+        ew.put("tries", tries.longValue());
+        ew.put("success", success.longValue());
         ew.put("fails", fails);
         ew.put("tryWaitAverage", tryWait.getMeanRate());
       };

--- a/solr/core/src/java/org/apache/solr/servlet/BucketedQueryRateLimiter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/BucketedQueryRateLimiter.java
@@ -1,0 +1,192 @@
+package org.apache.solr.servlet;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+import org.apache.solr.client.solrj.request.beans.RateLimiterPayload;
+import org.apache.solr.common.util.Utils;
+import org.apache.solr.core.RateLimiterConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BucketedQueryRateLimiter extends RequestRateLimiter {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private static final Map<String, Class<? extends Condition>> conditionImpls =
+      new LinkedHashMap<>();
+
+  List<Bucket> buckets = new ArrayList<>();
+
+  @Override
+  public SlotMetadata handleRequest(RequestWrapper request) throws InterruptedException {
+    for (Bucket bucket : buckets) {
+      if (bucket.test(request)) {
+        if (bucket.guaranteedSlotsPool.tryAcquire(
+            bucket.bucketCfg.slotAcquisitionTimeoutInMS, TimeUnit.MILLISECONDS)) {
+          return bucket.guaranteedSlotMetadata;
+        } else {
+          // could not acquire  aslot
+          return RequestRateLimiter.nullSlotMetadata;
+        }
+      }
+    }
+    // no bucket matches
+    return null;
+  }
+
+  static class Bucket {
+    private final String cfg;
+    private RateLimiterPayload.ReadBucketConfig bucketCfg;
+    private final Semaphore guaranteedSlotsPool;
+    private final SlotMetadata guaranteedSlotMetadata;
+    private final List<Condition> conditions = new ArrayList<>();
+
+    private Bucket fallback;
+
+    public boolean test(RequestWrapper req) {
+      boolean isPass = true;
+      for (Condition condition : conditions) {
+        if (!condition.test(req)) isPass = false;
+      }
+      return isPass;
+    }
+
+    public Bucket(RateLimiterPayload.ReadBucketConfig bucketCfg) {
+      this.bucketCfg = bucketCfg;
+      cfg = bucketCfg.jsonStr();
+      this.guaranteedSlotsPool = new Semaphore(bucketCfg.allowedRequests);
+      this.guaranteedSlotMetadata = new SlotMetadata(guaranteedSlotsPool);
+    }
+
+    @Override
+    public String toString() {
+      return cfg;
+    }
+  }
+
+  static {
+    conditionImpls.put(ReqHeaderCondition.ID, ReqHeaderCondition.class);
+    conditionImpls.put(QueryParamCondition.ID, QueryParamCondition.class);
+  }
+
+  @SuppressWarnings("unchecked")
+  public BucketedQueryRateLimiter(RateLimiterConfig rateLimiterConfig) {
+    super(rateLimiterConfig);
+
+    for (RateLimiterPayload.ReadBucketConfig bucketCfg : rateLimiterConfig.readBuckets) {
+      Bucket b = new Bucket(bucketCfg);
+      buckets.add(b);
+      if (bucketCfg.conditions == null || bucketCfg.conditions.isEmpty()) {
+        b.conditions.add(MatchAllCondition.INST);
+        continue;
+      }
+      for (Object c : bucketCfg.conditions) {
+        List<Object> conditionInfo = c instanceof List ? (List<Object>) c : List.of(c);
+        for (Object o : conditionInfo) {
+          Map<String, Object> info = (Map<String, Object>) o;
+          Condition condition = null;
+
+          for (Map.Entry<String, Class<? extends Condition>> e : conditionImpls.entrySet()) {
+            if (info.containsKey(e.getKey())) {
+              try {
+                condition = e.getValue().getDeclaredConstructor().newInstance().init(info);
+                break;
+              } catch (Exception ex) {
+                // unlikely
+                throw new RuntimeException(ex);
+              }
+            }
+          }
+          if (condition == null) {
+            throw new RuntimeException("Unknown condition : " + Utils.toJSONString(info));
+          }
+          b.conditions.add(condition);
+        }
+      }
+    }
+  }
+
+  public interface Condition {
+    boolean test(RequestWrapper req);
+
+    Condition init(Map<String, Object> config);
+
+    String identifier();
+  }
+
+  public abstract static class KeyValCondition implements Condition {
+    protected String name;
+    protected Pattern valuePattern;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Condition init(Map<String, Object> config) {
+      Map<String, String> kv = (Map<String, String>) config.get(identifier());
+      name = kv.keySet().iterator().next();
+      valuePattern = Pattern.compile(kv.values().iterator().next());
+      return this;
+    }
+
+    @Override
+    public boolean test(RequestWrapper req) {
+      String val = readVal(req);
+      if (val == null) val = "";
+      return valuePattern.matcher(val).find();
+    }
+
+    protected abstract String readVal(RequestWrapper req);
+  }
+
+  public static class ReqHeaderCondition extends KeyValCondition {
+    public static final String ID = "headerPattern";
+
+    @Override
+    public String identifier() {
+      return ID;
+    }
+
+    @Override
+    protected String readVal(RequestWrapper req) {
+      return req.getHeader(name);
+    }
+  }
+
+  public static class QueryParamCondition extends KeyValCondition {
+    public static final String ID = "queryParamPattern";
+
+    @Override
+    public String identifier() {
+      return ID;
+    }
+
+    @Override
+    protected String readVal(RequestWrapper req) {
+      return req.getParameter(name);
+    }
+  }
+
+  public static class MatchAllCondition implements Condition {
+    public static final String ID = "";
+    public static final MatchAllCondition INST = new MatchAllCondition();
+
+    @Override
+    public boolean test(RequestWrapper req) {
+      return true;
+    }
+
+    @Override
+    public Condition init(Map<String, Object> config) {
+      return this;
+    }
+
+    @Override
+    public String identifier() {
+      return ID;
+    }
+  }
+}

--- a/solr/core/src/java/org/apache/solr/servlet/BucketedQueryRateLimiter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/BucketedQueryRateLimiter.java
@@ -1,6 +1,5 @@
 package org.apache.solr.servlet;
 
-import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -22,7 +21,7 @@ import org.apache.solr.metrics.SolrMetricsContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class BucketedQueryRateLimiter extends RequestRateLimiter implements SolrMetricProducer {
+public class BucketedQueryRateLimiter extends QueryRateLimiter implements SolrMetricProducer {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private static final Map<String, Class<? extends Condition>> conditionImpls =
@@ -94,7 +93,7 @@ public class BucketedQueryRateLimiter extends RequestRateLimiter implements Solr
         ew.put("available", guaranteedSlotsPool.availablePermits());
         ew.put("tries", tries.longValue());
         ew.put("success", success.longValue());
-        ew.put("fails", fails);
+        ew.put("fails", fails.longValue());
         ew.put("tryWaitAverage", tryWait.getMeanRate());
       };
     }

--- a/solr/core/src/java/org/apache/solr/servlet/BucketedQueryRateLimiter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/BucketedQueryRateLimiter.java
@@ -82,7 +82,7 @@ public class BucketedQueryRateLimiter extends QueryRateLimiter implements SolrMe
     public boolean test(RequestWrapper req) {
       boolean isPass = true;
       for (Condition condition : conditions) {
-        if (!condition.test(req)) isPass = false;
+        if (!condition.test(req)) return false;
       }
       return isPass;
     }

--- a/solr/core/src/java/org/apache/solr/servlet/CoreContainerProvider.java
+++ b/solr/core/src/java/org/apache/solr/servlet/CoreContainerProvider.java
@@ -58,6 +58,7 @@ import javax.servlet.UnavailableException;
 import org.apache.http.client.HttpClient;
 import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.util.VectorUtil;
+import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.cloud.ZkController;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
@@ -268,6 +269,10 @@ public class CoreContainerProvider implements ServletContextListener {
               });
 
       this.rateLimitManager = builder.build();
+      RequestRateLimiter queryRateLimiter =  this.rateLimitManager.getRequestRateLimiter(SolrRequest.SolrRequestType.QUERY);
+      if(queryRateLimiter instanceof BucketedQueryRateLimiter) {
+        ((BucketedQueryRateLimiter)queryRateLimiter).initializeMetrics(coresInit.getSolrMetricsContext(), "bucketedQueryRateLimiter");
+      }
 
       if (zkController != null) {
         zkController.zkStateReader.registerClusterPropertiesListener(this.rateLimitManager);

--- a/solr/core/src/java/org/apache/solr/servlet/QueryRateLimiter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/QueryRateLimiter.java
@@ -19,28 +19,26 @@ package org.apache.solr.servlet;
 
 import static org.apache.solr.core.RateLimiterConfig.RL_CONFIG_KEY;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.Map;
-import org.apache.solr.client.solrj.SolrRequest;
+import java.util.function.Supplier;
 import org.apache.solr.client.solrj.request.beans.RateLimiterPayload;
 import org.apache.solr.common.cloud.SolrZkClient;
-import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.util.Utils;
 import org.apache.solr.core.RateLimiterConfig;
-import org.apache.solr.util.SolrJacksonAnnotationInspector;
-import org.apache.zookeeper.KeeperException;
-import org.apache.zookeeper.data.Stat;
 
 /**
  * Implementation of RequestRateLimiter specific to query request types. Most of the actual work is
  * delegated to the parent class but specific configurations and parsing are handled by this class.
  */
 public class QueryRateLimiter extends RequestRateLimiter {
-  private static final ObjectMapper mapper = SolrJacksonAnnotationInspector.createObjectMapper();
 
-  public QueryRateLimiter(SolrZkClient solrZkClient) {
-    super(constructQueryRateLimiterConfig(solrZkClient));
+  public QueryRateLimiter(Supplier<SolrZkClient.NodeData> solrZkClient) {
+    super(RateLimitManager.constructQueryRateLimiterConfig(solrZkClient));
+  }
+
+  public QueryRateLimiter(RateLimiterConfig cfg) {
+    super(cfg);
   }
 
   public void processConfigChange(Map<String, Object> properties) throws IOException {
@@ -51,75 +49,9 @@ public class QueryRateLimiter extends RequestRateLimiter {
       return;
     }
 
-    RateLimiterPayload rateLimiterMeta = mapper.readValue(configInput, RateLimiterPayload.class);
+    RateLimiterPayload rateLimiterMeta =
+        RateLimitManager.mapper.readValue(configInput, RateLimiterPayload.class);
 
-    constructQueryRateLimiterConfigInternal(rateLimiterMeta, rateLimiterConfig);
-  }
-
-  // To be used in initialization
-  @SuppressWarnings({"unchecked"})
-  private static RateLimiterConfig constructQueryRateLimiterConfig(SolrZkClient zkClient) {
-    try {
-
-      if (zkClient == null) {
-        return new RateLimiterConfig(SolrRequest.SolrRequestType.QUERY);
-      }
-
-      RateLimiterConfig rateLimiterConfig =
-          new RateLimiterConfig(SolrRequest.SolrRequestType.QUERY);
-      Map<String, Object> clusterPropsJson =
-          (Map<String, Object>)
-              Utils.fromJSON(zkClient.getData(ZkStateReader.CLUSTER_PROPS, null, new Stat(), true));
-      byte[] configInput = Utils.toJSON(clusterPropsJson.get(RL_CONFIG_KEY));
-
-      if (configInput.length == 0) {
-        // No Rate Limiter configuration defined in clusterprops.json. Return default configuration
-        // values
-        return rateLimiterConfig;
-      }
-
-      RateLimiterPayload rateLimiterMeta = mapper.readValue(configInput, RateLimiterPayload.class);
-
-      constructQueryRateLimiterConfigInternal(rateLimiterMeta, rateLimiterConfig);
-
-      return rateLimiterConfig;
-    } catch (KeeperException.NoNodeException e) {
-      return new RateLimiterConfig(SolrRequest.SolrRequestType.QUERY);
-    } catch (KeeperException | InterruptedException e) {
-      throw new RuntimeException(
-          "Error reading cluster property", SolrZkClient.checkInterrupted(e));
-    } catch (IOException e) {
-      throw new RuntimeException("Encountered an IOException " + e.getMessage());
-    }
-  }
-
-  private static void constructQueryRateLimiterConfigInternal(
-      RateLimiterPayload rateLimiterMeta, RateLimiterConfig rateLimiterConfig) {
-
-    if (rateLimiterMeta == null) {
-      // No Rate limiter configuration defined in clusterprops.json
-      return;
-    }
-
-    if (rateLimiterMeta.allowedRequests != null) {
-      rateLimiterConfig.allowedRequests = rateLimiterMeta.allowedRequests.intValue();
-    }
-
-    if (rateLimiterMeta.enabled != null) {
-      rateLimiterConfig.isEnabled = rateLimiterMeta.enabled;
-    }
-
-    if (rateLimiterMeta.guaranteedSlots != null) {
-      rateLimiterConfig.guaranteedSlotsThreshold = rateLimiterMeta.guaranteedSlots;
-    }
-
-    if (rateLimiterMeta.slotBorrowingEnabled != null) {
-      rateLimiterConfig.isSlotBorrowingEnabled = rateLimiterMeta.slotBorrowingEnabled;
-    }
-
-    if (rateLimiterMeta.slotAcquisitionTimeoutInMS != null) {
-      rateLimiterConfig.waitForSlotAcquisition =
-          rateLimiterMeta.slotAcquisitionTimeoutInMS.longValue();
-    }
+    RateLimitManager.constructQueryRateLimiterConfigInternal(rateLimiterMeta, rateLimiterConfig);
   }
 }

--- a/solr/core/src/java/org/apache/solr/servlet/RateLimitManager.java
+++ b/solr/core/src/java/org/apache/solr/servlet/RateLimitManager.java
@@ -19,18 +19,25 @@ package org.apache.solr.servlet;
 
 import static org.apache.solr.common.params.CommonParams.SOLR_REQUEST_CONTEXT_PARAM;
 import static org.apache.solr.common.params.CommonParams.SOLR_REQUEST_TYPE_PARAM;
+import static org.apache.solr.core.RateLimiterConfig.RL_CONFIG_KEY;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 import javax.servlet.http.HttpServletRequest;
 import net.jcip.annotations.ThreadSafe;
 import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.client.solrj.request.beans.RateLimiterPayload;
 import org.apache.solr.common.cloud.ClusterPropertiesListener;
 import org.apache.solr.common.cloud.SolrZkClient;
+import org.apache.solr.common.util.Utils;
+import org.apache.solr.core.RateLimiterConfig;
+import org.apache.solr.util.SolrJacksonAnnotationInspector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +52,7 @@ import org.slf4j.LoggerFactory;
  */
 @ThreadSafe
 public class RateLimitManager implements ClusterPropertiesListener {
+  static final ObjectMapper mapper = SolrJacksonAnnotationInspector.createObjectMapper();
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   public static final int DEFAULT_CONCURRENT_REQUESTS =
@@ -57,6 +65,71 @@ public class RateLimitManager implements ClusterPropertiesListener {
   public RateLimitManager() {
     this.requestRateLimiterMap = new HashMap<>();
     this.activeRequestsMap = new ConcurrentHashMap<>();
+  }
+
+  // To be used in initialization
+  @SuppressWarnings({"unchecked"})
+  public static RateLimiterConfig constructQueryRateLimiterConfig(
+      Supplier<SolrZkClient.NodeData> nodeDataSupplier) {
+    try {
+
+      if (nodeDataSupplier == null) {
+        return new RateLimiterConfig(SolrRequest.SolrRequestType.QUERY);
+      }
+
+      RateLimiterConfig rateLimiterConfig =
+          new RateLimiterConfig(SolrRequest.SolrRequestType.QUERY);
+      Map<String, Object> clusterPropsJson =
+          (Map<String, Object>) Utils.fromJSON(nodeDataSupplier.get().data);
+      byte[] configInput = Utils.toJSON(clusterPropsJson.get(RL_CONFIG_KEY));
+
+      if (configInput.length == 0) {
+        // No Rate Limiter configuration defined in clusterprops.json. Return default configuration
+        // values
+        return rateLimiterConfig;
+      }
+
+      RateLimiterPayload rateLimiterMeta = mapper.readValue(configInput, RateLimiterPayload.class);
+
+      constructQueryRateLimiterConfigInternal(rateLimiterMeta, rateLimiterConfig);
+
+      return rateLimiterConfig;
+    } catch (IOException e) {
+      throw new RuntimeException("Encountered an IOException " + e.getMessage());
+    }
+  }
+
+  public static void constructQueryRateLimiterConfigInternal(
+      RateLimiterPayload rateLimiterMeta, RateLimiterConfig rateLimiterConfig) {
+
+    if (rateLimiterMeta == null) {
+      // No Rate limiter configuration defined in clusterprops.json
+      return;
+    }
+
+    if (rateLimiterMeta.allowedRequests != null) {
+      rateLimiterConfig.allowedRequests = rateLimiterMeta.allowedRequests.intValue();
+    }
+
+    if (rateLimiterMeta.enabled != null) {
+      rateLimiterConfig.isEnabled = rateLimiterMeta.enabled;
+    }
+
+    if (rateLimiterMeta.guaranteedSlots != null) {
+      rateLimiterConfig.guaranteedSlotsThreshold = rateLimiterMeta.guaranteedSlots;
+    }
+
+    if (rateLimiterMeta.slotBorrowingEnabled != null) {
+      rateLimiterConfig.isSlotBorrowingEnabled = rateLimiterMeta.slotBorrowingEnabled;
+    }
+
+    if (rateLimiterMeta.slotAcquisitionTimeoutInMS != null) {
+      rateLimiterConfig.waitForSlotAcquisition =
+          rateLimiterMeta.slotAcquisitionTimeoutInMS.longValue();
+    }
+    if (rateLimiterMeta.readBuckets != null && !rateLimiterMeta.readBuckets.isEmpty()) {
+      rateLimiterConfig.readBuckets = rateLimiterMeta.readBuckets;
+    }
   }
 
   @Override
@@ -103,13 +176,29 @@ public class RateLimitManager implements ClusterPropertiesListener {
       return true;
     }
 
-    RequestRateLimiter.SlotMetadata result = requestRateLimiter.handleRequest();
+    RequestRateLimiter.SlotMetadata result =
+        requestRateLimiter.handleRequest(
+            new RequestRateLimiter.RequestWrapper() {
+              @Override
+              public String getParameter(String name) {
+                return request.getParameter(name);
+              }
+
+              @Override
+              public String getHeader(String name) {
+                return request.getHeader(name);
+              }
+            });
 
     if (result != null) {
       // Can be the case if request rate limiter is disabled
       if (result.isReleasable()) {
         activeRequestsMap.put(request, result);
       }
+      return true;
+    }
+    if (requestRateLimiter instanceof BucketedQueryRateLimiter) {
+      // there is no slot borrowing for bucketed rate limiter
       return true;
     }
 
@@ -188,17 +277,22 @@ public class RateLimitManager implements ClusterPropertiesListener {
   }
 
   public static class Builder {
-    protected SolrZkClient solrZkClient;
+    protected Supplier<SolrZkClient.NodeData> nodeDataSupplier;
 
-    public Builder(SolrZkClient solrZkClient) {
-      this.solrZkClient = solrZkClient;
+    public Builder(Supplier<SolrZkClient.NodeData> nodeDataSupplier) {
+      this.nodeDataSupplier = nodeDataSupplier;
     }
 
     public RateLimitManager build() {
       RateLimitManager rateLimitManager = new RateLimitManager();
 
+      RateLimiterConfig cfg = constructQueryRateLimiterConfig(nodeDataSupplier);
+
+      RequestRateLimiter queryRateLimiter =
+          cfg.readBuckets == null ? new QueryRateLimiter(cfg) : new BucketedQueryRateLimiter(cfg);
+
       rateLimitManager.registerRequestRateLimiter(
-          new QueryRateLimiter(solrZkClient), SolrRequest.SolrRequestType.QUERY);
+          queryRateLimiter, SolrRequest.SolrRequestType.QUERY);
 
       return rateLimitManager;
     }

--- a/solr/core/src/java/org/apache/solr/servlet/RequestRateLimiter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/RequestRateLimiter.java
@@ -42,7 +42,7 @@ public class RequestRateLimiter {
   private final RateLimiterConfig rateLimiterConfig;
   private final SlotMetadata guaranteedSlotMetadata;
   private final SlotMetadata borrowedSlotMetadata;
-  private static final SlotMetadata nullSlotMetadata = new SlotMetadata(null);
+  protected static final SlotMetadata nullSlotMetadata = new SlotMetadata(null);
 
   public RequestRateLimiter(RateLimiterConfig rateLimiterConfig) {
     this.rateLimiterConfig = rateLimiterConfig;
@@ -58,7 +58,7 @@ public class RequestRateLimiter {
    * Handles an incoming request. returns a metadata object representing the metadata for the
    * acquired slot, if acquired. If a slot is not acquired, returns a null metadata object.
    */
-  public SlotMetadata handleRequest() throws InterruptedException {
+  public SlotMetadata handleRequest(RequestWrapper request) throws InterruptedException {
 
     if (!rateLimiterConfig.isEnabled) {
       return nullSlotMetadata;
@@ -102,7 +102,7 @@ public class RequestRateLimiter {
 
   // Represents the metadata for a slot
   static class SlotMetadata {
-    private final Semaphore usedPool;
+    final Semaphore usedPool;
 
     public SlotMetadata(Semaphore usedPool) {
       this.usedPool = usedPool;
@@ -117,5 +117,11 @@ public class RequestRateLimiter {
     public boolean isReleasable() {
       return usedPool != null;
     }
+  }
+
+  public interface RequestWrapper {
+    String getParameter(String name);
+
+    String getHeader(String name);
   }
 }

--- a/solr/core/src/java/org/apache/solr/servlet/ServletUtils.java
+++ b/solr/core/src/java/org/apache/solr/servlet/ServletUtils.java
@@ -209,7 +209,11 @@ public abstract class ServletUtils {
     RateLimitManager rateLimitManager = getRateLimitManager(request);
     try {
       try {
-        accepted = rateLimitManager.handleRequest(request);
+        if(rateLimitManager != null) {
+          accepted = rateLimitManager.handleRequest(request);
+        } else {
+          accepted = true;
+        }
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         throw new SolrException(ErrorCode.SERVER_ERROR, e.getMessage());

--- a/solr/core/src/java/org/apache/solr/servlet/ServletUtils.java
+++ b/solr/core/src/java/org/apache/solr/servlet/ServletUtils.java
@@ -231,7 +231,7 @@ public abstract class ServletUtils {
       traceHttpRequestExecution2(request, response, limitedExecution, trace);
     } finally {
       if (accepted) {
-        rateLimitManager.decrementActiveRequests(request);
+        if(rateLimitManager!= null) rateLimitManager.decrementActiveRequests(request);
       }
     }
   }

--- a/solr/core/src/java/org/apache/solr/servlet/ServletUtils.java
+++ b/solr/core/src/java/org/apache/solr/servlet/ServletUtils.java
@@ -209,7 +209,7 @@ public abstract class ServletUtils {
     RateLimitManager rateLimitManager = getRateLimitManager(request);
     try {
       try {
-        if(rateLimitManager != null) {
+        if (rateLimitManager != null) {
           accepted = rateLimitManager.handleRequest(request);
         } else {
           accepted = true;
@@ -231,7 +231,7 @@ public abstract class ServletUtils {
       traceHttpRequestExecution2(request, response, limitedExecution, trace);
     } finally {
       if (accepted) {
-        if(rateLimitManager!= null) rateLimitManager.decrementActiveRequests(request);
+        if (rateLimitManager != null) rateLimitManager.decrementActiveRequests(request);
       }
     }
   }

--- a/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/SolrDispatchFilter.java
@@ -43,6 +43,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.solr.api.V2HttpCall;
+import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.SolrException.ErrorCode;
 import org.apache.solr.common.util.ExecutorUtil;

--- a/solr/core/src/test/org/apache/solr/servlet/TestBucketedRateLimit.java
+++ b/solr/core/src/test/org/apache/solr/servlet/TestBucketedRateLimit.java
@@ -1,7 +1,6 @@
 package org.apache.solr.servlet;
 
 import java.nio.charset.StandardCharsets;
-
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.cloud.SolrCloudTestCase;
 import org.apache.solr.common.cloud.SolrZkClient;
@@ -9,75 +8,76 @@ import org.apache.zookeeper.data.Stat;
 import org.junit.BeforeClass;
 
 public class TestBucketedRateLimit extends SolrCloudTestCase {
-    private static final String FIRST_COLLECTION = "c1";
+  private static final String FIRST_COLLECTION = "c1";
 
-    @BeforeClass
-    public static void setupCluster() throws Exception {
-        configureCluster(1).addConfig(FIRST_COLLECTION, configset("cloud-minimal")).configure();
-    }
+  @BeforeClass
+  public static void setupCluster() throws Exception {
+    configureCluster(1).addConfig(FIRST_COLLECTION, configset("cloud-minimal")).configure();
+  }
 
-    public void testConfig() throws Exception {
-        String config =
-                "{\n"
-                        + "  \"rate-limiters\": {\n"
-                        + "    \"readBuckets\": [\n"
-                        + "      {\n"
-                        + "        \"name\": \"expensive\",\n"
-                        + "        \"conditions\": [{\n"
-                        + "          \"queryParamPattern\": {\n"
-                        + "            \"q\": \".*multijoin.*\"\n"
-                        + "          }\n"
-                        + "        }],\n"
-                        + "        \"allowedRequests\": 5,\n"
-                        + "        \"slotAcquisitionTimeoutInMS\": 100\n"
-                        + "      },\n"
-                        + "      {\n"
-                        + "        \"name\": \"low\",\n"
-                        + "        \"conditions\": [{\n"
-                        + "          \"headerPattern\": {\n"
-                        + "            \"solr_req_priority\": \"20\"\n"
-                        + "          }\n"
-                        + "        }],\n"
-                        + "        \"allowedRequests\": 20,\n"
-                        + "        \"slotAcquisitionTimeoutInMS\": 100\n"
-                        + "      },\n"
-                        + "      {\n"
-                        + "        \"name\": \"global\",\n"
-                        + "        \"conditions\": [],\n"
-                        + "        \"allowedRequests\": 50,\n"
-                        + "        \"slotAcquisitionTimeoutInMS\": 100\n"
-                        + "      }\n"
-                        + "    ]\n"
-                        + "  }\n"
-                        + "}\n"
-                        + "\n";
-        RateLimitManager mgr =
-                new RateLimitManager.Builder(
-                        () ->
-                                new SolrZkClient.NodeData(new Stat(), config.getBytes(StandardCharsets.UTF_8)))
-                        .build();
-        RequestRateLimiter rl = mgr.getRequestRateLimiter(SolrRequest.SolrRequestType.QUERY);
-        assertTrue(rl instanceof BucketedQueryRateLimiter);
-        BucketedQueryRateLimiter brl = (BucketedQueryRateLimiter) rl;
-        assertEquals(3, brl.buckets.size());
+  public void testConfig() throws Exception {
+    String config =
+        "{\n"
+            + "  \"rate-limiters\": {\n"
+            + "    \"readBuckets\": [\n"
+            + "      {\n"
+            + "        \"name\": \"expensive\",\n"
+            + "        \"conditions\": [{\n"
+            + "          \"queryParamPattern\": {\n"
+            + "            \"q\": \".*multijoin.*\"\n"
+            + "          }\n"
+            + "        }],\n"
+            + "        \"allowedRequests\": 5,\n"
+            + "        \"slotAcquisitionTimeoutInMS\": 100\n"
+            + "      },\n"
+            + "      {\n"
+            + "        \"name\": \"low\",\n"
+            + "        \"conditions\": [{\n"
+            + "          \"headerPattern\": {\n"
+            + "            \"solr_req_priority\": \"20\"\n"
+            + "          }\n"
+            + "        }],\n"
+            + "        \"allowedRequests\": 20,\n"
+            + "        \"slotAcquisitionTimeoutInMS\": 100\n"
+            + "      },\n"
+            + "      {\n"
+            + "        \"name\": \"global\",\n"
+            + "        \"conditions\": [],\n"
+            + "        \"allowedRequests\": 50,\n"
+            + "        \"slotAcquisitionTimeoutInMS\": 100\n"
+            + "      }\n"
+            + "    ]\n"
+            + "  }\n"
+            + "}\n"
+            + "\n";
+    RateLimitManager mgr =
+        new RateLimitManager.Builder(
+                () ->
+                    new SolrZkClient.NodeData(new Stat(), config.getBytes(StandardCharsets.UTF_8)))
+            .build();
+    RequestRateLimiter rl = mgr.getRequestRateLimiter(SolrRequest.SolrRequestType.QUERY);
+    assertTrue(rl instanceof BucketedQueryRateLimiter);
+    BucketedQueryRateLimiter brl = (BucketedQueryRateLimiter) rl;
+    assertEquals(3, brl.buckets.size());
 
-        RequestRateLimiter.SlotMetadata smd = rl.handleRequest(new RequestRateLimiter.RequestWrapper() {
-            @Override
-            public String getParameter(String name) {
+    RequestRateLimiter.SlotMetadata smd =
+        rl.handleRequest(
+            new RequestRateLimiter.RequestWrapper() {
+              @Override
+              public String getParameter(String name) {
                 return null;
-            }
+              }
 
-            @Override
-            public String getHeader(String name) {
-                if (name.equals("solr_req_priority"))
-                    return "20";
+              @Override
+              public String getHeader(String name) {
+                if (name.equals("solr_req_priority")) return "20";
                 else return null;
-            }
-        });
+              }
+            });
 
-        //star
-        assertEquals(19, smd.usedPool.availablePermits());
-        smd.decrementRequest();
-        assertEquals(20, smd.usedPool.availablePermits());
-    }
+    // star
+    assertEquals(19, smd.usedPool.availablePermits());
+    smd.decrementRequest();
+    assertEquals(20, smd.usedPool.availablePermits());
+  }
 }

--- a/solr/core/src/test/org/apache/solr/servlet/TestBucketedRateLimit.java
+++ b/solr/core/src/test/org/apache/solr/servlet/TestBucketedRateLimit.java
@@ -1,0 +1,83 @@
+package org.apache.solr.servlet;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.cloud.SolrCloudTestCase;
+import org.apache.solr.common.cloud.SolrZkClient;
+import org.apache.zookeeper.data.Stat;
+import org.junit.BeforeClass;
+
+public class TestBucketedRateLimit extends SolrCloudTestCase {
+    private static final String FIRST_COLLECTION = "c1";
+
+    @BeforeClass
+    public static void setupCluster() throws Exception {
+        configureCluster(1).addConfig(FIRST_COLLECTION, configset("cloud-minimal")).configure();
+    }
+
+    public void testConfig() throws Exception {
+        String config =
+                "{\n"
+                        + "  \"rate-limiters\": {\n"
+                        + "    \"readBuckets\": [\n"
+                        + "      {\n"
+                        + "        \"name\": \"expensive\",\n"
+                        + "        \"conditions\": [{\n"
+                        + "          \"queryParamPattern\": {\n"
+                        + "            \"q\": \".*multijoin.*\"\n"
+                        + "          }\n"
+                        + "        }],\n"
+                        + "        \"allowedRequests\": 5,\n"
+                        + "        \"slotAcquisitionTimeoutInMS\": 100\n"
+                        + "      },\n"
+                        + "      {\n"
+                        + "        \"name\": \"low\",\n"
+                        + "        \"conditions\": [{\n"
+                        + "          \"headerPattern\": {\n"
+                        + "            \"solr_req_priority\": \"20\"\n"
+                        + "          }\n"
+                        + "        }],\n"
+                        + "        \"allowedRequests\": 20,\n"
+                        + "        \"slotAcquisitionTimeoutInMS\": 100\n"
+                        + "      },\n"
+                        + "      {\n"
+                        + "        \"name\": \"global\",\n"
+                        + "        \"conditions\": [],\n"
+                        + "        \"allowedRequests\": 50,\n"
+                        + "        \"slotAcquisitionTimeoutInMS\": 100\n"
+                        + "      }\n"
+                        + "    ]\n"
+                        + "  }\n"
+                        + "}\n"
+                        + "\n";
+        RateLimitManager mgr =
+                new RateLimitManager.Builder(
+                        () ->
+                                new SolrZkClient.NodeData(new Stat(), config.getBytes(StandardCharsets.UTF_8)))
+                        .build();
+        RequestRateLimiter rl = mgr.getRequestRateLimiter(SolrRequest.SolrRequestType.QUERY);
+        assertTrue(rl instanceof BucketedQueryRateLimiter);
+        BucketedQueryRateLimiter brl = (BucketedQueryRateLimiter) rl;
+        assertEquals(3, brl.buckets.size());
+
+        RequestRateLimiter.SlotMetadata smd = rl.handleRequest(new RequestRateLimiter.RequestWrapper() {
+            @Override
+            public String getParameter(String name) {
+                return null;
+            }
+
+            @Override
+            public String getHeader(String name) {
+                if (name.equals("solr_req_priority"))
+                    return "20";
+                else return null;
+            }
+        });
+
+        //star
+        assertEquals(19, smd.usedPool.availablePermits());
+        smd.decrementRequest();
+        assertEquals(20, smd.usedPool.availablePermits());
+    }
+}

--- a/solr/core/src/test/org/apache/solr/servlet/TestRequestRateLimiter.java
+++ b/solr/core/src/test/org/apache/solr/servlet/TestRequestRateLimiter.java
@@ -26,6 +26,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrRequest;
@@ -214,10 +215,10 @@ public class TestRequestRateLimiter extends SolrCloudTestCase {
     }
 
     @Override
-    public SlotMetadata handleRequest() throws InterruptedException {
+    public SlotMetadata handleRequest(RequestWrapper request) throws InterruptedException {
       incomingRequestCount.getAndIncrement();
 
-      SlotMetadata response = super.handleRequest();
+      SlotMetadata response = super.handleRequest(request);
 
       if (response != null) {
         acceptedNewRequestCount.getAndIncrement();
@@ -244,7 +245,8 @@ public class TestRequestRateLimiter extends SolrCloudTestCase {
     private final RequestRateLimiter queryRequestRateLimiter;
     private final RequestRateLimiter indexRequestRateLimiter;
 
-    public MockBuilder(SolrZkClient zkClient, RequestRateLimiter queryRequestRateLimiter) {
+    public MockBuilder(
+        Supplier<SolrZkClient.NodeData> zkClient, RequestRateLimiter queryRequestRateLimiter) {
       super(zkClient);
 
       this.queryRequestRateLimiter = queryRequestRateLimiter;
@@ -252,7 +254,7 @@ public class TestRequestRateLimiter extends SolrCloudTestCase {
     }
 
     public MockBuilder(
-        SolrZkClient zkClient,
+        Supplier<SolrZkClient.NodeData> zkClient,
         RequestRateLimiter queryRequestRateLimiter,
         RequestRateLimiter indexRequestRateLimiter) {
       super(zkClient);

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/RateLimiterPayload.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/RateLimiterPayload.java
@@ -17,6 +17,7 @@
 
 package org.apache.solr.client.solrj.request.beans;
 
+import java.util.List;
 import java.util.Objects;
 import org.apache.solr.common.annotation.JsonProperty;
 import org.apache.solr.common.util.ReflectMapWriter;
@@ -32,6 +33,7 @@ public class RateLimiterPayload implements ReflectMapWriter {
   @JsonProperty public Boolean slotBorrowingEnabled;
 
   @JsonProperty public Integer slotAcquisitionTimeoutInMS;
+  @JsonProperty public List<ReadBucketConfig> readBuckets;
 
   public RateLimiterPayload copy() {
     RateLimiterPayload result = new RateLimiterPayload();
@@ -41,7 +43,7 @@ public class RateLimiterPayload implements ReflectMapWriter {
     result.allowedRequests = allowedRequests;
     result.slotBorrowingEnabled = slotBorrowingEnabled;
     result.slotAcquisitionTimeoutInMS = slotAcquisitionTimeoutInMS;
-
+    result.readBuckets = readBuckets;
     return result;
   }
 
@@ -66,5 +68,16 @@ public class RateLimiterPayload implements ReflectMapWriter {
         allowedRequests,
         slotBorrowingEnabled,
         slotAcquisitionTimeoutInMS);
+  }
+
+  public static class ReadBucketConfig implements ReflectMapWriter {
+
+    @JsonProperty public String name;
+
+    @JsonProperty public Integer allowedRequests;
+
+    @JsonProperty public Integer slotAcquisitionTimeoutInMS;
+
+    @JsonProperty public List<Object> conditions;
   }
 }


### PR DESCRIPTION
* A query needs to be passed with the following header:
`Solr-Request-Type: QUERY`
* As per below configuration, a query should be passed with a query parameter `?q-bucket=test-bucket`
* Example clusterprops.json:

```
    {
      "rate-limiters": {
        "readBuckets": [
        {
        "name": "test-bucket",
        "conditions": [{
          "queryParamPattern": {
            "q-bucket": "test-bucket"
          }
        }],
        "allowedRequests": 2,
        "slotAcquisitionTimeoutInMS": 1000
      }

        ]
      }
    }
