### PR TITLE
RateLimiter fixes: live adjustable, slot borrowing, cleaner state tracking via try-with-resources

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/RateLimiterConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/RateLimiterConfig.java
@@ -78,15 +78,23 @@ public class RateLimiterConfig {
 
     this.definition = definition;
 
-    allowedRequests = definition.allowedRequests == null ? DEFAULT_CONCURRENT_REQUESTS : definition.allowedRequests;
+    allowedRequests =
+        definition.allowedRequests == null
+            ? DEFAULT_CONCURRENT_REQUESTS
+            : definition.allowedRequests;
 
     isEnabled = definition.enabled == null ? false : definition.enabled; // disabled by default
 
-    guaranteedSlotsThreshold = definition.guaranteedSlots == null ? this.allowedRequests / 2 : definition.guaranteedSlots;
+    guaranteedSlotsThreshold =
+        definition.guaranteedSlots == null ? this.allowedRequests / 2 : definition.guaranteedSlots;
 
-    isSlotBorrowingEnabled = definition.slotBorrowingEnabled == null ? false : definition.slotBorrowingEnabled;
+    isSlotBorrowingEnabled =
+        definition.slotBorrowingEnabled == null ? false : definition.slotBorrowingEnabled;
 
-    waitForSlotAcquisition = definition.slotAcquisitionTimeoutInMS == null ? DEFAULT_SLOT_ACQUISITION_TIMEOUT_MS : definition.slotAcquisitionTimeoutInMS.longValue();
+    waitForSlotAcquisition =
+        definition.slotAcquisitionTimeoutInMS == null
+            ? DEFAULT_SLOT_ACQUISITION_TIMEOUT_MS
+            : definition.slotAcquisitionTimeoutInMS.longValue();
 
     return true;
   }

--- a/solr/core/src/java/org/apache/solr/servlet/QueryRateLimiter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/QueryRateLimiter.java
@@ -54,8 +54,7 @@ public class QueryRateLimiter extends RequestRateLimiter {
       rateLimiterMeta = mapper.readValue(configInput, RateLimiterPayload.class);
     }
 
-    synchronized (rateLimiterConfig) {
-      // `rateLimiterConfig` is what we're mutating, so synchronize on it.
+    synchronized (this) {
       if (rateLimiterConfig.update(rateLimiterMeta)) {
         // config has changed, re-init
         init();

--- a/solr/core/src/java/org/apache/solr/servlet/RateLimitManager.java
+++ b/solr/core/src/java/org/apache/solr/servlet/RateLimitManager.java
@@ -23,13 +23,14 @@ import static org.apache.solr.common.params.CommonParams.SOLR_REQUEST_TYPE_PARAM
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.invoke.MethodHandles;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.servlet.http.HttpServletRequest;
 import net.jcip.annotations.ThreadSafe;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.common.cloud.ClusterPropertiesListener;
 import org.apache.solr.common.cloud.SolrZkClient;
+import org.apache.solr.core.RateLimiterConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,26 +52,34 @@ public class RateLimitManager implements ClusterPropertiesListener {
   public static final int DEFAULT_CONCURRENT_REQUESTS =
       (Runtime.getRuntime().availableProcessors()) * 3;
   public static final long DEFAULT_SLOT_ACQUISITION_TIMEOUT_MS = -1;
-  private final Map<String, RequestRateLimiter> requestRateLimiterMap;
+  private final ConcurrentHashMap<String, RequestRateLimiter> requestRateLimiterMap;
 
   public RateLimitManager() {
-    this.requestRateLimiterMap = new HashMap<>();
+    this.requestRateLimiterMap = new ConcurrentHashMap<>();
   }
 
   @Override
   public boolean onChange(Map<String, Object> properties) {
 
     // Hack: We only support query rate limiting for now
-    QueryRateLimiter queryRateLimiter =
-        (QueryRateLimiter) getRequestRateLimiter(SolrRequest.SolrRequestType.QUERY);
-
-    if (queryRateLimiter != null) {
-      try {
-        queryRateLimiter.processConfigChange(properties);
-      } catch (IOException e) {
-        throw new UncheckedIOException(e);
-      }
-    }
+    requestRateLimiterMap.compute(
+        SolrRequest.SolrRequestType.QUERY.toString(),
+        (k, v) -> {
+          try {
+            RateLimiterConfig newConfig =
+                QueryRateLimiter.processConfigChange(
+                    SolrRequest.SolrRequestType.QUERY,
+                    v == null ? null : v.getRateLimiterConfig(),
+                    properties);
+            if (newConfig == null) {
+              return v;
+            } else {
+              return new QueryRateLimiter(newConfig);
+            }
+          } catch (IOException e) {
+            throw new UncheckedIOException(e);
+          }
+        });
 
     return false;
   }

--- a/solr/core/src/java/org/apache/solr/servlet/RateLimitManager.java
+++ b/solr/core/src/java/org/apache/solr/servlet/RateLimitManager.java
@@ -79,7 +79,8 @@ public class RateLimitManager implements ClusterPropertiesListener {
   // identify which (if any) rate limiter can handle this request. Internal requests will not be
   // rate limited
   // Returns true if request is accepted for processing, false if it should be rejected
-  public RequestRateLimiter.SlotReservation handleRequest(HttpServletRequest request) throws InterruptedException {
+  public RequestRateLimiter.SlotReservation handleRequest(HttpServletRequest request)
+      throws InterruptedException {
     String requestContext = request.getHeader(SOLR_REQUEST_CONTEXT_PARAM);
     String typeOfRequest = request.getHeader(SOLR_REQUEST_TYPE_PARAM);
 

--- a/solr/core/src/java/org/apache/solr/servlet/RequestRateLimiter.java
+++ b/solr/core/src/java/org/apache/solr/servlet/RequestRateLimiter.java
@@ -19,7 +19,6 @@ package org.apache.solr.servlet;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.io.Closeable;
-import java.lang.invoke.VarHandle;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -35,43 +34,18 @@ import org.apache.solr.core.RateLimiterConfig;
 @ThreadSafe
 public class RequestRateLimiter {
 
-  private static final class State {
-    // Total slots that are available for this request rate limiter.
-    private final Semaphore totalSlotsPool;
+  // Total slots that are available for this request rate limiter.
+  private final Semaphore totalSlotsPool;
 
-    // Competitive slots pool that are available for this rate limiter as well as borrowing by other
-    // request rate limiters. By competitive, the meaning is that there is no prioritization for the
-    // acquisition of these slots -- First Come First Serve, irrespective of whether the request is
-    // of
-    // this request rate limiter or other.
-    private final Semaphore borrowableSlotsPool;
+  // Competitive slots pool that are available for this rate limiter as well as borrowing by other
+  // request rate limiters. By competitive, the meaning is that there is no prioritization for the
+  // acquisition of these slots -- First Come First Serve, irrespective of whether the request is
+  // of
+  // this request rate limiter or other.
+  private final Semaphore borrowableSlotsPool;
 
-    private final AtomicInteger nativeReservations;
+  private final AtomicInteger nativeReservations;
 
-    private final int guaranteedSlots;
-
-    private final long waitForSlotAcquisition;
-
-    private State(RateLimiterConfig config) {
-      totalSlotsPool = new Semaphore(config.allowedRequests);
-      guaranteedSlots = config.guaranteedSlotsThreshold;
-      if (!config.isSlotBorrowingEnabled || guaranteedSlots >= config.allowedRequests) {
-        // slot borrowing is disabled, either explicitly or implicitly
-        borrowableSlotsPool = null;
-        nativeReservations = null;
-      } else if (guaranteedSlots <= 0) {
-        // all slots are guaranteed
-        borrowableSlotsPool = totalSlotsPool;
-        nativeReservations = null;
-      } else {
-        borrowableSlotsPool = new Semaphore(config.allowedRequests - guaranteedSlots);
-        nativeReservations = new AtomicInteger();
-      }
-      this.waitForSlotAcquisition = config.waitForSlotAcquisition;
-    }
-  }
-
-  private State state;
   private final RateLimiterConfig rateLimiterConfig;
   public static final SlotReservation UNLIMITED =
       () -> {
@@ -80,30 +54,37 @@ public class RequestRateLimiter {
 
   public RequestRateLimiter(RateLimiterConfig rateLimiterConfig) {
     this.rateLimiterConfig = rateLimiterConfig;
-    init();
-    // within the ctor, we need to ensure that subsequent reads get a non-null value for
-    // `state`, so call `VarHandle.fullFence()`; beyond that, it's arbitrary what state
-    // is applied to a given request
-    VarHandle.fullFence();
-  }
-
-  public final void init() {
-    state = new State(rateLimiterConfig);
+    totalSlotsPool = new Semaphore(rateLimiterConfig.allowedRequests);
+    int guaranteedSlots = rateLimiterConfig.guaranteedSlotsThreshold;
+    if (!rateLimiterConfig.isSlotBorrowingEnabled
+        || guaranteedSlots >= rateLimiterConfig.allowedRequests) {
+      // slot borrowing is disabled, either explicitly or implicitly
+      borrowableSlotsPool = null;
+      nativeReservations = null;
+    } else if (guaranteedSlots <= 0) {
+      // all slots are guaranteed
+      borrowableSlotsPool = totalSlotsPool;
+      nativeReservations = null;
+    } else {
+      borrowableSlotsPool = new Semaphore(rateLimiterConfig.allowedRequests - guaranteedSlots);
+      nativeReservations = new AtomicInteger();
+    }
   }
 
   @VisibleForTesting
   boolean isEmpty() {
-    if (state.totalSlotsPool.availablePermits() != rateLimiterConfig.allowedRequests) {
+    if (totalSlotsPool.availablePermits() != rateLimiterConfig.allowedRequests) {
       return false;
     }
-    if (state.nativeReservations == null) {
+    if (nativeReservations == null) {
       return true;
     }
-    if (state.nativeReservations.get() != 0) {
+    if (nativeReservations.get() != 0) {
       return false;
     }
-    return state.borrowableSlotsPool.availablePermits()
-        == rateLimiterConfig.allowedRequests - state.guaranteedSlots;
+    assert borrowableSlotsPool != null; // implied by `nativeReservations != null`
+    return borrowableSlotsPool.availablePermits()
+        == rateLimiterConfig.allowedRequests - rateLimiterConfig.guaranteedSlotsThreshold;
   }
 
   /**
@@ -116,23 +97,26 @@ public class RequestRateLimiter {
       return UNLIMITED;
     }
 
-    final State state = this.state;
-    final Semaphore totalSlotsPool = state.totalSlotsPool;
-
-    if (totalSlotsPool.tryAcquire(state.waitForSlotAcquisition, TimeUnit.MILLISECONDS)) {
-      final Semaphore borrowableSlotsPool = state.borrowableSlotsPool;
-      if (borrowableSlotsPool == null || totalSlotsPool == borrowableSlotsPool) {
+    if (totalSlotsPool.tryAcquire(
+        rateLimiterConfig.waitForSlotAcquisition, TimeUnit.MILLISECONDS)) {
+      if (nativeReservations == null) {
+        assert borrowableSlotsPool == null || totalSlotsPool == borrowableSlotsPool;
         // simple case: all slots guaranteed; or none, do not double-acquire
         return new SingleSemaphoreReservation(totalSlotsPool);
-      } else if (state.nativeReservations.incrementAndGet() <= state.guaranteedSlots
+      }
+      assert borrowableSlotsPool != null; // implied by `nativeReservations != null`
+      if (nativeReservations.incrementAndGet() <= rateLimiterConfig.guaranteedSlotsThreshold
           || borrowableSlotsPool.tryAcquire()) {
         // we either fungibly occupy a guaranteed slot, so don't have to acquire
         // a borrowable slot; or we acquire a borrowable slot
         return new NativeBorrowableReservation(
-            totalSlotsPool, borrowableSlotsPool, state.nativeReservations, state.guaranteedSlots);
+            totalSlotsPool,
+            borrowableSlotsPool,
+            nativeReservations,
+            rateLimiterConfig.guaranteedSlotsThreshold);
       } else {
         // this should never happen, but if it does we should not leak permits/accounting
-        state.nativeReservations.decrementAndGet();
+        nativeReservations.decrementAndGet();
         totalSlotsPool.release();
         throw new IllegalStateException(
             "if we have a top-level slot, there should be an available borrowable slot");
@@ -153,13 +137,11 @@ public class RequestRateLimiter {
    *     long lived.
    */
   public SlotReservation allowSlotBorrowing() throws InterruptedException {
-    final State state = this.state;
-    final Semaphore borrowableSlotsPool = state.borrowableSlotsPool;
     if (borrowableSlotsPool == null) {
       return null;
     }
-    final Semaphore totalSlotsPool = state.totalSlotsPool;
-    if (totalSlotsPool.tryAcquire(state.waitForSlotAcquisition, TimeUnit.MILLISECONDS)) {
+    if (totalSlotsPool.tryAcquire(
+        rateLimiterConfig.waitForSlotAcquisition, TimeUnit.MILLISECONDS)) {
       if (totalSlotsPool == borrowableSlotsPool) {
         // simple case: there are no guaranteed slots; do not double-acquire
         return new SingleSemaphoreReservation(borrowableSlotsPool);

--- a/solr/core/src/java/org/apache/solr/servlet/ServletUtils.java
+++ b/solr/core/src/java/org/apache/solr/servlet/ServletUtils.java
@@ -203,10 +203,8 @@ public abstract class ServletUtils {
       HttpServletResponse response,
       Runnable limitedExecution)
       throws ServletException, IOException {
-    boolean accepted = false;
-    try {
-      accepted = rateLimitManager.handleRequest(request);
-      if (!accepted) {
+    try (RequestRateLimiter.SlotReservation accepted = rateLimitManager.handleRequest(request)) {
+      if (accepted == null) {
         response.sendError(ErrorCode.TOO_MANY_REQUESTS.code, RateLimitManager.ERROR_MESSAGE);
         return;
       }
@@ -216,10 +214,6 @@ public abstract class ServletUtils {
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new SolrException(ErrorCode.SERVER_ERROR, e.getMessage());
-    } finally {
-      if (accepted) {
-        rateLimitManager.decrementActiveRequests(request);
-      }
     }
   }
 

--- a/solr/core/src/test/org/apache/solr/servlet/TestRequestRateLimiter.java
+++ b/solr/core/src/test/org/apache/solr/servlet/TestRequestRateLimiter.java
@@ -221,10 +221,10 @@ public class TestRequestRateLimiter extends SolrCloudTestCase {
     }
 
     @Override
-    public SlotMetadata handleRequest() throws InterruptedException {
+    public SlotReservation handleRequest() throws InterruptedException {
       incomingRequestCount.getAndIncrement();
 
-      SlotMetadata response = super.handleRequest();
+      SlotReservation response = super.handleRequest();
 
       if (response != null) {
         acceptedNewRequestCount.getAndIncrement();
@@ -236,10 +236,10 @@ public class TestRequestRateLimiter extends SolrCloudTestCase {
     }
 
     @Override
-    public SlotMetadata allowSlotBorrowing() throws InterruptedException {
-      SlotMetadata result = super.allowSlotBorrowing();
+    public SlotReservation allowSlotBorrowing() throws InterruptedException {
+      SlotReservation result = super.allowSlotBorrowing();
 
-      if (result.isReleasable()) {
+      if (result != null) {
         borrowedSlotCount.incrementAndGet();
       }
 

--- a/solr/core/src/test/org/apache/solr/servlet/TestRequestRateLimiter.java
+++ b/solr/core/src/test/org/apache/solr/servlet/TestRequestRateLimiter.java
@@ -295,95 +295,108 @@ public class TestRequestRateLimiter extends SolrCloudTestCase {
   @SuppressWarnings("try")
   public void blah() throws IOException, InterruptedException, ExecutionException, TimeoutException {
     Random r = random();
-    int allowed = r.nextInt(8) + 1;
+    int maxAllowed = 32;
+    int allowed = r.nextInt(maxAllowed) + 1;
     int guaranteed = r.nextInt(allowed + 1);
     int borrowLimit = allowed - guaranteed;
-    RequestRateLimiter limiter = new RequestRateLimiter(
-        new RateLimiterConfig(
+    RateLimiterConfig config = new RateLimiterConfig(
         SolrRequest.SolrRequestType.QUERY,
         true,
         guaranteed,
         20,
         allowed /* allowedRequests */,
-        true /* isSlotBorrowing */)
-    );
+        true /* isSlotBorrowing */);
+    RequestRateLimiter limiter = new RequestRateLimiter(config);
     ExecutorService exec = ExecutorUtil.newMDCAwareCachedThreadPool("tests");
     try (Closeable c = () -> ExecutorUtil.shutdownAndAwaitTermination(exec)) {
-      AtomicBoolean finish = new AtomicBoolean();
-      AtomicInteger outstanding = new AtomicInteger();
-      AtomicInteger outstandingBorrowed = new AtomicInteger();
-      LongAdder executed = new LongAdder();
-      LongAdder skipped = new LongAdder();
-      LongAdder borrowedExecuted = new LongAdder();
-      LongAdder borrowedSkipped = new LongAdder();
-      List<Future<Void>> futures = new ArrayList<>();
-      int nativeClients = r.nextInt(16);
-      for (int i = nativeClients; i > 0; i--) {
-        Random tRandom = new Random(r.nextLong());
-        futures.add(exec.submit(() -> {
-          while (!finish.get()) {
-            try (RequestRateLimiter.SlotReservation slotReservation = limiter.handleRequest()) {
-              if (slotReservation != null) {
-                executed.increment();
-                int ct = outstanding.incrementAndGet();
-                assertTrue(ct+" <= "+allowed, ct <= allowed);
-                ct = outstandingBorrowed.get();
-                assertTrue(ct+" <= "+borrowLimit, ct <= borrowLimit);
-                Thread.sleep(tRandom.nextInt(200));
-                int ct1 = outstandingBorrowed.get();
-                assertTrue(ct1+" <= "+borrowLimit, ct1 <= borrowLimit);
-                int ct2 = outstanding.getAndDecrement();
-                assertTrue(ct2+" <= "+allowed, ct2 <= allowed);
-              } else {
-                skipped.increment();
-                Thread.sleep(tRandom.nextInt(10));
+      for (int j = 0; j < 5; j++) {
+        System.err.println("for "+allowed+"/"+guaranteed);
+        int allowedF = allowed;
+        int borrowLimitF = borrowLimit;
+        AtomicBoolean finish = new AtomicBoolean();
+        AtomicInteger outstanding = new AtomicInteger();
+        AtomicInteger outstandingBorrowed = new AtomicInteger();
+        LongAdder executed = new LongAdder();
+        LongAdder skipped = new LongAdder();
+        LongAdder borrowedExecuted = new LongAdder();
+        LongAdder borrowedSkipped = new LongAdder();
+        List<Future<Void>> futures = new ArrayList<>();
+        int nativeClients = r.nextInt(allowed << 1);
+        for (int i = nativeClients; i > 0; i--) {
+          Random tRandom = new Random(r.nextLong());
+          futures.add(exec.submit(() -> {
+            while (!finish.get()) {
+              try (RequestRateLimiter.SlotReservation slotReservation = limiter.handleRequest()) {
+                if (slotReservation != null) {
+                  executed.increment();
+                  int ct = outstanding.incrementAndGet();
+                  assertTrue(ct+" <= "+allowedF, ct <= allowedF);
+                  ct = outstandingBorrowed.get();
+                  assertTrue(ct+" <= "+borrowLimitF, ct <= borrowLimitF);
+                  Thread.sleep(tRandom.nextInt(200));
+                  int ct1 = outstandingBorrowed.get();
+                  assertTrue(ct1+" <= "+borrowLimitF, ct1 <= borrowLimitF);
+                  int ct2 = outstanding.getAndDecrement();
+                  assertTrue(ct2+" <= "+allowedF, ct2 <= allowedF);
+                } else {
+                  skipped.increment();
+                  Thread.sleep(tRandom.nextInt(10));
+                }
               }
             }
-          }
-          return null;
-        }));
-      }
-      int borrowClients = r.nextInt(16);
-      for (int i = borrowClients; i > 0; i--) {
-        Random tRandom = new Random(r.nextLong());
-        futures.add(exec.submit(() -> {
-          while (!finish.get()) {
-            try (RequestRateLimiter.SlotReservation slotReservation = limiter.allowSlotBorrowing()) {
-              if (slotReservation != null) {
-                borrowedExecuted.increment();
-                int ct = outstanding.incrementAndGet();
-                assertTrue(ct+" <= "+allowed, ct <= allowed);
-                ct = outstandingBorrowed.incrementAndGet();
-                assertTrue(ct+" <= "+borrowLimit, ct <= borrowLimit);
-                Thread.sleep(tRandom.nextInt(200));
-                int ct1 = outstandingBorrowed.getAndDecrement();
-                assertTrue(ct1+" <= "+borrowLimit, ct1 <= borrowLimit);
-                int ct2 = outstanding.getAndDecrement();
-                assertTrue(ct2+" <= "+allowed, ct2 <= allowed);
-              } else {
-                borrowedSkipped.increment();
-                Thread.sleep(tRandom.nextInt(10));
+            return null;
+          }));
+        }
+        int borrowClients = r.nextInt(allowed << 1);
+        for (int i = borrowClients; i > 0; i--) {
+          Random tRandom = new Random(r.nextLong());
+          futures.add(exec.submit(() -> {
+            while (!finish.get()) {
+              try (RequestRateLimiter.SlotReservation slotReservation = limiter.allowSlotBorrowing()) {
+                if (slotReservation != null) {
+                  borrowedExecuted.increment();
+                  int ct = outstanding.incrementAndGet();
+                  assertTrue(ct+" <= "+allowedF, ct <= allowedF);
+                  ct = outstandingBorrowed.incrementAndGet();
+                  assertTrue(ct+" <= "+borrowLimitF, ct <= borrowLimitF);
+                  Thread.sleep(tRandom.nextInt(200));
+                  int ct1 = outstandingBorrowed.getAndDecrement();
+                  assertTrue(ct1+" <= "+borrowLimitF, ct1 <= borrowLimitF);
+                  int ct2 = outstanding.getAndDecrement();
+                  assertTrue(ct2+" <= "+allowedF, ct2 <= allowedF);
+                } else {
+                  borrowedSkipped.increment();
+                  Thread.sleep(tRandom.nextInt(10));
+                }
               }
             }
+            return null;
+          }));
+        }
+        Thread.sleep(5000); // let it run for a while
+        finish.set(true);
+        List<Exception> exceptions = new ArrayList<>();
+        for (Future<Void> f : futures) {
+          try {
+            f.get(1, TimeUnit.SECONDS);
+          } catch (Exception e) {
+            exceptions.add(e);
           }
-          return null;
-        }));
-      }
-      Thread.sleep(10000); // let it run for a while
-      finish.set(true);
-      List<Exception> exceptions = new ArrayList<>();
-      for (Future<Void> f : futures) {
-        try {
-          f.get(1, TimeUnit.SECONDS);
-        } catch (Exception e) {
-          exceptions.add(e);
         }
-      }
-      if (!exceptions.isEmpty()) {
-        for (Exception e : exceptions) {
-          e.printStackTrace(System.err);
+        if (!exceptions.isEmpty()) {
+          for (Exception e : exceptions) {
+            e.printStackTrace(System.err);
+          }
+          fail("found "+exceptions.size()+" exceptions");
         }
-        fail("found "+exceptions.size()+" exceptions");
+        assertEquals(0, outstanding.get());
+        assertEquals(0, outstandingBorrowed.get());
+        allowed = r.nextInt(maxAllowed) + 1;
+        guaranteed = r.nextInt(allowed + 1);
+        borrowLimit = allowed - guaranteed;
+        config.allowedRequests = allowed;
+        config.guaranteedSlotsThreshold = guaranteed;
+        limiter.init();
       }
     }
   }

--- a/solr/core/src/test/org/apache/solr/servlet/TestRequestRateLimiter.java
+++ b/solr/core/src/test/org/apache/solr/servlet/TestRequestRateLimiter.java
@@ -391,6 +391,7 @@ public class TestRequestRateLimiter extends SolrCloudTestCase {
         }
         assertEquals(0, outstanding.get());
         assertEquals(0, outstandingBorrowed.get());
+        assertTrue(limiter.isEmpty());
         allowed = r.nextInt(maxAllowed) + 1;
         guaranteed = r.nextInt(allowed + 1);
         borrowLimit = allowed - guaranteed;


### PR DESCRIPTION
There are 3 main changes included here:
1. allow atomically changing settings in a way that actually allows modifying the full range of config settings live (previously some settings could be updated, but others -- namely, the actual request limits -- changes would not actually take effect).
2. close out rate-limiting slots via try-with-resources. This is much safer, cleaner, and more memory-efficient, and supports more flexible slot-granting. (previously the outstanding state had been tracked in a separate map in the RateLimitManager, which was really unnecessary/needlessly complex/inflexible)
3. there was a bug in slot borrowing that could in principle cause slots to be denied to native request types with guaranteed slots, even when plenty of slots are available. More likely consequences of the bug would be:
  a. native request types waiting up to twice as long as specified by slot allocation millis
  b. native request types pointlessly waiting `slot allocation millis` even when plenty of slots are available

For our initial use case, 1 is necessary, 2 is "nice to have" but probably not functionally different, 3 fixes a bug that would have impacted our use case to some extent, even if we were to have set `guaranteed==allowed` (surprisingly).