### PR TITLE
SizeAwareDirectory can also optimize single-file fileLength calculation

### DIFF
--- a/solr/core/src/java/org/apache/solr/storage/AccessDirectory.java
+++ b/solr/core/src/java/org/apache/solr/storage/AccessDirectory.java
@@ -22,9 +22,11 @@ import static org.apache.solr.storage.CompressingDirectory.COMPRESSION_BLOCK_MAS
 import static org.apache.solr.storage.CompressingDirectory.COMPRESSION_BLOCK_SHIFT;
 import static org.apache.solr.storage.CompressingDirectory.COMPRESSION_BLOCK_SIZE;
 import static org.apache.solr.storage.CompressingDirectory.DirectIOIndexOutput.HEADER_SIZE;
+import static org.apache.solr.storage.CompressingDirectory.readLengthFromHeader;
 
 import java.io.Closeable;
 import java.io.EOFException;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -39,6 +41,7 @@ import java.nio.LongBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -134,11 +137,19 @@ public class AccessDirectory extends MMapDirectory {
     try {
       return super.fileLength(name);
     } catch (NoSuchFileException | FileNotFoundException ex) {
-      LazyEntry lazy = open(name);
-      if (lazy == null) {
-        throw ex;
-      } else {
+      // we don't want to lazy `open()` here, because if all we want is the fileLength (which
+      // is sometimes done from a context where the file doesn't exist, and shouldn't be
+      // restored), then we don't want to incur the hit of restoring and mapping the lazy file.
+      LazyEntry lazy = activeLazy.get(name);
+      if (lazy != null) {
         return lazy.input.length();
+      } else {
+        try {
+          return readLengthFromHeader(compressedPath.resolve(name));
+        } catch (Throwable t) {
+          t.addSuppressed(ex);
+          throw t;
+        }
       }
     }
   }

--- a/solr/core/src/java/org/apache/solr/storage/AccessDirectory.java
+++ b/solr/core/src/java/org/apache/solr/storage/AccessDirectory.java
@@ -26,7 +26,6 @@ import static org.apache.solr.storage.CompressingDirectory.readLengthFromHeader;
 
 import java.io.Closeable;
 import java.io.EOFException;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -41,7 +40,6 @@ import java.nio.LongBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;

--- a/solr/core/src/java/org/apache/solr/storage/CompressingDirectory.java
+++ b/solr/core/src/java/org/apache/solr/storage/CompressingDirectory.java
@@ -129,6 +129,10 @@ public class CompressingDirectory extends FSDirectory {
     if (getPendingDeletions().contains(name)) {
       throw new NoSuchFileException("file \"" + name + "\" is pending delete");
     }
+    return readLengthFromHeader(path);
+  }
+
+  public static long readLengthFromHeader(Path path) throws IOException {
     if (Files.size(path) < Long.BYTES) {
       return 0;
     } else {

--- a/solr/core/src/java/org/apache/solr/storage/SizeAwareDirectory.java
+++ b/solr/core/src/java/org/apache/solr/storage/SizeAwareDirectory.java
@@ -78,6 +78,19 @@ public class SizeAwareDirectory extends FilterDirectory
   }
 
   @Override
+  public long fileLength(String name) throws IOException {
+    Long ret = fileSizeMap.get(name);
+    SizeAccountingIndexOutput live;
+    if (ret != null) {
+      return ret;
+    } else if ((live = liveOutputs.get(name)) != null) {
+      return live.backing.getFilePointer();
+    } else {
+      return super.fileLength(name);
+    }
+  }
+
+  @Override
   public long size() throws IOException {
     Integer reconcileThreshold = CoreAdminHandler.getReconcileThreshold();
     if (initialized

--- a/solr/core/src/java/org/apache/solr/storage/SizeAwareDirectory.java
+++ b/solr/core/src/java/org/apache/solr/storage/SizeAwareDirectory.java
@@ -86,7 +86,8 @@ public class SizeAwareDirectory extends FilterDirectory
     } else if ((live = liveOutputs.get(name)) != null) {
       return live.backing.getFilePointer();
     } else {
-      return super.fileLength(name);
+      // fallback delegate to wrapped Directory
+      return in.fileLength(name);
     }
   }
 


### PR DESCRIPTION
this needs still to be ported to `fs/branch_9x`, along with the other TeeDirectory-related code.