### PR TITLE
add CircuitBreaker timesTripped metric

### DIFF
--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -201,7 +201,7 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
             (k, v) -> {
               metrics.add(
                       new PrometheusMetric(
-                              String.format("times_tripped%s", k),
+                              "times_tripped"+k,
                               PrometheusMetricType.COUNTER,
                               "number of times circuit has been tripped",
                               v));

--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -16,6 +16,8 @@
  */
 package org.apache.solr.servlet;
 
+import static org.apache.solr.util.circuitbreaker.CircuitBreakerRegistry.getTimesTrippedMetrics;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayOutputStream;
@@ -52,8 +54,6 @@ import org.apache.solr.core.CoreContainer;
 import org.apache.solr.storage.CompressingDirectory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.solr.util.circuitbreaker.CircuitBreakerRegistry.getTimesTrippedMetrics;
 
 /**
  * FullStory: a simple servlet to produce a few prometheus metrics. This servlet exists for
@@ -197,16 +197,16 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
   }
 
   private void getCircuitBreakerMetrics(List<PrometheusMetric> metrics) {
-    getTimesTrippedMetrics().forEach(
+    getTimesTrippedMetrics()
+        .forEach(
             (k, v) -> {
               metrics.add(
-                      new PrometheusMetric(
-                              "times_tripped"+k,
-                              PrometheusMetricType.COUNTER,
-                              "number of times circuit has been tripped",
-                              v));
-            }
-    );
+                  new PrometheusMetric(
+                      "times_tripped" + k,
+                      PrometheusMetricType.COUNTER,
+                      "number of times circuit has been tripped",
+                      v));
+            });
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})

--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -53,6 +53,8 @@ import org.apache.solr.storage.CompressingDirectory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.solr.util.circuitbreaker.CircuitBreakerRegistry.getTimesTrippedMetrics;
+
 /**
  * FullStory: a simple servlet to produce a few prometheus metrics. This servlet exists for
  * backwards compatibility and will be removed in favor of the native prometheus-exporter.
@@ -92,6 +94,7 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
       caller.call(qTime, metrics, request);
     }
     getCompressingDirectoryPoolMetrics(metrics);
+    getCircuitBreakerMetrics(metrics);
     getSharedCacheMetrics(metrics, getSolrDispatchFilter(request).getCores(), cacheMetricTypes);
     metrics.add(
         new PrometheusMetric(
@@ -191,6 +194,19 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
               "init " + BASE_POOL_DESCRIPTION + "outstanding (in use) high water mark",
               v[5]));
     }
+  }
+
+  private void getCircuitBreakerMetrics(List<PrometheusMetric> metrics) {
+    getTimesTrippedMetrics().forEach(
+            (k, v) -> {
+              metrics.add(
+                      new PrometheusMetric(
+                              String.format("times_tripped%s", k),
+                              PrometheusMetricType.COUNTER,
+                              "number of times circuit has been tripped",
+                              v));
+            }
+    );
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreaker.java
@@ -51,6 +51,8 @@ public abstract class CircuitBreaker implements NamedListInitializedPlugin, Clos
 
   private boolean debugMode = false;
 
+  private long timesTripped = 0;
+
   @Override
   public void init(NamedList<?> args) {
     SolrPluginUtils.invokeSetters(this, args);
@@ -119,5 +121,13 @@ public abstract class CircuitBreaker implements NamedListInitializedPlugin, Clos
 
   public void setDebugMode(boolean debugMode) {
     this.debugMode = debugMode;
+  }
+
+  public void incrementTripped(long times) {
+    this.timesTripped += times;
+  }
+
+  public long getTimesTripped() {
+    return this.timesTripped;
   }
 }

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreaker.java
@@ -51,8 +51,6 @@ public abstract class CircuitBreaker implements NamedListInitializedPlugin, Clos
 
   private boolean debugMode = false;
 
-  private long timesTripped = 0;
-
   @Override
   public void init(NamedList<?> args) {
     SolrPluginUtils.invokeSetters(this, args);
@@ -121,13 +119,5 @@ public abstract class CircuitBreaker implements NamedListInitializedPlugin, Clos
 
   public void setDebugMode(boolean debugMode) {
     this.debugMode = debugMode;
-  }
-
-  public void incrementTripped(long times) {
-    this.timesTripped += times;
-  }
-
-  public long getTimesTripped() {
-    return this.timesTripped;
   }
 }

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
@@ -43,8 +43,7 @@ import org.slf4j.LoggerFactory;
 public class CircuitBreakerRegistry implements Closeable {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  private final Map<SolrRequestType, List<CircuitBreaker>> circuitBreakerMap =
-      new HashMap<>();
+  private final Map<SolrRequestType, List<CircuitBreaker>> circuitBreakerMap = new HashMap<>();
   private static final Map<String, Long> circuitBreakerTrippedMetrics = new ConcurrentHashMap<>();
 
   public CircuitBreakerRegistry() {}
@@ -108,7 +107,9 @@ public class CircuitBreakerRegistry implements Closeable {
 
   private void incrementTripped(SolrRequestType requestType, CircuitBreaker circuitBreaker) {
     String metricKey =
-            circuitBreaker.getClass().getSimpleName() + "_" + requestType.name().toLowerCase(Locale.ROOT);
+        circuitBreaker.getClass().getSimpleName()
+            + "_"
+            + requestType.name().toLowerCase(Locale.ROOT);
     circuitBreakerTrippedMetrics.merge(metricKey, 1L, Long::sum);
   }
 

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
@@ -43,7 +43,8 @@ import org.slf4j.LoggerFactory;
 public class CircuitBreakerRegistry implements Closeable {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  private static final Map<SolrRequestType, List<CircuitBreaker>> circuitBreakerMap = new ConcurrentHashMap<>();
+  private static final Map<SolrRequestType, List<CircuitBreaker>> circuitBreakerMap =
+      new ConcurrentHashMap<>();
 
   public CircuitBreakerRegistry() {}
 
@@ -107,14 +108,15 @@ public class CircuitBreakerRegistry implements Closeable {
   public static Map<String, Long> getTimesTrippedMetrics() {
     Map<String, Long> ret = new HashMap<>();
     circuitBreakerMap.forEach(
-            (reqType, cbs) -> {
-              for (CircuitBreaker cb : cbs) {
-                String metricKey = cb.getClass().getSimpleName()+"_"+reqType.name().toLowerCase(Locale.ROOT);
-                // there can be multiple circuit breakers of the same type and reqType, so sum their trip times
-                ret.merge(metricKey, cb.getTimesTripped(), Long::sum);
-              }
-            }
-    );
+        (reqType, cbs) -> {
+          for (CircuitBreaker cb : cbs) {
+            String metricKey =
+                cb.getClass().getSimpleName() + "_" + reqType.name().toLowerCase(Locale.ROOT);
+            // there can be multiple circuit breakers of the same type and reqType, so sum their
+            // trip times
+            ret.merge(metricKey, cb.getTimesTripped(), Long::sum);
+          }
+        });
     return ret;
   }
 

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
@@ -113,12 +113,7 @@ public class CircuitBreakerRegistry implements Closeable {
   }
 
   public static Map<String, Long> getTimesTrippedMetrics() {
-    Map<String, Long> ret = new HashMap<>();
-    circuitBreakerTrippedMetrics.forEach(
-        (k, v) -> {
-          ret.put(k, v);
-        });
-    return ret;
+    return Map.copyOf(circuitBreakerTrippedMetrics);
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
@@ -109,7 +109,7 @@ public class CircuitBreakerRegistry implements Closeable {
     circuitBreakerMap.forEach(
             (reqType, cbs) -> {
               for (CircuitBreaker cb : cbs) {
-                String metricKey = cb.getClass().getSimpleName()+"_"+reqType.name().toLowerCase();
+                String metricKey = cb.getClass().getSimpleName()+"_"+reqType.name().toLowerCase(Locale.ROOT);
                 // there can be multiple circuit breakers of the same type and reqType, so sum their trip times
                 ret.merge(metricKey, cb.getTimesTripped(), Long::sum);
               }

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
@@ -109,7 +109,7 @@ public class CircuitBreakerRegistry implements Closeable {
     circuitBreakerMap.forEach(
             (reqType, cbs) -> {
               for (CircuitBreaker cb : cbs) {
-                String metricKey = String.format("%s_%s",cb.getClass().getSimpleName(),reqType.name().toLowerCase());
+                String metricKey = cb.getClass().getSimpleName()+"_"+reqType.name().toLowerCase();
                 // there can be multiple circuit breakers of the same type and reqType, so sum their trip times
                 ret.merge(metricKey, cb.getTimesTripped(), Long::sum);
               }


### PR DESCRIPTION
This PR adds a metric for each CircuitBreaker that is configured in Solr. The metrics are named like so:
```
# times_tripped_<name of circuit breaker class>_<request type>
times_tripped_load_average_circuit_breaker_query
```
All metrics from every CircuitBreaker of the same class and request type are rolled up into this one metric, and reported through the PrometheusMetricsServlet. 

### Testing
Tested by adding this to a config on my local machine:
```
...
  <circuitBreaker class="solr.LoadAverageCircuitBreaker">
    <double name="threshold">1</double>
    <arr name="requestTypes">
      <str>update</str>
    </arr>
  </circuitBreaker>

  <circuitBreaker class="solr.LoadAverageCircuitBreaker">
    <double name="threshold">1</double>
    <arr name="requestTypes">
      <str>query</str>
    </arr>
  </circuitBreaker>
...
```

Then, issuing some requests to a collection, and seeing the circuit breaker activate. Then, I checked `http://localhost:8983/solr/metrics` to make sure this showed up:
```
# HELP times_tripped_load_average_circuit_breaker_query number of times circuit has been tripped
# TYPE times_tripped_load_average_circuit_breaker_query counter
times_tripped_load_average_circuit_breaker_query 1
# HELP times_tripped_load_average_circuit_breaker_update number of times circuit has been tripped
# TYPE times_tripped_load_average_circuit_breaker_update counter
times_tripped_load_average_circuit_breaker_update 0
```

Also tested that Solr functions as normal when no CircuitBreakers are configured. 