### PR TITLE
Facet merger bit sets.

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/facet/FacetMerger.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetMerger.java
@@ -44,7 +44,8 @@ public abstract class FacetMerger {
   public static class Context {
     // FacetComponentState state;  // todo: is this needed?
     final int numShards;
-    // BitSet per shard, each bit set holds bucket nums for whether or not a bucket has been seen for a given shard.
+    // BitSet per shard, each bit set holds bucket nums for whether or not a bucket has been seen
+    // for a given shard.
     private final BitSet[] sawShard;
     // bucket1_shard1, bucket1_shard2]
     private final Map<String, Integer> shardmap = new HashMap<>();

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetMerger.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetMerger.java
@@ -44,13 +44,14 @@ public abstract class FacetMerger {
   public static class Context {
     // FacetComponentState state;  // todo: is this needed?
     final int numShards;
-    // [bucket0_shard0, bucket0_shard1, bucket0_shard2,  bucket1_shard0,
-    private final BitSet sawShard = new BitSet();
+    // BitSet per shard, each bit set holds bucket nums for whether or not a bucket has been seen for a given shard.
+    private final BitSet[] sawShard;
     // bucket1_shard1, bucket1_shard2]
-    private Map<String, Integer> shardmap = new HashMap<>();
+    private final Map<String, Integer> shardmap = new HashMap<>();
 
     public Context(int numShards) {
       this.numShards = numShards;
+      this.sawShard = new BitSet[numShards];
     }
 
     Object root; // per-shard response
@@ -75,11 +76,17 @@ public abstract class FacetMerger {
 
     public void setShardFlag(int bucketNum) {
       // rely on normal bitset expansion (uses a doubling strategy)
-      sawShard.set(bucketNum * numShards + shardNum);
+      BitSet bitSet = sawShard[shardNum];
+      if (bitSet == null) {
+        bitSet = new BitSet();
+        sawShard[shardNum] = bitSet;
+      }
+      bitSet.set(bucketNum);
     }
 
     public boolean getShardFlag(int bucketNum, int shardNum) {
-      return sawShard.get(bucketNum * numShards + shardNum);
+      BitSet bitSet = sawShard[shardNum];
+      return bitSet != null && bitSet.get(bucketNum);
     }
 
     public boolean getShardFlag(int bucketNum) {


### PR DESCRIPTION
Move shards to independent bit sets.

Seeing refinement errors for orgs with full shards:
```
...caused by fs/solr/solrcloud/client.go:604 [(*rawClient).doRaw] failed to complete Solr request
...caused by fs/solr/solrcloud/client.go:680 [(*rawClient).doRequest] failed to complete Solr request
...caused by fs/solr/solrcloud/solrcloud.go:95 [checkResponse] failed solr request to https://solrqueryaggregator-c92-4:8987/solr/KJMMK/select?debug=off&indent=off&rid=35a2dc05ba5a8a7f3f2187db91df0fea-838aba54f13a73e0&shards.preference=replica.type%3ANRT%2Creplica.type%3APULL&shards.tolerant=true&timeAllowed=120000&wat=ComputeMetric%3ADimensionComputation&wt=json
...caused by (500) bitIndex < 0: -2147482121
```