### PR TITLE
Backport SOLR-17063 LogWatcher memory leak fix from upstream branch_9x

### DIFF
--- a/solr/core/src/java/org/apache/solr/logging/jul/JulWatcher.java
+++ b/solr/core/src/java/org/apache/solr/logging/jul/JulWatcher.java
@@ -145,11 +145,6 @@ public class JulWatcher extends LogWatcher<LogRecord> {
   }
 
   @Override
-  public long getTimestamp(LogRecord event) {
-    return event.getMillis();
-  }
-
-  @Override
   public SolrDocument toSolrDocument(LogRecord event) {
     SolrDocument doc = new SolrDocument();
     doc.setField("time", new Date(event.getMillis()));

--- a/solr/core/src/java/org/apache/solr/logging/log4j2/Log4j2Watcher.java
+++ b/solr/core/src/java/org/apache/solr/logging/log4j2/Log4j2Watcher.java
@@ -261,7 +261,7 @@ public class Log4j2Watcher extends LogWatcher<LogEvent> {
   public void registerListener(ListenerConfig cfg) {
     if (history != null) throw new IllegalStateException("History already registered");
 
-    history = new CircularList<LogEvent>(cfg.size);
+    history = new CircularList<>(cfg.size);
 
     Level threshold = (cfg.threshold != null) ? Level.toLevel(cfg.threshold) : Level.WARN;
     ThresholdFilter filter =
@@ -279,11 +279,6 @@ public class Log4j2Watcher extends LogWatcher<LogEvent> {
 
     config.addAppender(appender, threshold, filter);
     ctx.updateLoggers();
-  }
-
-  @Override
-  public long getTimestamp(LogEvent event) {
-    return event.getTimeMillis();
   }
 
   @Override

--- a/solr/core/src/test/org/apache/solr/logging/TestLogWatcher.java
+++ b/solr/core/src/test/org/apache/solr/logging/TestLogWatcher.java
@@ -16,17 +16,31 @@
  */
 package org.apache.solr.logging;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.StringWriter;
 import java.lang.invoke.MethodHandles;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.common.MapWriter;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
+import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.TimeSource;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.request.SolrQueryRequestBase;
+import org.apache.solr.response.BinaryQueryResponseWriter;
+import org.apache.solr.response.JSONResponseWriter;
+import org.apache.solr.response.JacksonJsonWriter;
+import org.apache.solr.response.QueryResponseWriter;
+import org.apache.solr.response.SolrQueryResponse;
 import org.apache.solr.util.TimeOut;
 import org.junit.Before;
 import org.junit.Test;
+import org.noggit.CharArr;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,7 +59,7 @@ public class TestLogWatcher extends SolrTestCaseJ4 {
   //       All we really care about is that new watchers get the new messages, so test for that
   //       explicitly. See SOLR-12732.
   @Test
-  public void testLog4jWatcher() throws InterruptedException {
+  public void testLog4jWatcher() throws InterruptedException, IOException {
     LogWatcher<?> watcher = null;
     int lim = random().nextInt(3) + 2;
     // Every time through this loop, ensure that, of all the test messages that have been logged,
@@ -65,9 +79,12 @@ public class TestLogWatcher extends SolrTestCaseJ4 {
       boolean foundNewMsg = false;
       boolean foundOldMessage = false;
       // In local testing this loop usually succeeds 1-2 tries, so it's not very expensive to loop.
+      QueryResponseWriter responseWriter =
+          random().nextBoolean() ? new JacksonJsonWriter() : new JSONResponseWriter();
       do {
         // Returns an empty (but non-null) list even if there are no messages yet.
         SolrDocumentList events = watcher.getHistory(-1, null);
+        validateWrite(responseWriter, events, msg);
         for (SolrDocument doc : events) {
           String oneMsg = (String) doc.get("message");
           if (oneMsg.equals(msg)) {
@@ -103,5 +120,57 @@ public class TestLogWatcher extends SolrTestCaseJ4 {
       }
       oldMessages.add(msg);
     }
+  }
+
+  /**
+   * Here we validate that serialization works as expected for several different methods. Ideally we
+   * would use actual serialization from Jersey/Jackson, since this is what really happens in V2
+   * APIs. But this is simpler, and should give us roughly equivalent assurances.
+   */
+  private static void validateWrite(
+      QueryResponseWriter responseWriter, SolrDocumentList docs, String expectMsg)
+      throws IOException {
+    SolrQueryRequest req = new SolrQueryRequestBase(null, new ModifiableSolrParams()) {};
+    SolrQueryResponse rsp = new SolrQueryResponse();
+    rsp.addResponse(docs);
+    String output;
+    if (responseWriter instanceof BinaryQueryResponseWriter) {
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      ((BinaryQueryResponseWriter) responseWriter).write(baos, req, rsp);
+      baos.close();
+      output = baos.toString(StandardCharsets.UTF_8);
+    } else {
+      StringWriter writer = new StringWriter();
+      responseWriter.write(writer, req, rsp);
+      writer.close();
+      output = writer.toString();
+    }
+    assertTrue("found: " + output, output.contains(expectMsg));
+    validateWrite(docs, expectMsg);
+  }
+
+  private static void validateWrite(SolrDocumentList docs, String expectMsg) throws IOException {
+    CharArr arr = new CharArr();
+    org.noggit.JSONWriter w = new org.noggit.JSONWriter(arr, 2);
+    docs.writeMap(
+        new MapWriter.EntryWriter() {
+          boolean first = true;
+
+          @Override
+          public MapWriter.EntryWriter put(CharSequence k, Object v) {
+            if (first) {
+              first = false;
+            } else {
+              w.writeValueSeparator();
+            }
+            w.indent();
+            w.writeString(k.toString());
+            w.writeNameSeparator();
+            w.write(v);
+            return this;
+          }
+        });
+    String output = arr.toString();
+    assertTrue("found: " + output, output.contains(expectMsg));
   }
 }

--- a/solr/core/src/test/org/apache/solr/logging/TestLogWatcher.java
+++ b/solr/core/src/test/org/apache/solr/logging/TestLogWatcher.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.solr.SolrTestCaseJ4;
-import org.apache.solr.common.MapWriter;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.params.ModifiableSolrParams;
@@ -152,24 +151,7 @@ public class TestLogWatcher extends SolrTestCaseJ4 {
   private static void validateWrite(SolrDocumentList docs, String expectMsg) throws IOException {
     CharArr arr = new CharArr();
     org.noggit.JSONWriter w = new org.noggit.JSONWriter(arr, 2);
-    docs.writeMap(
-        new MapWriter.EntryWriter() {
-          boolean first = true;
-
-          @Override
-          public MapWriter.EntryWriter put(CharSequence k, Object v) {
-            if (first) {
-              first = false;
-            } else {
-              w.writeValueSeparator();
-            }
-            w.indent();
-            w.writeString(k.toString());
-            w.writeNameSeparator();
-            w.write(v);
-            return this;
-          }
-        });
+    w.write(docs);
     String output = arr.toString();
     assertTrue("found: " + output, output.contains(expectMsg));
   }


### PR DESCRIPTION
This is a straight cherry-pick, so opening this PR against `fs/branch_9_3`. The included cherry-picks are included in upstream 9.5 and 9.6 releases, respectively.