### PR TITLE
SAI-4784 : `SearchHandler` might ignore shard exception with shards.tolerant=true

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -581,7 +581,8 @@ public class SearchHandler extends RequestHandlerBase
               responsesWithException.forEach(r -> log.warn("Shard request failed : {}", r));
 
               // If things are not tolerant, abort everything and rethrow
-              Throwable nonTolerableException = findNonTolerableException(tolerant, responsesWithException);
+              Throwable nonTolerableException =
+                  findNonTolerableException(tolerant, responsesWithException);
               if (nonTolerableException != null) {
                 shardHandler1.cancelAll();
                 if (nonTolerableException instanceof SolrException) {
@@ -652,28 +653,37 @@ public class SearchHandler extends RequestHandlerBase
   }
 
   static List<ShardResponse> findResponsesWithException(ShardResponse response) {
-    //a single response instance can contain multiple responses
+    // a single response instance can contain multiple responses
     Set<ShardResponse> allResponses = new LinkedHashSet<>();
     if (response.getShardRequest() != null) {
       allResponses.addAll(response.getShardRequest().responses);
     }
 
-    //the original response might or might not be a part of response.getShardRequest().responses...
+    // the original response might or might not be a part of response.getShardRequest().responses...
     allResponses.add(response);
     return allResponses.stream().filter(r -> r.getException() != null).collect(Collectors.toList());
   }
 
   static Throwable findNonTolerableException(boolean tolerant, List<ShardResponse> responses) {
-    if (tolerant) { //if tolerant, see if there are any responses with non-tolerant error codes
-      Optional<ShardResponse> nonTolerableResponse = responses.stream().filter(r -> NONTOLERANT_ERROR_CODES.contains(SolrException.ErrorCode.getErrorCode(r.getRspCode()))).findFirst();
+    if (tolerant) { // if tolerant, see if there are any responses with non-tolerant error codes
+      Optional<ShardResponse> nonTolerableResponse =
+          responses.stream()
+              .filter(
+                  r ->
+                      NONTOLERANT_ERROR_CODES.contains(
+                          SolrException.ErrorCode.getErrorCode(r.getRspCode())))
+              .findFirst();
       return nonTolerableResponse.map(ShardResponse::getException).orElse(null);
-    } else { //cannot tolerate any exception
-      return responses.stream().filter(r -> r.getException() != null).findFirst().map(ShardResponse::getException).orElse(null);
+    } else { // cannot tolerate any exception
+      return responses.stream()
+          .filter(r -> r.getException() != null)
+          .findFirst()
+          .map(ShardResponse::getException)
+          .orElse(null);
     }
   }
 
   private static final List<String> VERBOSE_LOGGING_PARAMS = Arrays.asList("fq", "json");
-
 
   private SolrParams removeVerboseParams(final SolrParams params) {
     // Filter params by removing kv of VERBOSE_LOGGING_PARAMS, so that we can then call toString

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -30,13 +30,16 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.apache.lucene.index.ExitableDirectoryReader;
 import org.apache.lucene.queryparser.surround.query.TooManyBasicQueries;
@@ -572,18 +575,20 @@ public class SearchHandler extends RequestHandlerBase
             if (srsp == null) break; // no more requests to wait for
 
             // Was there an exception?
-            if (srsp.getException() != null) {
-              log.warn("Shard request failed : {}", srsp);
+            List<ShardResponse> responsesWithException = findResponsesWithException(srsp);
+
+            if (!responsesWithException.isEmpty()) {
+              responsesWithException.forEach(r -> log.warn("Shard request failed : {}", r));
+
               // If things are not tolerant, abort everything and rethrow
-              if (!tolerant
-                  || NONTOLERANT_ERROR_CODES.contains(
-                      SolrException.ErrorCode.getErrorCode(srsp.getRspCode()))) {
+              Throwable nonTolerableException = findNonTolerableException(tolerant, responsesWithException);
+              if (nonTolerableException != null) {
                 shardHandler1.cancelAll();
-                if (srsp.getException() instanceof SolrException) {
-                  throw (SolrException) srsp.getException();
+                if (nonTolerableException instanceof SolrException) {
+                  throw (SolrException) nonTolerableException;
                 } else {
                   throw new SolrException(
-                      SolrException.ErrorCode.SERVER_ERROR, srsp.getException());
+                      SolrException.ErrorCode.SERVER_ERROR, nonTolerableException);
                 }
               } else {
                 rsp.getResponseHeader()
@@ -646,7 +651,29 @@ public class SearchHandler extends RequestHandlerBase
     }
   }
 
+  static List<ShardResponse> findResponsesWithException(ShardResponse response) {
+    //a single response instance can contain multiple responses
+    Set<ShardResponse> allResponses = new LinkedHashSet<>();
+    if (response.getShardRequest() != null) {
+      allResponses.addAll(response.getShardRequest().responses);
+    }
+
+    //the original response might or might not be a part of response.getShardRequest().responses...
+    allResponses.add(response);
+    return allResponses.stream().filter(r -> r.getException() != null).collect(Collectors.toList());
+  }
+
+  static Throwable findNonTolerableException(boolean tolerant, List<ShardResponse> responses) {
+    if (tolerant) { //if tolerant, see if there are any responses with non-tolerant error codes
+      Optional<ShardResponse> nonTolerableResponse = responses.stream().filter(r -> NONTOLERANT_ERROR_CODES.contains(SolrException.ErrorCode.getErrorCode(r.getRspCode()))).findFirst();
+      return nonTolerableResponse.map(ShardResponse::getException).orElse(null);
+    } else { //cannot tolerate any exception
+      return responses.stream().filter(r -> r.getException() != null).findFirst().map(ShardResponse::getException).orElse(null);
+    }
+  }
+
   private static final List<String> VERBOSE_LOGGING_PARAMS = Arrays.asList("fq", "json");
+
 
   private SolrParams removeVerboseParams(final SolrParams params) {
     // Filter params by removing kv of VERBOSE_LOGGING_PARAMS, so that we can then call toString

--- a/solr/core/src/test/org/apache/solr/handler/component/SearchHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/SearchHandlerTest.java
@@ -383,6 +383,80 @@ public class SearchHandlerTest extends SolrTestCaseJ4 {
     }
   }
 
+  @Test
+  public void testFindResponsesWithException() {
+    ShardResponse response1 = new ShardResponse();
+    ShardResponse response2 = new ShardResponse();
+    ShardRequest request = new ShardRequest();
+    response1.setShardRequest(request);
+    response2.setShardRequest(request);
+
+    //shards.tolerant=false - single response with no exception
+    request.responses.add(response1);
+    assertEquals(List.of(), SearchHandler.findResponsesWithException(response1));
+
+    //shards.tolerant=false - multiple responses with no exception
+    request.responses.add(response2);
+    assertEquals(List.of(), SearchHandler.findResponsesWithException(response2));
+
+    //shards.tolerant=false - first response with exception
+    request.responses.clear(); //nothing in responses based on HttpShardHandler#take
+    response1.setException(new Exception());
+    assertEquals(List.of(response1), SearchHandler.findResponsesWithException(response1));
+
+    //shards.tolerant=false - second response with exception
+    response1.setException(null);
+    response2.setException(new Exception());
+    request.responses.add(response1); //only response1 will be in responses based on HttpShardHandler#take
+    assertEquals(List.of(response2), SearchHandler.findResponsesWithException(response2));
+
+    //shards.tolerant=true - multiple responses no exception
+    response1 = new ShardResponse();
+    response2 = new ShardResponse();
+    request = new ShardRequest();
+    request.responses.add(response1);
+    request.responses.add(response2);
+    response1.setShardRequest(request);
+    response2.setShardRequest(request);
+
+    //the last response - response2 will be used as argument
+    assertEquals(List.of(), SearchHandler.findResponsesWithException(response2));
+
+    //shards.tolerant=true - exception on response1
+    response1.setException(new Exception());
+    //the last response - response2 will be used as argument, however response1 should be located as one that gives exception
+    assertEquals(List.of(response1), SearchHandler.findResponsesWithException(response2));
+
+    //shards.tolerant=true - exception on both response1 and response2
+    response2.setException(new Exception());
+    //the last response - response2 will be used as argument, both responses should be included in the result, with correct ordering and no duplicates
+    assertEquals(List.of(response1, response2), SearchHandler.findResponsesWithException(response2));
+  }
+
+  public void testFindNonTolerableException() {
+    ShardResponse response1 = new ShardResponse();
+    ShardResponse response2 = new ShardResponse();
+    ShardRequest request = new ShardRequest();
+    response1.setShardRequest(request);
+    response2.setShardRequest(request);
+
+    Exception exception1 = new Exception("exception1");
+    response1.setResponseCode(429); //tolerable response code
+    response1.setException(exception1);
+    Exception exception2 = new Exception("exception2");
+    response2.setResponseCode(400); //non-tolerable response code
+    response2.setException(exception2);
+
+    //shards.tolerant=false
+    assertEquals(exception1, SearchHandler.findNonTolerableException(false, List.of(response1)));
+
+    //shards.tolerant=true
+    assertEquals(null, SearchHandler.findNonTolerableException(true, List.of(response1)));
+
+    //shards.tolerant=true
+    assertEquals(exception2, SearchHandler.findNonTolerableException(true, List.of(response1, response2)));
+  }
+
   private static <T> T getRandomEntry(Collection<T> collection) {
     if (null == collection || collection.isEmpty()) return null;
 

--- a/solr/core/src/test/org/apache/solr/handler/component/SearchHandlerTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/SearchHandlerTest.java
@@ -391,26 +391,27 @@ public class SearchHandlerTest extends SolrTestCaseJ4 {
     response1.setShardRequest(request);
     response2.setShardRequest(request);
 
-    //shards.tolerant=false - single response with no exception
+    // shards.tolerant=false - single response with no exception
     request.responses.add(response1);
     assertEquals(List.of(), SearchHandler.findResponsesWithException(response1));
 
-    //shards.tolerant=false - multiple responses with no exception
+    // shards.tolerant=false - multiple responses with no exception
     request.responses.add(response2);
     assertEquals(List.of(), SearchHandler.findResponsesWithException(response2));
 
-    //shards.tolerant=false - first response with exception
-    request.responses.clear(); //nothing in responses based on HttpShardHandler#take
+    // shards.tolerant=false - first response with exception
+    request.responses.clear(); // nothing in responses based on HttpShardHandler#take
     response1.setException(new Exception());
     assertEquals(List.of(response1), SearchHandler.findResponsesWithException(response1));
 
-    //shards.tolerant=false - second response with exception
+    // shards.tolerant=false - second response with exception
     response1.setException(null);
     response2.setException(new Exception());
-    request.responses.add(response1); //only response1 will be in responses based on HttpShardHandler#take
+    request.responses.add(
+        response1); // only response1 will be in responses based on HttpShardHandler#take
     assertEquals(List.of(response2), SearchHandler.findResponsesWithException(response2));
 
-    //shards.tolerant=true - multiple responses no exception
+    // shards.tolerant=true - multiple responses no exception
     response1 = new ShardResponse();
     response2 = new ShardResponse();
     request = new ShardRequest();
@@ -419,18 +420,21 @@ public class SearchHandlerTest extends SolrTestCaseJ4 {
     response1.setShardRequest(request);
     response2.setShardRequest(request);
 
-    //the last response - response2 will be used as argument
+    // the last response - response2 will be used as argument
     assertEquals(List.of(), SearchHandler.findResponsesWithException(response2));
 
-    //shards.tolerant=true - exception on response1
+    // shards.tolerant=true - exception on response1
     response1.setException(new Exception());
-    //the last response - response2 will be used as argument, however response1 should be located as one that gives exception
+    // the last response - response2 will be used as argument, however response1 should be located
+    // as one that gives exception
     assertEquals(List.of(response1), SearchHandler.findResponsesWithException(response2));
 
-    //shards.tolerant=true - exception on both response1 and response2
+    // shards.tolerant=true - exception on both response1 and response2
     response2.setException(new Exception());
-    //the last response - response2 will be used as argument, both responses should be included in the result, with correct ordering and no duplicates
-    assertEquals(List.of(response1, response2), SearchHandler.findResponsesWithException(response2));
+    // the last response - response2 will be used as argument, both responses should be included in
+    // the result, with correct ordering and no duplicates
+    assertEquals(
+        List.of(response1, response2), SearchHandler.findResponsesWithException(response2));
   }
 
   public void testFindNonTolerableException() {
@@ -441,20 +445,21 @@ public class SearchHandlerTest extends SolrTestCaseJ4 {
     response2.setShardRequest(request);
 
     Exception exception1 = new Exception("exception1");
-    response1.setResponseCode(429); //tolerable response code
+    response1.setResponseCode(429); // tolerable response code
     response1.setException(exception1);
     Exception exception2 = new Exception("exception2");
-    response2.setResponseCode(400); //non-tolerable response code
+    response2.setResponseCode(400); // non-tolerable response code
     response2.setException(exception2);
 
-    //shards.tolerant=false
+    // shards.tolerant=false
     assertEquals(exception1, SearchHandler.findNonTolerableException(false, List.of(response1)));
 
-    //shards.tolerant=true
+    // shards.tolerant=true
     assertEquals(null, SearchHandler.findNonTolerableException(true, List.of(response1)));
 
-    //shards.tolerant=true
-    assertEquals(exception2, SearchHandler.findNonTolerableException(true, List.of(response1, response2)));
+    // shards.tolerant=true
+    assertEquals(
+        exception2, SearchHandler.findNonTolerableException(true, List.of(response1, response2)));
   }
 
   private static <T> T getRandomEntry(Collection<T> collection) {


### PR DESCRIPTION
## Description
It is found that `SearchHandler` sometimes does not re-throw the shard exception even if the shard response was `400` (one of the non-tolerant response codes that should re-throw exception despite shards.tolerant=true)

Based on the pattern, it appears that this happens when the last shard response was OK

## Cause
The existing handling in [HttpShardHandler](https://github.com/cowpaths/fullstory-solr/blob/fs/branch_9x/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java#L238-L260) would accumulate multiple `ShardResponse` in the `response.getShardRequest().responses`, while only the last one would be returned by such method.

Therefore, for `shards.tolerant=true`, if exceptions occurred in any of the shard response but not the last shard response, then the logic would not be able to [identify the exception](https://github.com/cowpaths/fullstory-solr/blob/fs/branch_9x/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java#L575). For example, `response.getShardRequest().responses` might have [response1, response2, response3], even if response2 has exception, the one returned by the method is response3, which `.getException` is null

## Solution
Added 2 methods:
`findResponsesWithException(ShardResponse)` -  From the param, find all of the responses either embedded in the param or the param itself with exception. Preserving the ordering and avoid duplicates.

`findNonTolerableException(boolean, List<ShardResponse>)` - first boolean indicates whether we are tolerant. Then from the list of `ShardResponse`s, find if the first exception that we should rethrow from SearchHandler.


Extracted those 2 methods for easier unit testing. There are few combinations of `ShardResponse` that we should test on

## Remarks
This could increase the # of failure returned to the client. At least for surround query, most of the errors were likely obscured by the last OK shard responses, which usually take the longest to compute since it didn't hit the limit.