### PR TITLE
SAI-4737: System prop `solr.MaxBasicQueriesOverride` for surround query

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/SurroundQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/SurroundQParserPlugin.java
@@ -49,17 +49,25 @@ public class SurroundQParserPlugin extends QParserPlugin {
       try {
         int absoluteMaxBasicQueries = Integer.parseInt(maxBasicQueriesSystemProp);
         if (absoluteMaxBasicQueries > 0) {
-          log.info("maxBasicQueries with system property {} with value {}", MAX_BASIC_QUERIES_SYSTEM_PROP, maxBasicQueriesSystemProp);
+          log.info(
+              "maxBasicQueries with system property {} with value {}",
+              MAX_BASIC_QUERIES_SYSTEM_PROP,
+              maxBasicQueriesSystemProp);
           return absoluteMaxBasicQueries;
         } else {
-          log.info("Ignoring system property {} value {} since it is non-positive", MAX_BASIC_QUERIES_SYSTEM_PROP, maxBasicQueriesSystemProp);
+          log.info(
+              "Ignoring system property {} value {} since it is non-positive",
+              MAX_BASIC_QUERIES_SYSTEM_PROP,
+              maxBasicQueriesSystemProp);
         }
       } catch (NumberFormatException e) {
-        log.warn("Invalid system property {} value {}", MAX_BASIC_QUERIES_SYSTEM_PROP, maxBasicQueriesSystemProp);
-
+        log.warn(
+            "Invalid system property {} value {}",
+            MAX_BASIC_QUERIES_SYSTEM_PROP,
+            maxBasicQueriesSystemProp);
       }
     }
-    return -1; //-1 indicates no absolute max basic queries
+    return -1; // -1 indicates no absolute max basic queries
   }
 
   @Override
@@ -100,7 +108,11 @@ public class SurroundQParserPlugin extends QParserPlugin {
       }
 
       if (ABSOLUTE_MAX_BASIC_QUERIES > 0 && this.maxBasicQueries > ABSOLUTE_MAX_BASIC_QUERIES) {
-        log.info("Overriding maxBasicQueries from query {} with system property {} value {}", this.maxBasicQueries, MAX_BASIC_QUERIES_SYSTEM_PROP, ABSOLUTE_MAX_BASIC_QUERIES);
+        log.info(
+            "Overriding maxBasicQueries from query {} with system property {} value {}",
+            this.maxBasicQueries,
+            MAX_BASIC_QUERIES_SYSTEM_PROP,
+            ABSOLUTE_MAX_BASIC_QUERIES);
         this.maxBasicQueries = ABSOLUTE_MAX_BASIC_QUERIES;
       }
 

--- a/solr/core/src/java/org/apache/solr/search/SurroundQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/SurroundQParserPlugin.java
@@ -47,10 +47,10 @@ public class SurroundQParserPlugin extends QParserPlugin {
     String maxBasicQueriesSystemProp = System.getProperty(MAX_BASIC_QUERIES_SYSTEM_PROP);
     if (maxBasicQueriesSystemProp != null) {
       try {
-        int absoluteMaxBasicQueries = Integer.parseInt(maxBasicQueriesSystemProp);
-        if (absoluteMaxBasicQueries > 0) {
+        int maxBasicQueriesOverride = Integer.parseInt(maxBasicQueriesSystemProp);
+        if (maxBasicQueriesOverride > 0) {
           log.info("maxBasicQueries with system property {} with value {}", MAX_BASIC_QUERIES_SYSTEM_PROP, maxBasicQueriesSystemProp);
-          return absoluteMaxBasicQueries;
+          return maxBasicQueriesOverride;
         } else {
           log.info("Ignoring system property {} value {} since it is non-positive", MAX_BASIC_QUERIES_SYSTEM_PROP, maxBasicQueriesSystemProp);
         }

--- a/solr/core/src/java/org/apache/solr/search/SurroundQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/SurroundQParserPlugin.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 public class SurroundQParserPlugin extends QParserPlugin {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   public static final String NAME = "surround";
+  private static final String MAX_BASIC_QUERIES_SYSTEM_PROP = "solr.absoluteMaxBasicQueries";
 
   @Override
   public QParser createParser(
@@ -77,6 +78,21 @@ public class SurroundQParserPlugin extends QParserPlugin {
           this.maxBasicQueries = DEFMAXBASICQUERIES;
         }
       }
+      String maxBasicQueriesSystemProp = System.getProperty(MAX_BASIC_QUERIES_SYSTEM_PROP);
+      if (maxBasicQueriesSystemProp != null) {
+        try {
+          int absoluteMaxBasicQueries = Integer.parseInt(maxBasicQueriesSystemProp);
+          if (absoluteMaxBasicQueries > 0) {
+            log.info("Overriding maxBasicQueries with system property {} with value {}", MAX_BASIC_QUERIES_SYSTEM_PROP, maxBasicQueriesSystemProp);
+            this.maxBasicQueries = absoluteMaxBasicQueries;
+          } else {
+            log.info("Ignoring system property {} value {} since it is non-positive", MAX_BASIC_QUERIES_SYSTEM_PROP, maxBasicQueriesSystemProp);
+          }
+        } catch (NumberFormatException e) {
+          log.warn("Invalid system property {} value {}", MAX_BASIC_QUERIES_SYSTEM_PROP, maxBasicQueriesSystemProp);
+        }
+      }
+
       // ugh .. colliding ParseExceptions
       try {
         sq = org.apache.lucene.queryparser.surround.parser.QueryParser.parse(qstr);

--- a/solr/core/src/java/org/apache/solr/search/SurroundQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/SurroundQParserPlugin.java
@@ -40,10 +40,10 @@ import org.slf4j.LoggerFactory;
 public class SurroundQParserPlugin extends QParserPlugin {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   public static final String NAME = "surround";
-  private static final String MAX_BASIC_QUERIES_SYSTEM_PROP = "solr.absoluteMaxBasicQueries";
-  private static final int ABSOLUTE_MAX_BASIC_QUERIES = readAbsolutionMaxBasicQueries();
+  private static final String MAX_BASIC_QUERIES_SYSTEM_PROP = "solr.maxBasicQueriesOverride";
+  private static final int MAX_BASIC_QUERIES_OVERRIDE = readMaxBasicQueriesOverride();
 
-  private static int readAbsolutionMaxBasicQueries() {
+  private static int readMaxBasicQueriesOverride() {
     String maxBasicQueriesSystemProp = System.getProperty(MAX_BASIC_QUERIES_SYSTEM_PROP);
     if (maxBasicQueriesSystemProp != null) {
       try {
@@ -59,7 +59,7 @@ public class SurroundQParserPlugin extends QParserPlugin {
 
       }
     }
-    return -1; //-1 indicates no absolute max basic queries
+    return -1; //-1 indicates no max basic queries override
   }
 
   @Override
@@ -99,9 +99,8 @@ public class SurroundQParserPlugin extends QParserPlugin {
         }
       }
 
-      if (ABSOLUTE_MAX_BASIC_QUERIES > 0 && this.maxBasicQueries > ABSOLUTE_MAX_BASIC_QUERIES) {
-        log.info("Overriding maxBasicQueries from query {} with system property {} value {}", this.maxBasicQueries, MAX_BASIC_QUERIES_SYSTEM_PROP, ABSOLUTE_MAX_BASIC_QUERIES);
-        this.maxBasicQueries = ABSOLUTE_MAX_BASIC_QUERIES;
+      if (MAX_BASIC_QUERIES_OVERRIDE > 0) {
+        this.maxBasicQueries = MAX_BASIC_QUERIES_OVERRIDE;
       }
 
       // ugh .. colliding ParseExceptions

--- a/solr/core/src/java/org/apache/solr/search/SurroundQParserPlugin.java
+++ b/solr/core/src/java/org/apache/solr/search/SurroundQParserPlugin.java
@@ -49,17 +49,25 @@ public class SurroundQParserPlugin extends QParserPlugin {
       try {
         int maxBasicQueriesOverride = Integer.parseInt(maxBasicQueriesSystemProp);
         if (maxBasicQueriesOverride > 0) {
-          log.info("maxBasicQueries with system property {} with value {}", MAX_BASIC_QUERIES_SYSTEM_PROP, maxBasicQueriesSystemProp);
+          log.info(
+              "maxBasicQueries with system property {} with value {}",
+              MAX_BASIC_QUERIES_SYSTEM_PROP,
+              maxBasicQueriesSystemProp);
           return maxBasicQueriesOverride;
         } else {
-          log.info("Ignoring system property {} value {} since it is non-positive", MAX_BASIC_QUERIES_SYSTEM_PROP, maxBasicQueriesSystemProp);
+          log.info(
+              "Ignoring system property {} value {} since it is non-positive",
+              MAX_BASIC_QUERIES_SYSTEM_PROP,
+              maxBasicQueriesSystemProp);
         }
       } catch (NumberFormatException e) {
-        log.warn("Invalid system property {} value {}", MAX_BASIC_QUERIES_SYSTEM_PROP, maxBasicQueriesSystemProp);
-
+        log.warn(
+            "Invalid system property {} value {}",
+            MAX_BASIC_QUERIES_SYSTEM_PROP,
+            maxBasicQueriesSystemProp);
       }
     }
-    return -1; //-1 indicates no max basic queries override
+    return -1; // -1 indicates no max basic queries override
   }
 
   @Override


### PR DESCRIPTION
## Description
To add a System prop `solr.maxBasicQueriesOverride` which:
1. If undefined or set as non positive number, it will just behave exactly the same as w/o this change
2. Otherwise, `solr.maxBasicQueriesOverride` value will always override the param `maxBasicQueries` from surround query.

## Solution
Modified `SurroundQParserPlugin` to read the system property (this happens only once per class). 

Take note that this is meant to be a temporary property for testing. We should NOT have this value set in long run, it should respect the `maxBasicQueries` from query param eventually. 

## Tests
Tested locally with case of 11000 matches surround query: 
1. Query with `maxBasicQuery=10000` and no `solr.maxBasicQueriesOverride` -> TooManyBasicQueries error
2. Query with `maxBasicQuery=10000` and set system property  `solr.maxBasicQueriesOverride=15000` ->  No error

Take note that this is run on unit test case `MiniSolrCloudCluster` with `IndexSearcher.setMaxClauseCount(50_000)`. Otherwise the case would fail with `org.apache.solr.common.SolrException: org.apache.lucene.search.IndexSearcher$TooManyNestedClauses: Query contains too many nested clauses; maxClauseCount is set to 1024`

## Remarks
This change will apply the override on all orgs, so we cannot do per org control with this change. However, that's probably okay to do it per node only.