### PR TITLE
SAI-4630: now that it's possible to configure external tlogDir, we must delete them

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -161,6 +161,7 @@ import org.apache.solr.update.SolrCoreState;
 import org.apache.solr.update.SolrCoreState.IndexWriterCloser;
 import org.apache.solr.update.SolrIndexWriter;
 import org.apache.solr.update.UpdateHandler;
+import org.apache.solr.update.UpdateLog;
 import org.apache.solr.update.VersionInfo;
 import org.apache.solr.update.processor.DistributedUpdateProcessorFactory;
 import org.apache.solr.update.processor.LogUpdateProcessorFactory;
@@ -3321,10 +3322,34 @@ public class SolrCore implements SolrInfoBean, Closeable {
       }
     }
     if (deleteInstanceDir) {
+      // if ulogDir is outside dataDir and instanceDir, we have to remove it explicitly
+      UpdateHandler uh = getUpdateHandler();
+      UpdateLog ulog;
+      Path ulogDir = null;
+      if (uh != null && (ulog = uh.getUpdateLog()) != null) {
+        ulogDir = Path.of(ulog.getLogDir());
+        if (ulogDir.startsWith(desc.getInstanceDir())
+            || (deleteDataDir && ulogDir.startsWith(getDataDir()))) {
+          // ulogDir will be implicitly deleted
+          ulogDir = null;
+        }
+      }
+      Path explicitDeleteUlogDir = ulogDir;
       addCloseHook(
           new CloseHook() {
             @Override
             public void postClose(SolrCore core) {
+              if (explicitDeleteUlogDir != null) {
+                try {
+                  PathUtils.deleteDirectory(explicitDeleteUlogDir);
+                } catch (IOException e) {
+                  log.error(
+                      "Failed to delete external ulog dir for core: {} ulogDir: {}",
+                      name,
+                      explicitDeleteUlogDir,
+                      e);
+                }
+              }
               if (desc != null) {
                 try {
                   PathUtils.deleteDirectory(desc.getInstanceDir());
@@ -3343,8 +3368,9 @@ public class SolrCore implements SolrInfoBean, Closeable {
 
   public static void deleteUnloadedCore(
       CoreDescriptor cd, boolean deleteDataDir, boolean deleteInstanceDir) {
+    Path dataDir = null;
     if (deleteDataDir) {
-      Path dataDir = cd.getInstanceDir().resolve(cd.getDataDir());
+      dataDir = cd.getInstanceDir().resolve(cd.getDataDir());
       try {
         PathUtils.deleteDirectory(dataDir);
       } catch (IOException e) {
@@ -3356,6 +3382,23 @@ public class SolrCore implements SolrInfoBean, Closeable {
       }
     }
     if (deleteInstanceDir) {
+      String ulogDir = cd.getUlogDir();
+      if (ulogDir != null) {
+        Path ulogDirPath = Path.of(ulogDir);
+        if (!ulogDirPath.startsWith(cd.getInstanceDir())
+            && (!deleteDataDir || !ulogDirPath.startsWith(dataDir))) {
+          // if ulogDir is outside dataDir and instanceDir, we have to remove it explicitly
+          try {
+            PathUtils.deleteDirectory(ulogDirPath);
+          } catch (IOException e) {
+            log.error(
+                "Failed to delete external ulog dir for core: {} ulogDir: {}",
+                cd.getName(),
+                ulogDirPath,
+                e);
+          }
+        }
+      }
       try {
         PathUtils.deleteDirectory(cd.getInstanceDir());
       } catch (IOException e) {

--- a/solr/core/src/test/org/apache/solr/update/CustomTLogDirTest.java
+++ b/solr/core/src/test/org/apache/solr/update/CustomTLogDirTest.java
@@ -24,6 +24,7 @@ import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
+import org.apache.solr.core.CoreContainer;
 import org.apache.solr.util.EmbeddedSolrServerTestRule;
 import org.apache.solr.util.SolrClientTestRule;
 import org.junit.ClassRule;
@@ -162,5 +163,8 @@ public class CustomTLogDirTest extends SolrTestCaseJ4 {
 
     assertNotNull(list);
     assertEquals(1, list.length);
+    CoreContainer cc = ((EmbeddedSolrServer) client).getCoreContainer();
+    cc.unload(collectionName, true, true, true);
+    assertFalse(resolvedTlogDir.toFile().exists());
   }
 }


### PR DESCRIPTION
 see [SOLR-16962](https://issues.apache.org/jira/browse/SOLR-16962)/[SOLR-6537](https://issues.apache.org/jira/browse/SOLR-6537)