### PR TITLE
Disable start request logs for get request

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -404,7 +404,7 @@ public class SearchHandler extends RequestHandlerBase
     rb.isDistrib = isDistrib(req);
     tagRequestWithRequestId(rb);
 
-    if (req.getPath().contains("select")) {
+    if (req.getPath() != null && req.getPath().contains("select")) {
       if (isShard) {
         // log a simple message on start
         log.info("Start Forwarded Search Query");

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -404,26 +404,23 @@ public class SearchHandler extends RequestHandlerBase
     rb.isDistrib = isDistrib(req);
     tagRequestWithRequestId(rb);
 
-    if (req.getPath() != null && req.getPath().contains("select")) {
-      if (isShard) {
-        // log a simple message on start
-        log.info("Start Forwarded Search Query");
-        SolrParams filteredParams = removeVerboseParams(req.getParams());
-        rsp.getToLog()
-            .asShallowMap(false)
-            .put(
-                "params", "{" + filteredParams + "}"); // replace "params" with the filtered version
-      } else {
-        // Then it is the first time this req hitting Solr - not a req distributed by another higher
-        // level req.
-        // We have to log the query here as
-        // 1. It's useful to know the query before the processing start in case if the query stalls
-        // 2. The existing logging in SolrCore does not contain the query as query construction
-        // happens after the log
-        //    entries are added to rsp.toLog
-        if (log.isInfoEnabled()) {
-          log.info("Start External Search Query: {}", req.getParamString());
-        }
+    if (isShard) {
+      // log a simple message on start
+      log.info("Start Forwarded Search Query");
+      SolrParams filteredParams = removeVerboseParams(req.getParams());
+      rsp.getToLog()
+          .asShallowMap(false)
+          .put("params", "{" + filteredParams + "}"); // replace "params" with the filtered version
+    } else if (rb.isDistrib) {
+      // Then it is the first time this req hitting Solr - not a req distributed by another higher
+      // level req.
+      // We have to log the query here as
+      // 1. It's useful to know the query before the processing start in case if the query stalls
+      // 2. The existing logging in SolrCore does not contain the query as query construction
+      // happens after the log
+      //    entries are added to rsp.toLog
+      if (log.isInfoEnabled()) {
+        log.info("Start External Search Query: {}", req.getParamString());
       }
     }
 

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -410,8 +410,9 @@ public class SearchHandler extends RequestHandlerBase
         log.info("Start Forwarded Search Query");
         SolrParams filteredParams = removeVerboseParams(req.getParams());
         rsp.getToLog()
-                .asShallowMap(false)
-                .put("params", "{" + filteredParams + "}"); // replace "params" with the filtered version
+            .asShallowMap(false)
+            .put(
+                "params", "{" + filteredParams + "}"); // replace "params" with the filtered version
       } else {
         // Then it is the first time this req hitting Solr - not a req distributed by another higher
         // level req.

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -404,23 +404,25 @@ public class SearchHandler extends RequestHandlerBase
     rb.isDistrib = isDistrib(req);
     tagRequestWithRequestId(rb);
 
-    if (isShard) {
-      // log a simple message on start
-      log.info("Start Forwarded Search Query");
-      SolrParams filteredParams = removeVerboseParams(req.getParams());
-      rsp.getToLog()
-          .asShallowMap(false)
-          .put("params", "{" + filteredParams + "}"); // replace "params" with the filtered version
-    } else {
-      // Then it is the first time this req hitting Solr - not a req distributed by another higher
-      // level req.
-      // We have to log the query here as
-      // 1. It's useful to know the query before the processing start in case if the query stalls
-      // 2. The existing logging in SolrCore does not contain the query as query construction
-      // happens after the log
-      //    entries are added to rsp.toLog
-      if (log.isInfoEnabled()) {
-        log.info("Start External Search Query: {}", req.getParamString());
+    if (req.getPath().contains("select")) {
+      if (isShard) {
+        // log a simple message on start
+        log.info("Start Forwarded Search Query");
+        SolrParams filteredParams = removeVerboseParams(req.getParams());
+        rsp.getToLog()
+                .asShallowMap(false)
+                .put("params", "{" + filteredParams + "}"); // replace "params" with the filtered version
+      } else {
+        // Then it is the first time this req hitting Solr - not a req distributed by another higher
+        // level req.
+        // We have to log the query here as
+        // 1. It's useful to know the query before the processing start in case if the query stalls
+        // 2. The existing logging in SolrCore does not contain the query as query construction
+        // happens after the log
+        //    entries are added to rsp.toLog
+        if (log.isInfoEnabled()) {
+          log.info("Start External Search Query: {}", req.getParamString());
+        }
       }
     }
 


### PR DESCRIPTION
Disabling the start log for `/get` request. Initially we added this log debugging `select` request. Thus just keeping that log for select request only.

This reduces almost 33% of log lines as we make many get requests.