### PR TITLE
Adding config option for ignored directories for core loader to allow skipping subdirectories that don't have cores

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -377,7 +377,7 @@ public class CoreContainer {
   }
 
   public CoreContainer(NodeConfig config, boolean asyncSolrCoreLoad) {
-    this(config, new CorePropertiesLocator(config.getCoreRootDirectory()), asyncSolrCoreLoad);
+    this(config, new CorePropertiesLocator(config.getCoreRootDirectory(), config.getCoreRootIgnoredDirectories()), asyncSolrCoreLoad);
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -377,7 +377,11 @@ public class CoreContainer {
   }
 
   public CoreContainer(NodeConfig config, boolean asyncSolrCoreLoad) {
-    this(config, new CorePropertiesLocator(config.getCoreRootDirectory(), config.getCoreRootIgnoredDirectories()), asyncSolrCoreLoad);
+    this(
+        config,
+        new CorePropertiesLocator(
+            config.getCoreRootDirectory(), config.getCoreRootIgnoredDirectories()),
+        asyncSolrCoreLoad);
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/core/CorePropertiesLocator.java
+++ b/solr/core/src/java/org/apache/solr/core/CorePropertiesLocator.java
@@ -51,8 +51,15 @@ public class CorePropertiesLocator implements CoresLocator {
 
   private final Path rootDirectory;
 
+  private final Set<Path> ignoredDirectories;
+
   public CorePropertiesLocator(Path coreDiscoveryRoot) {
+    this(coreDiscoveryRoot, null);
+  }
+
+  public CorePropertiesLocator(Path coreDiscoveryRoot, Set<Path> ignoredDirectories) {
     this.rootDirectory = coreDiscoveryRoot;
+    this.ignoredDirectories = ignoredDirectories;
     log.debug("Config-defined core root directory: {}", this.rootDirectory);
   }
 
@@ -145,6 +152,18 @@ public class CorePropertiesLocator implements CoresLocator {
           options,
           maxDepth,
           new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir,
+                                                     BasicFileAttributes attr)
+                    throws IOException {
+              for (Path i : ignoredDirectories) {
+                if (dir.startsWith(i)) {
+                  return FileVisitResult.SKIP_SUBTREE;
+                }
+              }
+              return FileVisitResult.CONTINUE;
+            }
+
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
                 throws IOException {

--- a/solr/core/src/java/org/apache/solr/core/CorePropertiesLocator.java
+++ b/solr/core/src/java/org/apache/solr/core/CorePropertiesLocator.java
@@ -155,9 +155,11 @@ public class CorePropertiesLocator implements CoresLocator {
             @Override
             public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attr)
                 throws IOException {
-              for (Path i : ignoredDirectories) {
-                if (dir.startsWith(i)) {
-                  return FileVisitResult.SKIP_SUBTREE;
+              if (ignoredDirectories != null) {
+                for (Path i : ignoredDirectories) {
+                  if (dir.startsWith(i)) {
+                    return FileVisitResult.SKIP_SUBTREE;
+                  }
                 }
               }
               return FileVisitResult.CONTINUE;

--- a/solr/core/src/java/org/apache/solr/core/CorePropertiesLocator.java
+++ b/solr/core/src/java/org/apache/solr/core/CorePropertiesLocator.java
@@ -153,9 +153,8 @@ public class CorePropertiesLocator implements CoresLocator {
           maxDepth,
           new SimpleFileVisitor<>() {
             @Override
-            public FileVisitResult preVisitDirectory(Path dir,
-                                                     BasicFileAttributes attr)
-                    throws IOException {
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attr)
+                throws IOException {
               for (Path i : ignoredDirectories) {
                 if (dir.startsWith(i)) {
                   return FileVisitResult.SKIP_SUBTREE;

--- a/solr/core/src/java/org/apache/solr/core/NodeConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/NodeConfig.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -55,6 +56,8 @@ public class NodeConfig {
   private final String nodeName;
 
   private final Path coreRootDirectory;
+
+  private final Set<Path> coreRootIgnoredDirectories;
 
   private final Path solrDataHome;
 
@@ -120,6 +123,7 @@ public class NodeConfig {
   private NodeConfig(
       String nodeName,
       Path coreRootDirectory,
+      Set<Path> coreRootIgnoredDirectories,
       Path solrDataHome,
       Integer booleanQueryMaxClauseCount,
       Path configSetBaseDirectory,
@@ -155,6 +159,7 @@ public class NodeConfig {
     // all Path params here are absolute and normalized.
     this.nodeName = nodeName;
     this.coreRootDirectory = coreRootDirectory;
+    this.coreRootIgnoredDirectories = coreRootIgnoredDirectories;
     this.solrDataHome = solrDataHome;
     this.booleanQueryMaxClauseCount = booleanQueryMaxClauseCount;
     this.configSetBaseDirectory = configSetBaseDirectory;
@@ -260,6 +265,10 @@ public class NodeConfig {
   /** Absolute. */
   public Path getCoreRootDirectory() {
     return coreRootDirectory;
+  }
+
+  public Set<Path> getCoreRootIgnoredDirectories() {
+    return coreRootIgnoredDirectories;
   }
 
   /** Absolute. */
@@ -575,6 +584,7 @@ public class NodeConfig {
     // all Path fields here are absolute and normalized.
     private SolrResourceLoader loader;
     private Path coreRootDirectory;
+    private Set<Path> coreRootIgnoredDirectories;
     private Path solrDataHome;
     private Integer booleanQueryMaxClauseCount;
     private Path configSetBaseDirectory;
@@ -649,6 +659,12 @@ public class NodeConfig {
 
     public NodeConfigBuilder setCoreRootDirectory(String coreRootDirectory) {
       this.coreRootDirectory = solrHome.resolve(coreRootDirectory).normalize();
+      return this;
+    }
+
+    public NodeConfigBuilder setCoreRootIgnoredDirectories(Set<Path> coreRootIgnoredDirectories) {
+      this.coreRootIgnoredDirectories = new HashSet<>();
+      this.coreRootIgnoredDirectories.addAll(coreRootIgnoredDirectories);
       return this;
     }
 
@@ -857,6 +873,7 @@ public class NodeConfig {
       return new NodeConfig(
           nodeName,
           coreRootDirectory,
+          coreRootIgnoredDirectories,
           solrDataHome,
           booleanQueryMaxClauseCount,
           configSetBaseDirectory,

--- a/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
@@ -349,6 +349,8 @@ public class SolrXmlConfig {
               case "coreRootDirectory":
                 builder.setCoreRootDirectory(it.txt());
                 break;
+              case "coreRootIgnoredDirectories":
+                builder.setCoreRootIgnoredDirectories(separatePaths(it.txt()));
               case "solrDataHome":
                 builder.setSolrDataHome(it.txt());
                 break;

--- a/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrXmlConfig.java
@@ -351,6 +351,7 @@ public class SolrXmlConfig {
                 break;
               case "coreRootIgnoredDirectories":
                 builder.setCoreRootIgnoredDirectories(separatePaths(it.txt()));
+                break;
               case "solrDataHome":
                 builder.setSolrDataHome(it.txt());
                 break;


### PR DESCRIPTION
This allows for adding a property to solr.xml:
```
<str name="coreRootIgnoredDirectories">${solr.solr.home}/access</str>
```
which will provide a comma separated list of directories that should be skipped when loading cores.

This is an optimization for TeeDirectory since we currently have our access directory under the coreRootDirectory where it looks for cores to load. We will not find cores to load in the access directory since the access directory copies don't have core.properties so this will allow us to skip those directories.