### PR TITLE
add global CircuitBreaker configuration in Zookeeper clusterprops with live-updating

### DIFF
--- a/solr/CHANGES.txt
+++ b/solr/CHANGES.txt
@@ -4,6 +4,452 @@ This file lists Solr's raw release notes with details of every change to Solr.
 Most people will find the solr-upgrade-notes.adoc file more approachable.
 https://github.com/apache/solr/blob/main/solr/solr-ref-guide/modules/upgrade-notes/pages/solr-upgrade-notes.adoc
 
+==================  9.7.0 ==================
+New Features
+---------------------
+* SOLR-13350: Multithreaded search execution (Ishan Chattopadhyaya, Mark Miller, Christine Poerschke, David Smiley, noble)
+
+* SOLR-17192: Put an UpdateRequestProcessor-enforced soft-limit on the number of fields allowed in a core.  The `NumFieldLimitingUpdateRequestProcessorFactory`
+  limit may be adjusted by raising the factory's `maxFields` setting, toggled in and out of "warning-only" mode using the `warnOnly` setting, or disabled entirely
+  by removing it solrconfig.xml.  The limit is set at 1000 fields in the "_default" configset, but left in warning-only mode. (David Smiley, Eric Pugh,
+  Jason Gerlowski)
+
+* SOLR-17277: Circuit breakers may now be configured in a "soft" or "warnOnly" mode in order to more easily test out new thresholds.  Soft breakers will log out a
+  message on each relevant request when tripped, but will not otherwise impact or short circuit the requests.  (Jason Gerlowski)
+
+Improvements
+---------------------
+* SOLR-16921: use -solrUrl to derive the zk host connection for bin/solr zk subcommands (Eric Pugh)
+
+* SOLR-14115: Add linkconfig, cluster, and updateacls as commands to SolrCLI.  Allow bin/solr commands to have parity with zkcli.sh commands. (Eric Pugh)
+
+* SOLR-17274: Allow JSON atomic updates to use multiple modifiers or a modifier like 'set' as a field name
+  if child docs are not enabled. (Calvin Smith, David Smiley)
+
+* SOLR-17300: Http2SolrClient.Builder.withHttpClient now copies HttpListenerFactory (e.g. for auth, metrics, traces, etc.)
+  (Sanjay Dutt, David Smiley)
+
+Optimizations
+---------------------
+* SOLR-17257: Both Minimize Cores and the Affinity replica placement strategies would over-gather
+  cluster metrics.  AttributeFetcherImpl was improved accordingly.  (Yohann Callea)
+
+Bug Fixes
+---------------------
+* SOLR-12813: subqueries should respect basic auth. (Rudy Seitz via Eric Pugh)
+
+* SOLR-17261: Remove unintended timeout of 60 seconds for core loading. (Houston Putman)
+
+* SOLR-17049: Actually mark all replicas down at startup and truly wait for them.
+  This includes replicas that might not exist anymore locally. (Houston Putman, Vincent Primault)
+
+* SOLR-17263: Fix 'Illegal character in query' exception in HttpJdkSolrClient (Andy Webb)
+
+* SOLR-17275: SolrJ ZkClientClusterStateProvider, revert SOLR-17153 for perf regression when aliases are used. (Aparna Suresh)
+
+* PR-2475: Fixed node listing bug in Admin UI when different hostnames start with the same front part. (@hgdharold via Eric Pugh)
+
+* SOLR-16659: Properly construct V2 base urls instead of replacing substring "/solr" with "/api" (Andrey Bozhko via Eric Pugh)
+
+Dependency Upgrades
+---------------------
+(No changes)
+
+Other Changes
+---------------------
+* SOLR-17248: Refactor ZK related SolrCli tools to separate SolrZkClient and CloudSolrClient instantiation/usage (Lamine Idjeraoui via Eric Pugh)
+
+* SOLR-16505: Use Jetty HTTP2 for index replication and other "recovery" operations
+  (Sanjay Dutt, David Smiley)
+
+* GITHUB#2454: Refactor preparePutOrPost method in HttpJdkSolrClient (Andy Webb)
+
+* SOLR-16503: Use Jetty HTTP2 for SyncStrategy and PeerSyncWithLeader for "recovery" operations (Sanjay Dutt, David Smiley)
+
+==================  9.6.1 ==================
+Bug Fixes
+---------------------
+* SOLR-17296: Remove (broken) singlePass attempt when reRankScale + debug is used, and fix underlying NPE. (hossman)
+
+* SOLR-17307: Use the system file separator instead of an explicit '/' in CachingDirectoryFactory (Houston Putman, hossman)
+
+==================  9.6.0 ==================
+New Features
+---------------------
+* SOLR-17141: Implement 'cpuAllowed' query parameter to limit the maximum CPU usage by a running query. (Andrzej Bialecki, Gus Heck, David Smiley)
+
+* SOLR-599: Add a new SolrJ client using the JDK’s built-in Http Client.  (James Dyer)
+
+* SOLR-16403: A new cluster singleton plugin to automatically remove inactive shards. (Paul McArthur, David Smiley)
+
+* SOLR-16466: Admin UI - Make it optional to sort list of commandline args (Shawn Heisey, Vincenzo D'Amore via Christine Poerschke)
+
+Improvements
+---------------------
+* SOLR-17119: When registering or updating a ConfigurablePlugin through the `/cluster/plugin` API,
+  config validation exceptions are now propagated to the callers. (Yohann Callea)
+
+* SOLR-16699: Add Collection creation time to CLUSTERSTATUS and COLSTATUS API responses
+  (Julien Pilourdault, Paul McArthur, David Smiley)
+
+* SOLR-17038: Expose the term count in /admin/segments handler if fieldInfo=true.
+  (Rahul Goswami via David Smiley and Christine Poerschke)
+
+* SOLR-17146: Add DelegatingBackupRepository and alternative checksum verification (Bruno Roustant)
+
+* SOLR-16858: KnnQParser's "Pre-Filtering" behavior is now controlable via local params (hossman)
+
+* SOLR-17145: The INSTALLSHARDDATA API now includes a 'requestid' field when run asynchronously (Jason Gerlowski)
+
+* SOLR-17159: bin/solr post now has proper unit testing.  Users can specify a --dry-run option to
+  simulate posting documents without sending them to Solr. (Eric Pugh)
+
+* SOLR-17058: Add 'distrib.statsCache' parameter to disable distributed stats requests at query time. (Wei Wang, Mikhail Khludnev)
+
+* SOLR-16138: Throw a exception when issuing a streaming expression and all cores are down instead of returning 0 documents. (Antoine Bursaux via Eric Pugh)
+
+* SOLR-17172: Add QueryLimits termination to the existing heavy SearchComponent-s. This allows query limits (e.g. timeAllowed,
+  cpuAllowed) to terminate expensive operations within components if limits are exceeded. (Andrzej Bialecki)
+
+* SOLR-17164: Add 2 arg variant of vectorSimilarity() function (Sanjay Dutt, hossman)
+
+* SOLR-17211: New SolrJ JDK client supports Async (James Dyer)
+
+* SOLR-17204: REPLACENODE now supports the source node not being live (Vincent Primault)
+
+* SOLR-14763: Add a CompletableFuture based asynchronous API to Http2SolrClient, HttpJdkSolrClient and LBHttp2SolrClient.
+  The previous asynchronous API is deprecated. (Rishi Sankar, James Dyer)
+
+Optimizations
+---------------------
+* SOLR-17144: Close searcherExecutor thread per core after 1 minute (Pierre Salagnac, Christine Poerschke)
+
+* GITHUB#2217: Scale to 10K+ collections better in ZkStateReader.refreshCollectionsList (David Smiley)
+
+
+Bug Fixes
+---------------------
+* SOLR-17153: CloudSolrClient could fail a request immediately following a collection creation.  Required double-checking the collection doesn’t exist. (Aparna Suresh via David Smiley)
+
+* SOLR-17152: Better alignment of Admin UI graph (janhoy)
+
+* SOLR-17148: Fixing Config API overlay property enabling or disabling the cache (Sanjay Dutt, hossman, Eric Pugh)
+
+* PR#2320: Avoid NullPointerException in SolrJ client due to missing
+  EnvToSyspropMappings.properties file (janhoy)
+
+* SOLR-17186: Streaming query breaks if token contains backtick (Rahul Goswami via Eric Pugh)
+
+* SOLR-17197: Fix getting fieldType by its name in FileBasedSpellChecker (Andrey Bozhko via Eric Pugh)
+
+* SOLR-17198: AffinityPlacementFactory can fail if Shard leadership changes occur while it is collecting metrics.
+  (Paul McArthur)
+
+* SOLR-17018: Add QueryLimits support to Learning To Rank rescoring.
+    (Alessandro Benedetti)
+
+* SOLR-14892: Queries with shards.info and shards.tolerant can yield multiple null keys in place of shard names
+  (Mathieu Marie, David Smiley)
+
+* SOLR-17110: Fixed JacksonJsonWriter to properly quote uuid values in json query response (Andrey Bozhko via Eric Pugh)
+
+* SOLR-17209: Fix NullPointerException in QueryComponent (Vincent Primault via Eric Pugh)
+
+* SOLR-17113: Correct how `/replication?command=details` describes errors in backup operations.  (Przemyslaw Ciezkowski via Christine Poerschke and Jason Gerlowski)
+
+* SOLR-17200: Fix false positive race condition in `/health?requireHealthyCores=true` during core loading (hossman)
+
+* SOLR-17218: Fix indexFetcher logging to include MDC details (hossman)
+
+* SOLR-17206: Eliminate the possibility of a -1 status code for SolrCloud update requests that are distributed.
+  (Paul McArthur)
+
+* SOLR-17213: Fix spurious warnings about solr url format in Solr CLI when users aren't providing a deprecated solr url.  (Eric Pugh)
+
+* SOLR-17176: Fix log history V2 API serialization (Michael Gibney)
+
+* SOLR-11535: Fix race condition in singleton-per-collection StateWatcher creation (Michael Gibney)
+
+* SOLR-16866: Reorder nested directory deletions to avoid logging spurious NoSuchFileException (Michael Gibney)
+
+* SOLR-17194: Fix CloudHttp2SolrClient doesn't preserve the passed httpClient to Http2ClusterStateProvider when using the internalClientBuilder (Eric Pugh, Lamine Idjeraoui, Houston Putman, Anshum Gupta)
+
+Dependency Upgrades
+---------------------
+* SOLR-17157: Upgrade Lucene to 9.10.0 (hossman, Christine Poerschke)
+
+* SOLR-17214: Update forbiddenapis to 3.7 (hossman)
+
+* GITHUB#2408: Update commons-cli to 1.7 (Eric Pugh)
+
+Other Changes
+---------------------
+
+* SOLR-17126: Cut over System.getProperty to EnvUtils.getProperty (janhoy)
+
+* SOLR-17066: GenericSolrRequest now has a `setRequiresCollection` setter that allows it to specify whether
+  it should make use of the client-level default collection/core. (Jason Gerlowski)
+
+* SOLR-17190: Replace org.apache.solr.util.LongSet with hppc LongHashSet (Michael Gibney)
+
+* SOLR-12089: Update FileBasedSpellChecker and IndexBasedSpellChecker to accept accuracy parameter
+  as float; deprecate `breakSugestionTieBreaker` parameter in favor of `breakSuggestionTieBreaker`
+  in WordBreakSolrSpellChecker (Andrey Bozhko via Eric Pugh)
+
+* SOLR-17201: Http2SolrClient and friends no longer marked as @lucene.experimental.
+  Krb5HttpClientBuilder and PreemptiveBasicAuthClientBuilderFactory no longer deprecated (janhoy)
+
+* SOLR-17217: Simplify verbose MatcherAssert.assertThat usage in tests (hossman)
+
+* SOLR-17232: PropertiesOutputStream is renamed IndexOutputOutputStream and overrides write(byte[], int, int).
+  (Bruno Roustant)
+
+* SOLR-17222: QueryResponseWriterUtil.NonFlushingStream should support bulk write methods (Michael Gibney)
+
+==================  9.5.0 ==================
+New Features
+---------------------
+* SOLR-17006: Collection creation & adding replicas: User-defined properties are persisted to state.json and
+  applied to new replicas, available for use as property substitution in configuration files.  (Vincent Primault)
+
+* SOLR-16974: Circuit Breakers can now be configured globally (janhoy, Christine Poerschke)
+
+* SOLR-16743: When using TLS, Solr can now auto-reload the keystore and truststore without the need to restart the process.
+  This is enabled by default when running with TLS and can be disabled or configured in solr.in.sh (Houston Putman, Tomás Fernández Löbbe)
+
+Improvements
+---------------------
+* SOLR-17053: Distributed search with shards.tolerant: if all shards fail, fail the request (Aparna Suresh via David Smiley)
+
+* SOLR-16924: RESTORECORE now sets the UpdateLog to ACTIVE state instead of requiring a separate
+  REQUESTAPPLYUPDATES call in Collection restore.  (Julia Maimone, David Smiley)
+
+* SOLR-16907: Fail when parsing an invalid custom permission definition from security.json (janhoy, Uwe Schindler)
+
+* SOLR-13748: Add support for mm (min should match) parameter to bool query parser (Andrey Bozhko)
+
+* SOLR-17046: SchemaCodecFactory is now the implicit default codec factory.  (hossman)
+
+* SOLR-16943: Extend Solr client tracing coverage to both Jetty Client and Apache HttpClient (Alex Deparvu, David Smiley)
+
+* SOLR-16397: Swap core v2 endpoints have been updated to be more REST-ful.
+  SWAP is now available at `POST /api/cores/coreName/swap` (Sanjay Dutt via Jason Gerlowski)
+
+* SOLR-17011: Add tracing spans to internal collection commands (Alex Deparvu)
+
+* SOLR-17041: Make CommitTracker currentTlogSize lazy (Alex Deparvu)
+
+* SOLR-16397: The rename-core v2 endpoint has been updated to be more REST-ful.
+  RENAME is now available at `POST /api/cores/coreName/rename` (Sanjay Dutt via Jason Gerlowski)
+
+* SOLR-17035: Add trace id to jetty thread names to improve debuggability via stack traces (Alex Deparvu)
+
+* SOLR-17079: Allow to declare replica placement plugins in solr.xml  (Vincent Primault)
+
+* SOLR-16959: Make the internal CoreSorter implementation configurable in solr.xml  (Vincent Primault)
+
+* SOLR-17050: Use compact JSON for Learning to Rank (LTR) feature and model storage. (Florin Babes, Christine Poerschke, Alessandro Benedetti)
+
+* SOLR-17094: Close objects contained inside an ObjectCache.  (Vincent Primault)
+
+* SOLR-16577: Ensure core load failures are always logged. (Haythem Khiri, David Smiley)
+
+* SOLR-17063: Do not retain log param references in LogWatcher (Michael Gibney)
+
+* SOLR-17066: SolrClient builders now allow users to specify a "default" collection or core
+  using the `withDefaultCollection` method.  Use of the Builder methods is preferable to including
+  the collection in the base URL accepted by certain client implementations. (Jason Gerlowski)
+
+* SOLR-15960: Unified use of system properties and environment variables (janhoy)
+
+* SOLR-16397: The MERGEINDEXES v2 endpoint has been updated to be more REST-ful.
+  MERGEINDEXES is now available at `POST /api/cores/coreName/merge-indices` (Sanjay Dutt via Jason Gerlowski)
+
+* PR#2186: Include the external file name in the log instead of the hard-coded value in FileFloatSource.java. (Hamzeh Aldmour via Uwe Schindler)
+
+* SOLR-17096: solr.xml now supports declaring clusterSingleton plugins (Paul McArthur, David Smiley)
+
+* SOLR-16397: The v2 endpoint to request the status of asynchronous CoreAdmin commands has been updated to be more REST-ful.
+  Now available at `GET /api/node/commands/someRequestId` (Sanjay Dutt via Jason Gerlowski)
+
+* SOLR-17068: bin/solr post CLI use of options is now aligned closely with bin/post CLI tool, and is consistently
+  referenced throughout the Ref Guide and source code, and is used through out our tests.  The bin/post tool
+  remains and has been tested to work. (Eric Pugh)
+
+Optimizations
+---------------------
+* SOLR-17084: LBSolrClient (used by CloudSolrClient) now returns the count of core tracked as not live AKA zombies
+  instead of the full list of cores.  This list is potentially as long as the number of cores.  When there are many
+  cores, this leads to high CPU and memory usage. (Gilles Bellaton, David Smiley)
+
+* SOLR-17036: UpdateLog lazy creates VersionBucket large array, and VersionBucket do not keep the highest version anymore.
+  This optimization reduces the memory usage, specially when the SolrCore is not used for indexing (Bruno Roustant)
+
+Bug Fixes
+---------------------
+* SOLR-17045: DenseVectorField w/ vectorDimension > 1024 now work automatically with _default configset, due to
+  implicit use of SchemaCodecFactory.  (hossman)
+
+* SOLR-10653: When there's a UUIDField in the schema and atomic update touches another field
+  the error occurs when leader updates replica (Mikhail Khludnev)
+
+* SOLR-17093: Collection restore API command now returns "requestid" when executed asynchronously like other APIs
+  (Tomás Fernández Löbbe)
+
+* SOLR-16952: In distributed i.e. multi-shard cloud mode returned dense vector 'fl' fields are now a list of numbers instead of strings. (Qais Qadri, Christine Poerschke)
+
+* SOLR-17090: The v2 "delete alias" API no longer errantly returns a 405 status code (Jason Gerlowski)
+
+* SOLR-17121: Fix SchemaCodecFactory to get PostingsFormat and DocValues from field. (Bruno Roustant, David Smiley)
+
+* SOLR-17116: The INSTALLSHARDDATA "collection-admin" API now reports errors correctly when run asynchronously. (Jason Gerlowski)
+
+* SOLR-17074: Fixed not correctly escaped quote in bin/solr script (Dominique Béjean, Vincenzo D'Amore)
+
+* SOLR-17120: Fix NullPointerException in UpdateLog.applyOlderUpdates that can occur if there are multiple partial
+  updates of the same document in separate requests using commitWithin. (Calvin Smith, Christine Poerschke)
+
+* SOLR-17112: bin/solr script doesn't do ps properly on some systems. (Vincenzo D'Amore via Eric Pugh)
+
+* SOLR-17149: Backups on collections with too many shards fail due to restrictive Executor queue size (Pierre Salagnac via Jason Gerlowski)
+
+Dependency Upgrades
+---------------------
+* PR#2055: Update org.mockito:mockito* from v5.5.0 to v5.8.0 (solrbot)
+
+* PR#2165: Update org.eclipse.jetty*:* to v10.0.19 (solrbot)
+
+* PR#2159: Update io.netty:* to v4.1.104.Final (solrbot)
+
+* PR#2048: Update dependency commons-cli:commons-cli to v1.6.0 (solrbot)
+
+* PR#2174: Update org.slf4j:* to v2.0.10 (solrbot)
+
+* PR#2135: Update dependency com.fasterxml.jackson:jackson-bom to v2.16.1 (solrbot)
+
+* PR#2138: Update dependency org.apache.commons:commons-compress to v1.25.0 (solrbot)
+
+* PR#2139: Update dependency org.apache.commons:commons-lang3 to v3.14.0 (solrbot)
+
+* PR#2035: Update dependency com.google.errorprone:error_prone_annotations to v2.23.0 (solrbot)
+
+* PR#2036: Update io.grpc:grpc-* to v1.59.0 (solrbot)
+
+* PR#2037: Update org.apache.logging.log4j:* to v2.21.0 (solrbot)
+
+* PR#2033: Update io.dropwizard.metrics:* to v4.2.21 (solrbot)
+
+* PR#2032: Update dependency io.swagger.core.v3:swagger-annotations to v2.2.17 (solrbot)
+
+* PR#2015: Update dependency org.codehaus.woodstox:stax2-api to v4.2.2 (solrbot)
+
+* PR#2034: Update dependency com.github.spotbugs:spotbugs-annotations to v4.8.0 (solrbot)
+
+* PR#2014: Update dependency com.google.guava:guava to v32.1.3-jre (solrbot)
+
+* PR#2010: Update dependency org.immutables:value-annotations to v2.10.0 (solrbot)
+
+* PR#2009: Update dependency io.opentelemetry:opentelemetry-bom to v1.31.0 (solrbot)
+
+* PR#2008: Update dependency org.semver4j:semver4j to v5.2.2 (solrbot)
+
+* PR#1989: Update org.apache.zookeeper:* to v3.9.1 (solrbot)
+
+* PR#1745: Update dependency com.google.cloud:google-cloud-bom to v0.204.0 (solrbot)
+
+* SOLR-17012: Update Apache Hadoop to 3.3.6 and Apache Curator to 5.5.0 (Kevin Risden)
+
+* SOLR-17026: Upgrade to Gradle 8.4 (Kevin Risden)
+
+* SOLR-17089: Upgrade Jersey to 3.1.5 (Jason Gerlowski)
+
+* SOLR-17097: Upgrade Lucene to 9.9.2 (Nazerke Seidan, Christine Poerschke, Pierre Salagnac)
+
+Other Changes
+---------------------
+* SOLR-17024: Remove support for the long-defunct "collectionDefaults" clusterprops key (Jason Gerlowski)
+
+* SOLR-17042: Deprecate the V2RequestSupport interface, and the associated `setUseV2` and `setUseBinaryV2` SolrRequest
+  methods.  SolrJ users looking to make use of v2 APIs in their applications can use the SolrRequest implementations
+  dedicated to that purpose. (Jason Gerlowski)
+
+* SOLR-17072: package CLI tool prints error JSONPath (Mikhail Khludnev)
+
+* SOLR-17078: The `train_and_upload_demo_model.py` script referenced in LTR documentation now uses Python3 (Jason Gerlowski)
+
+* SOLR-17091: dev tools script cloud.sh became broken after changes in 9.3 added a new -slim.tgz file it was not expecting
+  cloud.sh has been updated to ignore the -slim.tgz version of the tarball.
+
+* SOLR-16880: Solr now produces an OpenAPI Specification artifact on releases ("solr-openapi-x.y.z.json") that covers
+  Solr's v2 APIs. (Jason Gerlowski, Houston Putman)
+
+==================  9.4.1 ==================
+Bug Fixes
+---------------------
+* SOLR-17039: Entropy calculation in bin/solr script fails in Docker due to missing 'bc' cmd (janhoy)
+
+* SOLR-17057: JSON Query regression: If "query" is specified with a String (not JSON structure),
+  "defType" should parse it.  Since 9.4 defType was ignored.  (David Smiley)
+
+* SOLR-6853: Allow '/' characters in the text managed by Managed Resources API. (Nikita Rusetskii via Eric Pugh)
+
+* SOLR-17060: CoreContainer#create may deadlock with concurrent requests for metrics (Alex Deparvu, David Smiley)
+
+* SOLR-17098: ZK Credentials and ACLs are no longer sent to all ZK Servers when using Streaming Expressions.
+  They will only be used when sent to the default ZK Host. (Houston Putman, Jan Høydahl, David Smiley, Gus Heck, Qing Xu)
+
+* SOLR-16203: Properly initialize schema plugins loaded by SPI name (janhoy, hossman, Uwe Schindler)
+
+Dependency Upgrades
+---------------------
+* PR#2165: Update org.eclipse.jetty*:* to v10.0.19 (solrbot)
+
+* PR#2159: Update io.netty:* to v4.1.104.Final (solrbot)
+
+* PR#2048: Update dependency commons-cli:commons-cli to v1.6.0 (solrbot)
+
+* PR#2174: Update org.slf4j:* to v2.0.10 (solrbot)
+
+* PR#2135: Update dependency com.fasterxml.jackson:jackson-bom to v2.16.1 (solrbot)
+
+* PR#2138: Update dependency org.apache.commons:commons-compress to v1.25.0 (solrbot)
+
+* PR#2139: Update dependency org.apache.commons:commons-lang3 to v3.14.0 (solrbot)
+
+* PR#2035: Update dependency com.google.errorprone:error_prone_annotations to v2.23.0 (solrbot)
+
+* PR#2036: Update io.grpc:grpc-* to v1.59.0 (solrbot)
+
+* PR#2037: Update org.apache.logging.log4j:* to v2.21.0 (solrbot)
+
+* PR#2033: Update io.dropwizard.metrics:* to v4.2.21 (solrbot)
+
+* PR#2032: Update dependency io.swagger.core.v3:swagger-annotations to v2.2.17 (solrbot)
+
+* PR#2015: Update dependency org.codehaus.woodstox:stax2-api to v4.2.2 (solrbot)
+
+* PR#2031: Update dependency com.fasterxml.jackson:jackson-bom to v2.15.3 (solrbot)
+
+* PR#2034: Update dependency com.github.spotbugs:spotbugs-annotations to v4.8.0 (solrbot)
+
+* PR#2014: Update dependency com.google.guava:guava to v32.1.3-jre (solrbot)
+
+* PR#2010: Update dependency org.immutables:value-annotations to v2.10.0 (solrbot)
+
+* PR#2009: Update dependency io.opentelemetry:opentelemetry-bom to v1.31.0 (solrbot)
+
+* PR#2008: Update dependency org.semver4j:semver4j to v5.2.2 (solrbot)
+
+* PR#1989: Update org.apache.zookeeper:* to v3.9.1 (solrbot)
+
+* PR#1743: SOLR-17012: Update Apache Hadoop to 3.3.6 and Apache Curator to 5.5.0 (solrbot)
+
+* PR#1745: Update dependency com.google.cloud:google-cloud-bom to v0.204.0 (solrbot)
+
+
+Other Changes
+---------------------
+* SOLR-16949: Restrict certain file types from being uploaded to or downloaded from Config Sets (janhoy, Houston Putman)
 
 ==================  9.4.0 ==================
 New Features

--- a/solr/bin/solr
+++ b/solr/bin/solr
@@ -1886,6 +1886,28 @@ if [ "${SOLR_ENABLE_STREAM_BODY:-false}" == "true" ]; then
   SOLR_OPTS+=("-Dsolr.enableStreamBody=true")
 fi
 
+# Parse global circuit breaker env vars and convert to dot separated, lowercase properties
+if [ -n "${SOLR_CIRCUITBREAKER_UPDATE_CPU:-}" ]; then
+  SOLR_OPTS+=("-Dsolr.circuitbreaker.update.cpu=$SOLR_CIRCUITBREAKER_UPDATE_CPU")
+fi
+if [ -n "${SOLR_CIRCUITBREAKER_UPDATE_MEM:-}" ]; then
+  SOLR_OPTS+=("-Dsolr.circuitbreaker.update.mem=$SOLR_CIRCUITBREAKER_UPDATE_MEM")
+fi
+if [ -n "${SOLR_CIRCUITBREAKER_UPDATE_LOADAVG:-}" ]; then
+  SOLR_OPTS+=("-Dsolr.circuitbreaker.update.loadavg=$SOLR_CIRCUITBREAKER_UPDATE_LOADAVG")
+fi
+if [ -n "${SOLR_CIRCUITBREAKER_QUERY_CPU:-}" ]; then
+  SOLR_OPTS+=("-Dsolr.circuitbreaker.query.cpu=$SOLR_CIRCUITBREAKER_QUERY_CPU")
+fi
+if [ -n "${SOLR_CIRCUITBREAKER_QUERY_MEM:-}" ]; then
+  SOLR_OPTS+=("-Dsolr.circuitbreaker.query.mem=$SOLR_CIRCUITBREAKER_QUERY_MEM")
+fi
+if [ -n "${SOLR_CIRCUITBREAKER_QUERY_LOADAVG:-}" ]; then
+  SOLR_OPTS+=("-Dsolr.circuitbreaker.query.loadavg=$SOLR_CIRCUITBREAKER_QUERY_LOADAVG")
+fi
+
+echo "SOLR_OPTS is now: ${SOLR_OPTS[*]}"
+
 : ${SOLR_SERVER_DIR:=$DEFAULT_SERVER_DIR}
 
 if [ ! -e "$SOLR_SERVER_DIR" ]; then

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -1073,7 +1073,7 @@ public class CoreContainer {
     if (isZooKeeperAware()) {
       containerPluginsRegistry.refresh();
       getZkController().zkStateReader.registerClusterPropertiesListener(containerPluginsRegistry);
-      globalCircuitBreakerRegistry = new GlobalCircuitBreakerManager();
+      globalCircuitBreakerRegistry = new GlobalCircuitBreakerManager(this);
       getZkController().zkStateReader.registerClusterPropertiesListener(globalCircuitBreakerRegistry);
       ContainerPluginsApi containerPluginsApi = new ContainerPluginsApi(this);
       registerV2ApiIfEnabled(containerPluginsApi.readAPI);

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -236,7 +236,8 @@ public class CoreContainer {
 
   private final OrderedExecutor replayUpdatesExecutor;
 
-  private GlobalCircuitBreakerManager globalCircuitBreakerRegistry;
+  private final GlobalCircuitBreakerManager globalCircuitBreakerRegistry =
+      new GlobalCircuitBreakerManager(this);
 
   public CircuitBreakerRegistry getGlobalCircuitBreakerRegistry() {
     return globalCircuitBreakerRegistry.getCircuitBreakerRegistry();
@@ -1074,7 +1075,6 @@ public class CoreContainer {
     if (isZooKeeperAware()) {
       containerPluginsRegistry.refresh();
       getZkController().zkStateReader.registerClusterPropertiesListener(containerPluginsRegistry);
-      globalCircuitBreakerRegistry = new GlobalCircuitBreakerManager(this);
       getZkController()
           .zkStateReader
           .registerClusterPropertiesListener(globalCircuitBreakerRegistry);

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -153,7 +153,6 @@ import org.apache.solr.update.UpdateShardHandler;
 import org.apache.solr.util.OrderedExecutor;
 import org.apache.solr.util.RefCounted;
 import org.apache.solr.util.StartupLoggingUtils;
-import org.apache.solr.util.circuitbreaker.GlobalCircuitBreakerManager;
 import org.apache.solr.util.stats.MetricUtils;
 import org.apache.zookeeper.KeeperException;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
@@ -234,9 +233,6 @@ public class CoreContainer {
           new SolrNamedThreadFactory("coreContainerWorkExecutor"));
 
   private final OrderedExecutor replayUpdatesExecutor;
-
-  private final GlobalCircuitBreakerManager globalCircuitBreakerManager =
-      new GlobalCircuitBreakerManager(this);
 
   protected volatile LogWatcher<?> logging = null;
 
@@ -1070,9 +1066,6 @@ public class CoreContainer {
     if (isZooKeeperAware()) {
       containerPluginsRegistry.refresh();
       getZkController().zkStateReader.registerClusterPropertiesListener(containerPluginsRegistry);
-      getZkController()
-          .zkStateReader
-          .registerClusterPropertiesListener(globalCircuitBreakerManager);
       ContainerPluginsApi containerPluginsApi = new ContainerPluginsApi(this);
       registerV2ApiIfEnabled(containerPluginsApi.readAPI);
       registerV2ApiIfEnabled(containerPluginsApi.editAPI);

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -237,6 +237,7 @@ public class CoreContainer {
   private final OrderedExecutor replayUpdatesExecutor;
 
   private GlobalCircuitBreakerManager globalCircuitBreakerRegistry;
+
   public CircuitBreakerRegistry getGlobalCircuitBreakerRegistry() {
     return globalCircuitBreakerRegistry.getCircuitBreakerRegistry();
   }
@@ -1074,7 +1075,9 @@ public class CoreContainer {
       containerPluginsRegistry.refresh();
       getZkController().zkStateReader.registerClusterPropertiesListener(containerPluginsRegistry);
       globalCircuitBreakerRegistry = new GlobalCircuitBreakerManager(this);
-      getZkController().zkStateReader.registerClusterPropertiesListener(globalCircuitBreakerRegistry);
+      getZkController()
+          .zkStateReader
+          .registerClusterPropertiesListener(globalCircuitBreakerRegistry);
       ContainerPluginsApi containerPluginsApi = new ContainerPluginsApi(this);
       registerV2ApiIfEnabled(containerPluginsApi.readAPI);
       registerV2ApiIfEnabled(containerPluginsApi.editAPI);

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -178,6 +178,7 @@ import org.apache.solr.util.RefCounted;
 import org.apache.solr.util.TestInjection;
 import org.apache.solr.util.circuitbreaker.CircuitBreaker;
 import org.apache.solr.util.circuitbreaker.CircuitBreakerRegistry;
+import org.apache.solr.util.circuitbreaker.GlobalCircuitBreakerManager;
 import org.apache.solr.util.plugin.NamedListInitializedPlugin;
 import org.apache.solr.util.plugin.PluginInfoInitialized;
 import org.apache.solr.util.plugin.SolrCoreAware;
@@ -1115,8 +1116,7 @@ public class SolrCore implements SolrInfoBean, Closeable {
       // init pluggable circuit breakers, after metrics because some circuit breakers use metrics
       initPlugins(null, CircuitBreaker.class);
       if (this.coreContainer.isZooKeeperAware()) {
-        this.circuitBreakerRegistry.setGlobalRegistry(
-            this.coreContainer.getGlobalCircuitBreakerRegistry());
+        this.circuitBreakerRegistry.setGlobalRegistry(this.coreContainer.getGlobalCircuitBreakerRegistry());
       }
 
       SolrFieldCacheBean solrFieldCacheBean = new SolrFieldCacheBean();

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -251,7 +251,7 @@ public class SolrCore implements SolrInfoBean, Closeable {
   private final ConfigSet configSet;
   // singleton listener for all packages used in schema
 
-  private final CircuitBreakerRegistry circuitBreakerRegistry = new CircuitBreakerRegistry();
+  private final CircuitBreakerRegistry circuitBreakerRegistry;
 
   private final List<Runnable> confListeners = new CopyOnWriteArrayList<>();
 
@@ -1073,6 +1073,7 @@ public class SolrCore implements SolrInfoBean, Closeable {
     final CountDownLatch latch = new CountDownLatch(1);
     try {
       this.coreContainer = coreContainer;
+      this.circuitBreakerRegistry = new CircuitBreakerRegistry(coreContainer);
       this.configSet = configSet;
       this.coreDescriptor = Objects.requireNonNull(coreDescriptor, "coreDescriptor cannot be null");
       this.name = Objects.requireNonNull(coreDescriptor.getName());
@@ -3184,6 +3185,9 @@ public class SolrCore implements SolrInfoBean, Closeable {
             type.getSimpleName() + "." + info.name, (SolrMetricProducer) o);
       }
       if (o instanceof CircuitBreaker) {
+        if (o instanceof SolrCoreAware) {
+          ((SolrCoreAware) o).inform(this);
+        }
         circuitBreakerRegistry.register((CircuitBreaker) o);
       }
       if (info.isDefault()) {

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -178,6 +178,7 @@ import org.apache.solr.util.RefCounted;
 import org.apache.solr.util.TestInjection;
 import org.apache.solr.util.circuitbreaker.CircuitBreaker;
 import org.apache.solr.util.circuitbreaker.CircuitBreakerRegistry;
+import org.apache.solr.util.circuitbreaker.GlobalCircuitBreakerManager;
 import org.apache.solr.util.plugin.NamedListInitializedPlugin;
 import org.apache.solr.util.plugin.PluginInfoInitialized;
 import org.apache.solr.util.plugin.SolrCoreAware;
@@ -1074,6 +1075,9 @@ public class SolrCore implements SolrInfoBean, Closeable {
     try {
       this.coreContainer = coreContainer;
       this.circuitBreakerRegistry = new CircuitBreakerRegistry(coreContainer);
+      if (this.coreContainer.isZooKeeperAware()) {
+        GlobalCircuitBreakerManager.init(coreContainer);
+      }
       this.configSet = configSet;
       this.coreDescriptor = Objects.requireNonNull(coreDescriptor, "coreDescriptor cannot be null");
       this.name = Objects.requireNonNull(coreDescriptor.getName());

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -178,7 +178,6 @@ import org.apache.solr.util.RefCounted;
 import org.apache.solr.util.TestInjection;
 import org.apache.solr.util.circuitbreaker.CircuitBreaker;
 import org.apache.solr.util.circuitbreaker.CircuitBreakerRegistry;
-import org.apache.solr.util.circuitbreaker.GlobalCircuitBreakerManager;
 import org.apache.solr.util.plugin.NamedListInitializedPlugin;
 import org.apache.solr.util.plugin.PluginInfoInitialized;
 import org.apache.solr.util.plugin.SolrCoreAware;
@@ -1115,9 +1114,6 @@ public class SolrCore implements SolrInfoBean, Closeable {
 
       // init pluggable circuit breakers, after metrics because some circuit breakers use metrics
       initPlugins(null, CircuitBreaker.class);
-      if (this.coreContainer.isZooKeeperAware()) {
-        this.circuitBreakerRegistry.setGlobalRegistry(this.coreContainer.getGlobalCircuitBreakerRegistry());
-      }
 
       SolrFieldCacheBean solrFieldCacheBean = new SolrFieldCacheBean();
       // this is registered at the CONTAINER level because it's not core-specific - for now we

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -178,7 +178,6 @@ import org.apache.solr.util.RefCounted;
 import org.apache.solr.util.TestInjection;
 import org.apache.solr.util.circuitbreaker.CircuitBreaker;
 import org.apache.solr.util.circuitbreaker.CircuitBreakerRegistry;
-import org.apache.solr.util.circuitbreaker.GlobalCircuitBreakerManager;
 import org.apache.solr.util.plugin.NamedListInitializedPlugin;
 import org.apache.solr.util.plugin.PluginInfoInitialized;
 import org.apache.solr.util.plugin.SolrCoreAware;
@@ -1116,7 +1115,8 @@ public class SolrCore implements SolrInfoBean, Closeable {
       // init pluggable circuit breakers, after metrics because some circuit breakers use metrics
       initPlugins(null, CircuitBreaker.class);
       if (this.coreContainer.isZooKeeperAware()) {
-        this.circuitBreakerRegistry.setGlobalRegistry(this.coreContainer.getGlobalCircuitBreakerRegistry());
+        this.circuitBreakerRegistry.setGlobalRegistry(
+            this.coreContainer.getGlobalCircuitBreakerRegistry());
       }
 
       SolrFieldCacheBean solrFieldCacheBean = new SolrFieldCacheBean();

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -178,6 +178,7 @@ import org.apache.solr.util.RefCounted;
 import org.apache.solr.util.TestInjection;
 import org.apache.solr.util.circuitbreaker.CircuitBreaker;
 import org.apache.solr.util.circuitbreaker.CircuitBreakerRegistry;
+import org.apache.solr.util.circuitbreaker.GlobalCircuitBreakerManager;
 import org.apache.solr.util.plugin.NamedListInitializedPlugin;
 import org.apache.solr.util.plugin.PluginInfoInitialized;
 import org.apache.solr.util.plugin.SolrCoreAware;
@@ -1114,6 +1115,9 @@ public class SolrCore implements SolrInfoBean, Closeable {
 
       // init pluggable circuit breakers, after metrics because some circuit breakers use metrics
       initPlugins(null, CircuitBreaker.class);
+      if (this.coreContainer.isZooKeeperAware()) {
+        this.circuitBreakerRegistry.setGlobalRegistry(this.coreContainer.getGlobalCircuitBreakerRegistry());
+      }
 
       SolrFieldCacheBean solrFieldCacheBean = new SolrFieldCacheBean();
       // this is registered at the CONTAINER level because it's not core-specific - for now we

--- a/solr/core/src/java/org/apache/solr/core/SolrResourceLoader.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrResourceLoader.java
@@ -72,6 +72,7 @@ import org.apache.solr.schema.ManagedIndexSchemaFactory;
 import org.apache.solr.schema.SimilarityFactory;
 import org.apache.solr.search.QParserPlugin;
 import org.apache.solr.update.processor.UpdateRequestProcessorFactory;
+import org.apache.solr.util.circuitbreaker.CircuitBreaker;
 import org.apache.solr.util.plugin.SolrCoreAware;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -813,7 +814,8 @@ public class SolrResourceLoader
         SolrCoreAware.class,
         new Class<?>[] {
           // DO NOT ADD THINGS TO THIS LIST -- ESPECIALLY THINGS THAT CAN BE CREATED DYNAMICALLY
-          // VIA RUNTIME APIS -- UNTILL CAREFULLY CONSIDERING THE ISSUES MENTIONED IN SOLR-8311
+          // VIA RUNTIME APIS -- UNTIL CAREFULLY CONSIDERING THE ISSUES MENTIONED IN SOLR-8311
+          CircuitBreaker.class,
           CodecFactory.class,
           DirectoryFactory.class,
           ManagedIndexSchemaFactory.class,
@@ -919,7 +921,7 @@ public class SolrResourceLoader
   }
 
   /**
-   * Create a n instance of a class using an appropriate {@link SolrResourceLoader} depending on the
+   * Create an instance of a class using an appropriate {@link SolrResourceLoader} depending on the
    * package of that class
    *
    * @param registerCoreReloadListener register a listener for the package and reload the core if

--- a/solr/core/src/java/org/apache/solr/handler/ContentStreamHandlerBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/ContentStreamHandlerBase.java
@@ -131,15 +131,10 @@ public abstract class ContentStreamHandlerBase extends RequestHandlerBase {
       return false;
     }
     CircuitBreakerRegistry circuitBreakerRegistry = req.getCore().getCircuitBreakerRegistry();
-    CircuitBreakerRegistry globalCircuitBreakerRegistry =
-        req.getCoreContainer().getGlobalCircuitBreakerRegistry();
-    if (circuitBreakerRegistry.isEnabled(SolrRequestType.UPDATE)
-        || globalCircuitBreakerRegistry.isEnabled(SolrRequestType.UPDATE)) {
+    if (circuitBreakerRegistry.isEnabled(SolrRequestType.UPDATE)) {
       List<CircuitBreaker> trippedCircuitBreakers =
           circuitBreakerRegistry.checkTripped(SolrRequestType.UPDATE);
-      trippedCircuitBreakers.addAll(
-          globalCircuitBreakerRegistry.checkTripped(SolrRequestType.UPDATE));
-      if (!trippedCircuitBreakers.isEmpty()) {
+      if (trippedCircuitBreakers != null) {
         String errorMessage = CircuitBreakerRegistry.toErrorMessage(trippedCircuitBreakers);
         rsp.add(STATUS, FAILURE);
         rsp.setException(

--- a/solr/core/src/java/org/apache/solr/handler/ContentStreamHandlerBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/ContentStreamHandlerBase.java
@@ -131,10 +131,12 @@ public abstract class ContentStreamHandlerBase extends RequestHandlerBase {
       return false;
     }
     CircuitBreakerRegistry circuitBreakerRegistry = req.getCore().getCircuitBreakerRegistry();
-    if (circuitBreakerRegistry.isEnabled(SolrRequestType.UPDATE)) {
+    CircuitBreakerRegistry globalCircuitBreakerRegistry = req.getCoreContainer().getGlobalCircuitBreakerRegistry();
+    if (circuitBreakerRegistry.isEnabled(SolrRequestType.UPDATE) || globalCircuitBreakerRegistry.isEnabled(SolrRequestType.UPDATE)) {
       List<CircuitBreaker> trippedCircuitBreakers =
           circuitBreakerRegistry.checkTripped(SolrRequestType.UPDATE);
-      if (trippedCircuitBreakers != null) {
+      trippedCircuitBreakers.addAll(globalCircuitBreakerRegistry.checkTripped(SolrRequestType.UPDATE));
+      if (!trippedCircuitBreakers.isEmpty()) {
         String errorMessage = CircuitBreakerRegistry.toErrorMessage(trippedCircuitBreakers);
         rsp.add(STATUS, FAILURE);
         rsp.setException(
@@ -146,6 +148,7 @@ public abstract class ContentStreamHandlerBase extends RequestHandlerBase {
     }
     return false;
   }
+
 
   protected abstract ContentStreamLoader newLoader(
       SolrQueryRequest req, UpdateRequestProcessor processor);

--- a/solr/core/src/java/org/apache/solr/handler/ContentStreamHandlerBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/ContentStreamHandlerBase.java
@@ -131,11 +131,14 @@ public abstract class ContentStreamHandlerBase extends RequestHandlerBase {
       return false;
     }
     CircuitBreakerRegistry circuitBreakerRegistry = req.getCore().getCircuitBreakerRegistry();
-    CircuitBreakerRegistry globalCircuitBreakerRegistry = req.getCoreContainer().getGlobalCircuitBreakerRegistry();
-    if (circuitBreakerRegistry.isEnabled(SolrRequestType.UPDATE) || globalCircuitBreakerRegistry.isEnabled(SolrRequestType.UPDATE)) {
+    CircuitBreakerRegistry globalCircuitBreakerRegistry =
+        req.getCoreContainer().getGlobalCircuitBreakerRegistry();
+    if (circuitBreakerRegistry.isEnabled(SolrRequestType.UPDATE)
+        || globalCircuitBreakerRegistry.isEnabled(SolrRequestType.UPDATE)) {
       List<CircuitBreaker> trippedCircuitBreakers =
           circuitBreakerRegistry.checkTripped(SolrRequestType.UPDATE);
-      trippedCircuitBreakers.addAll(globalCircuitBreakerRegistry.checkTripped(SolrRequestType.UPDATE));
+      trippedCircuitBreakers.addAll(
+          globalCircuitBreakerRegistry.checkTripped(SolrRequestType.UPDATE));
       if (!trippedCircuitBreakers.isEmpty()) {
         String errorMessage = CircuitBreakerRegistry.toErrorMessage(trippedCircuitBreakers);
         rsp.add(STATUS, FAILURE);
@@ -148,7 +151,6 @@ public abstract class ContentStreamHandlerBase extends RequestHandlerBase {
     }
     return false;
   }
-
 
   protected abstract ContentStreamLoader newLoader(
       SolrQueryRequest req, UpdateRequestProcessor processor);

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -362,8 +362,10 @@ public class SearchHandler extends RequestHandlerBase
     final RTimerTree timer = rb.isDebug() ? req.getRequestTimer() : null;
 
     final CircuitBreakerRegistry circuitBreakerRegistry = req.getCore().getCircuitBreakerRegistry();
-    final CircuitBreakerRegistry globalCircuitBreakerRegistry = req.getCoreContainer().getGlobalCircuitBreakerRegistry();
-    if (circuitBreakerRegistry.isEnabled(SolrRequestType.QUERY) || globalCircuitBreakerRegistry.isEnabled(SolrRequestType.QUERY)) {
+    final CircuitBreakerRegistry globalCircuitBreakerRegistry =
+        req.getCoreContainer().getGlobalCircuitBreakerRegistry();
+    if (circuitBreakerRegistry.isEnabled(SolrRequestType.QUERY)
+        || globalCircuitBreakerRegistry.isEnabled(SolrRequestType.QUERY)) {
       List<CircuitBreaker> trippedCircuitBreakers;
 
       if (timer != null) {
@@ -371,12 +373,14 @@ public class SearchHandler extends RequestHandlerBase
         rb.setTimer(subt);
 
         trippedCircuitBreakers = circuitBreakerRegistry.checkTripped(SolrRequestType.QUERY);
-        trippedCircuitBreakers.addAll(globalCircuitBreakerRegistry.checkTripped(SolrRequestType.QUERY));
+        trippedCircuitBreakers.addAll(
+            globalCircuitBreakerRegistry.checkTripped(SolrRequestType.QUERY));
 
         rb.getTimer().stop();
       } else {
         trippedCircuitBreakers = circuitBreakerRegistry.checkTripped(SolrRequestType.QUERY);
-        trippedCircuitBreakers.addAll(globalCircuitBreakerRegistry.checkTripped(SolrRequestType.QUERY));
+        trippedCircuitBreakers.addAll(
+            globalCircuitBreakerRegistry.checkTripped(SolrRequestType.QUERY));
       }
 
       if (!trippedCircuitBreakers.isEmpty()) {

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -362,7 +362,8 @@ public class SearchHandler extends RequestHandlerBase
     final RTimerTree timer = rb.isDebug() ? req.getRequestTimer() : null;
 
     final CircuitBreakerRegistry circuitBreakerRegistry = req.getCore().getCircuitBreakerRegistry();
-    if (circuitBreakerRegistry.isEnabled(SolrRequestType.QUERY)) {
+    final CircuitBreakerRegistry globalCircuitBreakerRegistry = req.getCoreContainer().getGlobalCircuitBreakerRegistry();
+    if (circuitBreakerRegistry.isEnabled(SolrRequestType.QUERY) || globalCircuitBreakerRegistry.isEnabled(SolrRequestType.QUERY)) {
       List<CircuitBreaker> trippedCircuitBreakers;
 
       if (timer != null) {
@@ -370,13 +371,15 @@ public class SearchHandler extends RequestHandlerBase
         rb.setTimer(subt);
 
         trippedCircuitBreakers = circuitBreakerRegistry.checkTripped(SolrRequestType.QUERY);
+        trippedCircuitBreakers.addAll(globalCircuitBreakerRegistry.checkTripped(SolrRequestType.QUERY));
 
         rb.getTimer().stop();
       } else {
         trippedCircuitBreakers = circuitBreakerRegistry.checkTripped(SolrRequestType.QUERY);
+        trippedCircuitBreakers.addAll(globalCircuitBreakerRegistry.checkTripped(SolrRequestType.QUERY));
       }
 
-      if (trippedCircuitBreakers != null) {
+      if (!trippedCircuitBreakers.isEmpty()) {
         String errorMessage = CircuitBreakerRegistry.toErrorMessage(trippedCircuitBreakers);
         rsp.add(STATUS, FAILURE);
         rsp.setException(

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -17,9 +17,7 @@
 package org.apache.solr.handler.component;
 
 import static org.apache.solr.common.params.CommonParams.DISTRIB;
-import static org.apache.solr.common.params.CommonParams.FAILURE;
 import static org.apache.solr.common.params.CommonParams.PATH;
-import static org.apache.solr.common.params.CommonParams.STATUS;
 
 import com.codahale.metrics.Counter;
 import java.io.PrintWriter;
@@ -81,6 +79,7 @@ import org.apache.solr.util.RTimerTree;
 import org.apache.solr.util.SolrPluginUtils;
 import org.apache.solr.util.circuitbreaker.CircuitBreaker;
 import org.apache.solr.util.circuitbreaker.CircuitBreakerRegistry;
+import org.apache.solr.util.circuitbreaker.CircuitBreakerUtils;
 import org.apache.solr.util.plugin.PluginInfoInitialized;
 import org.apache.solr.util.plugin.SolrCoreAware;
 import org.slf4j.Logger;
@@ -376,15 +375,7 @@ public class SearchHandler extends RequestHandlerBase
         trippedCircuitBreakers = circuitBreakerRegistry.checkTripped(SolrRequestType.QUERY);
       }
 
-      if (trippedCircuitBreakers != null) {
-        String errorMessage = CircuitBreakerRegistry.toErrorMessage(trippedCircuitBreakers);
-        rsp.add(STATUS, FAILURE);
-        rsp.setException(
-            new SolrException(
-                CircuitBreaker.getErrorCode(trippedCircuitBreakers),
-                "Circuit Breakers tripped " + errorMessage));
-        return true;
-      }
+      return CircuitBreakerUtils.reportErrorIfBreakersTripped(rsp, trippedCircuitBreakers);
     }
     return false;
   }

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -362,10 +362,7 @@ public class SearchHandler extends RequestHandlerBase
     final RTimerTree timer = rb.isDebug() ? req.getRequestTimer() : null;
 
     final CircuitBreakerRegistry circuitBreakerRegistry = req.getCore().getCircuitBreakerRegistry();
-    final CircuitBreakerRegistry globalCircuitBreakerRegistry =
-        req.getCoreContainer().getGlobalCircuitBreakerRegistry();
-    if (circuitBreakerRegistry.isEnabled(SolrRequestType.QUERY)
-        || globalCircuitBreakerRegistry.isEnabled(SolrRequestType.QUERY)) {
+    if (circuitBreakerRegistry.isEnabled(SolrRequestType.QUERY)) {
       List<CircuitBreaker> trippedCircuitBreakers;
 
       if (timer != null) {
@@ -373,17 +370,13 @@ public class SearchHandler extends RequestHandlerBase
         rb.setTimer(subt);
 
         trippedCircuitBreakers = circuitBreakerRegistry.checkTripped(SolrRequestType.QUERY);
-        trippedCircuitBreakers.addAll(
-            globalCircuitBreakerRegistry.checkTripped(SolrRequestType.QUERY));
 
         rb.getTimer().stop();
       } else {
         trippedCircuitBreakers = circuitBreakerRegistry.checkTripped(SolrRequestType.QUERY);
-        trippedCircuitBreakers.addAll(
-            globalCircuitBreakerRegistry.checkTripped(SolrRequestType.QUERY));
       }
 
-      if (!trippedCircuitBreakers.isEmpty()) {
+      if (trippedCircuitBreakers != null) {
         String errorMessage = CircuitBreakerRegistry.toErrorMessage(trippedCircuitBreakers);
         rsp.add(STATUS, FAILURE);
         rsp.setException(

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CPUCircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CPUCircuitBreaker.java
@@ -126,7 +126,6 @@ public class CPUCircuitBreaker extends CircuitBreaker {
             .registry("solr.jvm")
             .getMetrics()
             .get("os.systemCpuLoad");
-    ;
     if (metric == null) {
       return -1.0;
     }

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CPUCircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CPUCircuitBreaker.java
@@ -121,11 +121,12 @@ public class CPUCircuitBreaker extends CircuitBreaker {
   protected double calculateLiveCPUUsage() {
     // TODO: Use Codahale Meter to calculate the value
     Metric metric =
-            this.coreContainer
+        this.coreContainer
             .getMetricManager()
             .registry("solr.jvm")
             .getMetrics()
-            .get("os.systemCpuLoad");;
+            .get("os.systemCpuLoad");
+    ;
     if (metric == null) {
       return -1.0;
     }

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CPUCircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CPUCircuitBreaker.java
@@ -20,6 +20,7 @@ package org.apache.solr.util.circuitbreaker;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
 import java.lang.invoke.MethodHandles;
+import java.util.Locale;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.metrics.SolrMetricManager;
@@ -130,6 +131,16 @@ public class CPUCircuitBreaker extends CircuitBreaker implements SolrCoreAware {
   public void inform(SolrCore core) {
     this.cc = core.getCoreContainer();
     enableIfSupported();
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        Locale.ROOT,
+        "%s(threshold=%f, warnOnly=%b)",
+        getClass().getSimpleName(),
+        cpuUsageThreshold,
+        isWarnOnly());
   }
 
   private void enableIfSupported() {

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreaker.java
@@ -50,7 +50,6 @@ public abstract class CircuitBreaker implements NamedListInitializedPlugin, Clos
   private final List<SolrRequestType> SUPPORTED_TYPES =
       List.of(SolrRequestType.QUERY, SolrRequestType.UPDATE);
 
-
   @Override
   public void init(NamedList<?> args) {
     SolrPluginUtils.invokeSetters(this, args);

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreaker.java
@@ -50,6 +50,7 @@ public abstract class CircuitBreaker implements NamedListInitializedPlugin, Clos
       List.of(SolrRequestType.QUERY, SolrRequestType.UPDATE);
 
   private boolean debugMode = false;
+  private double threshold;
 
   @Override
   public void init(NamedList<?> args) {
@@ -119,5 +120,9 @@ public abstract class CircuitBreaker implements NamedListInitializedPlugin, Clos
 
   public void setDebugMode(boolean debugMode) {
     this.debugMode = debugMode;
+  }
+
+  public void setThreshold(double threshold) {
+    this.threshold = threshold;
   }
 }

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreaker.java
@@ -46,6 +46,7 @@ import org.apache.solr.util.plugin.NamedListInitializedPlugin;
 public abstract class CircuitBreaker implements NamedListInitializedPlugin, Closeable {
   // Only query requests are checked by default
   private Set<SolrRequestType> requestTypes = Set.of(SolrRequestType.QUERY);
+  private boolean warnOnly;
   private final List<SolrRequestType> SUPPORTED_TYPES =
       List.of(SolrRequestType.QUERY, SolrRequestType.UPDATE);
 
@@ -54,6 +55,9 @@ public abstract class CircuitBreaker implements NamedListInitializedPlugin, Clos
   @Override
   public void init(NamedList<?> args) {
     SolrPluginUtils.invokeSetters(this, args);
+    if (args.getBooleanArg("warnOnly") != null) {
+      setWarnOnly(args.getBooleanArg("warnOnly"));
+    }
   }
 
   public CircuitBreaker() {}
@@ -95,6 +99,14 @@ public abstract class CircuitBreaker implements NamedListInitializedPlugin, Clos
                   }
                 })
             .collect(Collectors.toSet());
+  }
+
+  public void setWarnOnly(boolean warnOnly) {
+    this.warnOnly = warnOnly;
+  }
+
+  public boolean isWarnOnly() {
+    return warnOnly;
   }
 
   public Set<SolrRequestType> getRequestTypes() {

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreaker.java
@@ -50,7 +50,6 @@ public abstract class CircuitBreaker implements NamedListInitializedPlugin, Clos
       List.of(SolrRequestType.QUERY, SolrRequestType.UPDATE);
 
   private boolean debugMode = false;
-  private double threshold;
 
   @Override
   public void init(NamedList<?> args) {
@@ -122,7 +121,5 @@ public abstract class CircuitBreaker implements NamedListInitializedPlugin, Clos
     this.debugMode = debugMode;
   }
 
-  public void setThreshold(double threshold) {
-    this.threshold = threshold;
-  }
+  public abstract void setThreshold(double threshold);
 }

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreaker.java
@@ -50,7 +50,6 @@ public abstract class CircuitBreaker implements NamedListInitializedPlugin, Clos
   private final List<SolrRequestType> SUPPORTED_TYPES =
       List.of(SolrRequestType.QUERY, SolrRequestType.UPDATE);
 
-  private boolean debugMode = false;
 
   @Override
   public void init(NamedList<?> args) {
@@ -67,10 +66,6 @@ public abstract class CircuitBreaker implements NamedListInitializedPlugin, Clos
 
   /** Get error message when the circuit breaker triggers */
   public abstract String getErrorMessage();
-
-  public boolean isDebugMode() {
-    return debugMode;
-  }
 
   @Override
   public void close() throws IOException {
@@ -127,10 +122,6 @@ public abstract class CircuitBreaker implements NamedListInitializedPlugin, Clos
     } else {
       return SolrException.ErrorCode.TOO_MANY_REQUESTS;
     }
-  }
-
-  public void setDebugMode(boolean debugMode) {
-    this.debugMode = debugMode;
   }
 
   public abstract CircuitBreaker setThreshold(double threshold);

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerManager.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerManager.java
@@ -92,7 +92,9 @@ public class CircuitBreakerManager extends CircuitBreaker {
   }
 
   @Override
-  public CircuitBreakerManager setThreshold(double threshold) {return this;}
+  public CircuitBreakerManager setThreshold(double threshold) {
+    return this;
+  }
 
   // The methods below will be called by super class during init
   public void setMemEnabled(String enabled) {

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerManager.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerManager.java
@@ -91,6 +91,9 @@ public class CircuitBreakerManager extends CircuitBreaker {
     }
   }
 
+  @Override
+  public void setThreshold(double threshold) {}
+
   // The methods below will be called by super class during init
   public void setMemEnabled(String enabled) {
     this.memEnabled = Boolean.getBoolean(enabled);

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CircuitBreakerRegistry implements Closeable {
   protected static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-  
+
   private final Map<SolrRequestType, List<CircuitBreaker>> circuitBreakerMap = new HashMap<>();
   private static final Map<String, Long> circuitBreakerTrippedMetrics = new ConcurrentHashMap<>();
 

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
@@ -40,9 +40,9 @@ import org.slf4j.LoggerFactory;
  * @since 9.4
  */
 public class CircuitBreakerRegistry implements Closeable {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  protected static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  private final Map<SolrRequestType, List<CircuitBreaker>> circuitBreakerMap = new HashMap<>();
+  protected final Map<SolrRequestType, List<CircuitBreaker>> circuitBreakerMap = new HashMap<>();
 
   public CircuitBreakerRegistry() {}
 
@@ -77,7 +77,7 @@ public class CircuitBreakerRegistry implements Closeable {
    * @return CircuitBreakers which have triggered, null otherwise.
    */
   public List<CircuitBreaker> checkTripped(SolrRequestType requestType) {
-    List<CircuitBreaker> triggeredCircuitBreakers = null;
+    List<CircuitBreaker> triggeredCircuitBreakers = new ArrayList<>();
 
     for (CircuitBreaker circuitBreaker :
         circuitBreakerMap.getOrDefault(requestType, Collections.emptyList())) {
@@ -90,10 +90,6 @@ public class CircuitBreakerRegistry implements Closeable {
                 circuitBreaker.getErrorMessage());
           }
         } else {
-          if (triggeredCircuitBreakers == null) {
-            triggeredCircuitBreakers = new ArrayList<>();
-          }
-
           triggeredCircuitBreakers.add(circuitBreaker);
         }
       }

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
@@ -46,8 +46,6 @@ public class CircuitBreakerRegistry implements Closeable {
   private final Map<SolrRequestType, List<CircuitBreaker>> circuitBreakerMap = new HashMap<>();
   private static final Map<String, Long> circuitBreakerTrippedMetrics = new ConcurrentHashMap<>();
 
-  private CircuitBreakerRegistry globalRegistry;
-
   public CircuitBreakerRegistry() {}
 
   public void register(CircuitBreaker circuitBreaker) {
@@ -100,10 +98,6 @@ public class CircuitBreakerRegistry implements Closeable {
       }
     }
 
-    if (globalRegistry != null) {
-      triggeredCircuitBreakers.addAll(globalRegistry.checkTripped(requestType));
-    }
-
     return triggeredCircuitBreakers;
   }
 
@@ -138,10 +132,6 @@ public class CircuitBreakerRegistry implements Closeable {
 
   public boolean isEnabled(SolrRequestType requestType) {
     return circuitBreakerMap.containsKey(requestType);
-  }
-
-  public void setGlobalRegistry(CircuitBreakerRegistry globalRegistry) {
-    this.globalRegistry = globalRegistry;
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
@@ -22,32 +22,102 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.core.CoreContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Keeps track of all registered circuit breaker instances for various request types. Responsible
- * for a holistic view of whether a circuit breaker has tripped or not.
+ * for a holistic view of whether a circuit breaker has tripped or not. Circuit breakers may be
+ * registered globally and/or per-core. This registry has one instance per core, but keeps a static
+ * map of globally registered Circuit Breakers that are always checked.
  *
  * @lucene.experimental
  * @since 9.4
  */
 public class CircuitBreakerRegistry implements Closeable {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
   private final Map<SolrRequestType, List<CircuitBreaker>> circuitBreakerMap = new HashMap<>();
   private static final Map<String, Long> circuitBreakerTrippedMetrics = new ConcurrentHashMap<>();
+  private static final Map<SolrRequestType, List<CircuitBreaker>> globalCircuitBreakerMap =
+      new HashMap<>();
+  private static final Pattern SYSPROP_REGEX =
+      Pattern.compile("solr.circuitbreaker\\.(update|query)\\.(cpu|mem|loadavg)");
+  public static final String SYSPROP_PREFIX = "solr.circuitbreaker.";
+  public static final String SYSPROP_UPDATE_CPU = SYSPROP_PREFIX + "update.cpu";
+  public static final String SYSPROP_UPDATE_MEM = SYSPROP_PREFIX + "update.mem";
+  public static final String SYSPROP_UPDATE_LOADAVG = SYSPROP_PREFIX + "update.loadavg";
+  public static final String SYSPROP_QUERY_CPU = SYSPROP_PREFIX + "query.cpu";
+  public static final String SYSPROP_QUERY_MEM = SYSPROP_PREFIX + "query.mem";
+  public static final String SYSPROP_QUERY_LOADAVG = SYSPROP_PREFIX + "query.loadavg";
 
-  public CircuitBreakerRegistry() {}
+  public CircuitBreakerRegistry(CoreContainer coreContainer) {
+    initGlobal(coreContainer);
+  }
 
+  private static void initGlobal(CoreContainer coreContainer) {
+    // Read system properties to register global circuit breakers for update and query:
+    // Example: solr.circuitbreaker.update.cpu = 50
+    System.getProperties().keySet().stream()
+        .map(k -> SYSPROP_REGEX.matcher(k.toString()))
+        .filter(Matcher::matches)
+        .collect(Collectors.groupingBy(m -> m.group(2) + ":" + System.getProperty(m.group(0))))
+        .forEach(
+            (breakerAndValue, breakers) -> {
+              CircuitBreaker breaker;
+              String[] breakerAndValueArr = breakerAndValue.split(":");
+              switch (breakerAndValueArr[0]) {
+                case "cpu":
+                  breaker =
+                      new CPUCircuitBreaker(coreContainer)
+                          .setThreshold(Double.parseDouble(breakerAndValueArr[1]));
+                  break;
+                case "mem":
+                  breaker =
+                      new MemoryCircuitBreaker()
+                          .setThreshold(Double.parseDouble(breakerAndValueArr[1]));
+                  break;
+                case "loadavg":
+                  breaker =
+                      new LoadAverageCircuitBreaker()
+                          .setThreshold(Double.parseDouble(breakerAndValueArr[1]));
+                  break;
+                default:
+                  throw new IllegalArgumentException(
+                      "Unknown circuit breaker type: " + breakerAndValueArr[0]);
+              }
+              breaker.setRequestTypes(
+                  breakers.stream().map(m -> m.group(1)).collect(Collectors.toList()));
+              registerGlobal(breaker);
+              if (log.isInfoEnabled()) {
+                log.info(
+                    "Registered global circuit breaker {} for request type(s) {}",
+                    breakerAndValue,
+                    breaker.getRequestTypes());
+              }
+            });
+  }
+
+  /** List all registered circuit breakers for global context */
+  public static Set<CircuitBreaker> listGlobal() {
+    return globalCircuitBreakerMap.values().stream()
+        .flatMap(List::stream)
+        .collect(Collectors.toSet());
+  }
+
+  /** Register a circuit breaker for a core */
   public void register(CircuitBreaker circuitBreaker) {
     synchronized (circuitBreakerMap) {
       circuitBreaker
@@ -67,9 +137,27 @@ public class CircuitBreakerRegistry implements Closeable {
     }
   }
 
+  /** Register a global circuit breaker */
+  public static void registerGlobal(CircuitBreaker circuitBreaker) {
+    circuitBreaker
+        .getRequestTypes()
+        .forEach(
+            r -> {
+              List<CircuitBreaker> list =
+                  globalCircuitBreakerMap.computeIfAbsent(r, k -> new ArrayList<>());
+              list.add(circuitBreaker);
+            });
+  }
+
   @VisibleForTesting
   public void deregisterAll() throws IOException {
     this.close();
+    deregisterGlobal();
+  }
+
+  @VisibleForTesting
+  public static void deregisterGlobal() {
+    closeGlobal();
   }
 
   /**
@@ -79,10 +167,10 @@ public class CircuitBreakerRegistry implements Closeable {
    * @return CircuitBreakers which have triggered, null otherwise.
    */
   public List<CircuitBreaker> checkTripped(SolrRequestType requestType) {
+    Map<SolrRequestType, List<CircuitBreaker>> combinedMap = getCombinedMap();
+    final List<CircuitBreaker> breakersOfType = combinedMap.get(requestType);
     List<CircuitBreaker> triggeredCircuitBreakers = null;
-
-    for (CircuitBreaker circuitBreaker :
-        circuitBreakerMap.getOrDefault(requestType, Collections.emptyList())) {
+    for (CircuitBreaker circuitBreaker : breakersOfType) {
       if (circuitBreaker.isTripped()) {
         incrementTripped(requestType, circuitBreaker);
         if (circuitBreaker.isDebugMode()) {
@@ -135,43 +223,83 @@ public class CircuitBreakerRegistry implements Closeable {
   }
 
   public boolean isEnabled(SolrRequestType requestType) {
-    return circuitBreakerMap.containsKey(requestType);
+    return circuitBreakerMap.containsKey(requestType)
+        || globalCircuitBreakerMap.containsKey(requestType);
   }
 
   @Override
   public void close() throws IOException {
     synchronized (circuitBreakerMap) {
-      final AtomicInteger closeFailedCounter = new AtomicInteger(0);
-      circuitBreakerMap
-          .values()
-          .forEach(
-              list ->
-                  list.forEach(
-                      it -> {
-                        try {
-                          if (log.isDebugEnabled()) {
-                            log.debug(
-                                "Closed circuit breaker {} for request type(s) {}",
-                                it.getClass().getSimpleName(),
-                                it.getRequestTypes());
-                          }
-                          it.close();
-                        } catch (IOException e) {
-                          if (log.isErrorEnabled()) {
-                            log.error(
-                                String.format(
-                                    Locale.ROOT,
-                                    "Failed to close circuit breaker %s",
-                                    it.getClass().getSimpleName()),
-                                e);
-                          }
-                          closeFailedCounter.incrementAndGet();
-                        }
-                      }));
+      closeCircuitBreakers(
+          circuitBreakerMap.values().stream().flatMap(List::stream).collect(Collectors.toList()));
       circuitBreakerMap.clear();
-      if (closeFailedCounter.get() > 0) {
-        throw new IOException("Failed to close " + closeFailedCounter.get() + " circuit breakers");
-      }
     }
+  }
+
+  private static void closeGlobal() {
+    synchronized (globalCircuitBreakerMap) {
+      closeCircuitBreakers(
+          globalCircuitBreakerMap.values().stream()
+              .flatMap(List::stream)
+              .collect(Collectors.toList()));
+      globalCircuitBreakerMap.clear();
+    }
+  }
+
+  /**
+   * Close a list of circuit breakers, tracing any failures.
+   *
+   * @throws SolrException if any CB fails to close
+   */
+  private static void closeCircuitBreakers(List<CircuitBreaker> breakers) {
+    final AtomicInteger closeFailedCounter = new AtomicInteger(0);
+    breakers.forEach(
+        it -> {
+          try {
+            if (log.isDebugEnabled()) {
+              log.debug(
+                  "Closing circuit breaker {} for request type(s) {}",
+                  it.getClass().getSimpleName(),
+                  it.getRequestTypes());
+            }
+            it.close();
+          } catch (IOException e) {
+            if (log.isErrorEnabled()) {
+              log.error(
+                  String.format(
+                      Locale.ROOT,
+                      "Failed to close circuit breaker %s for request type(s) %s",
+                      it.getClass().getSimpleName(),
+                      it.getRequestTypes()),
+                  e);
+            }
+            closeFailedCounter.incrementAndGet();
+          }
+        });
+    if (closeFailedCounter.get() > 0) {
+      throw new SolrException(
+          SolrException.ErrorCode.SERVER_ERROR,
+          "Failed to close " + closeFailedCounter.get() + " circuit breakers");
+    }
+  }
+
+  /**
+   * Return a combined map of local and global circuit breaker maps, joining the two maps in a
+   * streaming fashion
+   */
+  private Map<SolrRequestType, List<CircuitBreaker>> getCombinedMap() {
+    Map<SolrRequestType, List<CircuitBreaker>> combinedMap = new HashMap<>(circuitBreakerMap);
+    globalCircuitBreakerMap.forEach(
+        (k, v) ->
+            combinedMap.merge(
+                k,
+                v,
+                (v1, v2) -> {
+                  List<CircuitBreaker> newList = new ArrayList<>();
+                  newList.addAll(v1);
+                  newList.addAll(v2);
+                  return newList;
+                }));
+    return combinedMap;
   }
 }

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
@@ -41,11 +41,10 @@ import org.slf4j.LoggerFactory;
  * @since 9.4
  */
 public class CircuitBreakerRegistry implements Closeable {
-  protected static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private final Map<SolrRequestType, List<CircuitBreaker>> circuitBreakerMap = new HashMap<>();
   private static final Map<String, Long> circuitBreakerTrippedMetrics = new ConcurrentHashMap<>();
-
 
   public CircuitBreakerRegistry() {}
 

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
@@ -34,10 +34,10 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.solr.client.solrj.SolrRequest.SolrRequestType;
 import org.apache.solr.common.SolrException;
+import org.apache.solr.common.util.EnvUtils;
 import org.apache.solr.core.CoreContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.solr.common.util.EnvUtils;
 
 /**
  * Keeps track of all registered circuit breaker instances for various request types. Responsible
@@ -194,7 +194,7 @@ public class CircuitBreakerRegistry implements Closeable {
     List<CircuitBreaker> triggeredCircuitBreakers = null;
     for (CircuitBreaker circuitBreaker : breakersOfType) {
       if (circuitBreaker.isTripped()) {
-          incrementTripped(requestType, circuitBreaker);
+        incrementTripped(requestType, circuitBreaker);
         if (triggeredCircuitBreakers == null) {
           triggeredCircuitBreakers = new ArrayList<>();
         }

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
@@ -37,6 +37,7 @@ import org.apache.solr.common.SolrException;
 import org.apache.solr.core.CoreContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.solr.common.util.EnvUtils;
 
 /**
  * Keeps track of all registered circuit breaker instances for various request types. Responsible

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
@@ -137,7 +137,11 @@ public class CircuitBreakerRegistry implements Closeable {
   }
 
   public boolean isEnabled(SolrRequestType requestType) {
-    return circuitBreakerMap.containsKey(requestType);
+    boolean globalEnabled = false;
+    if (this.globalRegistry != null) {
+      globalEnabled = this.globalRegistry.circuitBreakerMap.containsKey(requestType);
+    }
+    return circuitBreakerMap.containsKey(requestType) || globalEnabled;
   }
 
   public void setGlobalRegistry(CircuitBreakerRegistry globalRegistry) {

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
@@ -137,11 +137,7 @@ public class CircuitBreakerRegistry implements Closeable {
   }
 
   public boolean isEnabled(SolrRequestType requestType) {
-    boolean globalEnabled = false;
-    if (this.globalRegistry != null) {
-      globalEnabled = this.globalRegistry.circuitBreakerMap.containsKey(requestType);
-    }
-    return circuitBreakerMap.containsKey(requestType) || globalEnabled;
+    return circuitBreakerMap.containsKey(requestType);
   }
 
   public void setGlobalRegistry(CircuitBreakerRegistry globalRegistry) {

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
@@ -46,6 +46,8 @@ public class CircuitBreakerRegistry implements Closeable {
   private final Map<SolrRequestType, List<CircuitBreaker>> circuitBreakerMap = new HashMap<>();
   private static final Map<String, Long> circuitBreakerTrippedMetrics = new ConcurrentHashMap<>();
 
+  private CircuitBreakerRegistry globalRegistry;
+
   public CircuitBreakerRegistry() {}
 
   public void register(CircuitBreaker circuitBreaker) {
@@ -98,6 +100,10 @@ public class CircuitBreakerRegistry implements Closeable {
       }
     }
 
+    if (globalRegistry != null) {
+      triggeredCircuitBreakers.addAll(globalRegistry.checkTripped(requestType));
+    }
+
     return triggeredCircuitBreakers;
   }
 
@@ -132,6 +138,10 @@ public class CircuitBreakerRegistry implements Closeable {
 
   public boolean isEnabled(SolrRequestType requestType) {
     return circuitBreakerMap.containsKey(requestType);
+  }
+
+  public void setGlobalRegistry(CircuitBreakerRegistry globalRegistry) {
+    this.globalRegistry = globalRegistry;
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerRegistry.java
@@ -62,21 +62,28 @@ public class CircuitBreakerRegistry implements Closeable {
   public static final String SYSPROP_QUERY_CPU = SYSPROP_PREFIX + "query.cpu";
   public static final String SYSPROP_QUERY_MEM = SYSPROP_PREFIX + "query.mem";
   public static final String SYSPROP_QUERY_LOADAVG = SYSPROP_PREFIX + "query.loadavg";
+  public static final String SYSPROP_WARN_ONLY_SUFFIX = ".warnonly";
 
   public CircuitBreakerRegistry(CoreContainer coreContainer) {
     initGlobal(coreContainer);
   }
 
-  private static void initGlobal(CoreContainer coreContainer) {
+  public static List<CircuitBreaker> parseCircuitBreakersFromProperties(
+      CoreContainer coreContainer) {
     // Read system properties to register global circuit breakers for update and query:
     // Example: solr.circuitbreaker.update.cpu = 50
-    System.getProperties().keySet().stream()
-        .map(k -> SYSPROP_REGEX.matcher(k.toString()))
-        .filter(Matcher::matches)
-        .collect(Collectors.groupingBy(m -> m.group(2) + ":" + System.getProperty(m.group(0))))
+    final var parsedBreakers = new ArrayList<CircuitBreaker>();
+    EnvUtils.getProperties().keySet().stream()
+        .map(SYSPROP_REGEX::matcher)
+        .filter(Matcher::matches) // 0=solr.circuitbreaker.(update|query).(cpu|mem|loadavg),
+        // 1=update|query, 2=cpu|mem|loadavg
+        .collect(Collectors.groupingBy(m -> buildCircuitBreakerKey(m.group(2), m.group(0))))
         .forEach(
             (breakerAndValue, breakers) -> {
               CircuitBreaker breaker;
+              // See 'buildCircuitBreakerKey' for format
+              // 0=metric name (e.g. loadavg), 1=threshold value (e.g. 70), 2=warnOnly flag (e.g.
+              // "false")
               String[] breakerAndValueArr = breakerAndValue.split(":");
               switch (breakerAndValueArr[0]) {
                 case "cpu":
@@ -98,16 +105,30 @@ public class CircuitBreakerRegistry implements Closeable {
                   throw new IllegalArgumentException(
                       "Unknown circuit breaker type: " + breakerAndValueArr[0]);
               }
+              breaker.setWarnOnly(Boolean.parseBoolean(breakerAndValueArr[2]));
               breaker.setRequestTypes(
                   breakers.stream().map(m -> m.group(1)).collect(Collectors.toList()));
-              registerGlobal(breaker);
-              if (log.isInfoEnabled()) {
-                log.info(
-                    "Registered global circuit breaker {} for request type(s) {}",
-                    breakerAndValue,
-                    breaker.getRequestTypes());
-              }
+              parsedBreakers.add(breaker);
             });
+    return parsedBreakers;
+  }
+
+  private static String buildCircuitBreakerKey(String metricType, String thresholdProp) {
+    final var warnOnly = EnvUtils.getProperty(thresholdProp + SYSPROP_WARN_ONLY_SUFFIX, "false");
+    return metricType + ":" + System.getProperty(thresholdProp) + ":" + warnOnly;
+  }
+
+  private static void initGlobal(CoreContainer coreContainer) {
+    final var parsedBreakers = parseCircuitBreakersFromProperties(coreContainer);
+    for (CircuitBreaker breaker : parsedBreakers) {
+      registerGlobal(breaker);
+      if (log.isInfoEnabled()) {
+        log.info(
+            "Registered global circuit breaker {} for request type(s) {}",
+            breaker,
+            breaker.getRequestTypes());
+      }
+    }
   }
 
   /** List all registered circuit breakers for global context */
@@ -172,21 +193,12 @@ public class CircuitBreakerRegistry implements Closeable {
     List<CircuitBreaker> triggeredCircuitBreakers = null;
     for (CircuitBreaker circuitBreaker : breakersOfType) {
       if (circuitBreaker.isTripped()) {
-        incrementTripped(requestType, circuitBreaker);
-        if (circuitBreaker.isDebugMode()) {
-          if (log.isInfoEnabled()) {
-            log.info(
-                "Circuit breaker {} has tripped: {}",
-                circuitBreaker.getClass().getSimpleName(),
-                circuitBreaker.getErrorMessage());
-          }
-        } else {
-          if (triggeredCircuitBreakers == null) {
-            triggeredCircuitBreakers = new ArrayList<>();
-          }
-
-          triggeredCircuitBreakers.add(circuitBreaker);
+          incrementTripped(requestType, circuitBreaker);
+        if (triggeredCircuitBreakers == null) {
+          triggeredCircuitBreakers = new ArrayList<>();
         }
+
+        triggeredCircuitBreakers.add(circuitBreaker);
       }
     }
 

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerUtils.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/CircuitBreakerUtils.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.util.circuitbreaker;
+
+import static org.apache.solr.common.params.CommonParams.FAILURE;
+import static org.apache.solr.common.params.CommonParams.STATUS;
+
+import java.lang.invoke.MethodHandles;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.util.CollectionUtil;
+import org.apache.solr.response.SolrQueryResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CircuitBreakerUtils {
+
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  /**
+   * @param trippedBreakers a (potentially null or empty) list of tripped breakers that may
+   *     short-circuit this request
+   * @return true if any enabled "hard" (i.e. non-warnOnly) breakers were tripped; false otherwise
+   */
+  public static boolean reportErrorIfBreakersTripped(
+      SolrQueryResponse rsp, List<CircuitBreaker> trippedBreakers) {
+    if (CollectionUtil.isEmpty(trippedBreakers)) {
+      return false;
+    }
+
+    final var warnOnlyBreakers =
+        trippedBreakers.stream().filter(CircuitBreaker::isWarnOnly).collect(Collectors.toList());
+    if (CollectionUtil.isNotEmpty(warnOnlyBreakers)) {
+      if (log.isWarnEnabled()) {
+        log.warn(
+            "'warnOnly' circuit-breakers tripped for request: {}",
+            CircuitBreakerRegistry.toErrorMessage(warnOnlyBreakers));
+      }
+    }
+
+    final var hardBreakers =
+        trippedBreakers.stream()
+            .filter(Predicate.not(CircuitBreaker::isWarnOnly))
+            .collect(Collectors.toList());
+    if (CollectionUtil.isEmpty(hardBreakers)) {
+      return false;
+    }
+
+    // Build the error message and add it to the response.
+    String errorMessage = CircuitBreakerRegistry.toErrorMessage(hardBreakers);
+    rsp.add(STATUS, FAILURE);
+    rsp.setException(
+        new SolrException(
+            CircuitBreaker.getErrorCode(hardBreakers), "Circuit Breakers tripped " + errorMessage));
+    return true;
+  }
+}

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerFactory.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerFactory.java
@@ -1,0 +1,36 @@
+package org.apache.solr.util.circuitbreaker;
+
+import org.apache.solr.core.CoreContainer;
+
+public class GlobalCircuitBreakerFactory {
+    private final CoreContainer coreContainerOptional;
+
+    public GlobalCircuitBreakerFactory(CoreContainer coreContainerOptional) {
+        this.coreContainerOptional = coreContainerOptional;
+    }
+
+    public CircuitBreaker create(String className) throws Exception {
+        Class<?> clazz = Class.forName(className);
+
+        if (CircuitBreaker.class.isAssignableFrom(clazz)) {
+            // cast to CircuitBreaker class
+            Class<? extends CircuitBreaker> breakerClass = clazz.asSubclass(CircuitBreaker.class);
+
+            try {
+                // try with 0 arg constructor
+                return breakerClass.getDeclaredConstructor().newInstance();
+            } catch (NoSuchMethodException e) {
+                // otherwise, the CircuitBreaker requires a CoreContainer, so let's give it one
+                if (coreContainerOptional != null) {
+                    return breakerClass.getDeclaredConstructor(CoreContainer.class).newInstance(coreContainerOptional);
+                } else {
+                    throw new IllegalArgumentException(
+                            "The CircuitBreaker subclass requires a CoreContainer, but it was not provided"
+                    );
+                }
+            }
+        } else {
+            throw new IllegalArgumentException("Class " + className + " is not a subclass of CircuitBreaker");
+        }
+    }
+}

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerFactory.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerFactory.java
@@ -13,7 +13,6 @@ public class GlobalCircuitBreakerFactory {
     Class<?> clazz = Class.forName(className);
 
     if (CircuitBreaker.class.isAssignableFrom(clazz)) {
-      // cast to CircuitBreaker class
       Class<? extends CircuitBreaker> breakerClass = clazz.asSubclass(CircuitBreaker.class);
 
       try {

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerFactory.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerFactory.java
@@ -3,34 +3,36 @@ package org.apache.solr.util.circuitbreaker;
 import org.apache.solr.core.CoreContainer;
 
 public class GlobalCircuitBreakerFactory {
-    private final CoreContainer coreContainerOptional;
+  private final CoreContainer coreContainerOptional;
 
-    public GlobalCircuitBreakerFactory(CoreContainer coreContainerOptional) {
-        this.coreContainerOptional = coreContainerOptional;
-    }
+  public GlobalCircuitBreakerFactory(CoreContainer coreContainerOptional) {
+    this.coreContainerOptional = coreContainerOptional;
+  }
 
-    public CircuitBreaker create(String className) throws Exception {
-        Class<?> clazz = Class.forName(className);
+  public CircuitBreaker create(String className) throws Exception {
+    Class<?> clazz = Class.forName(className);
 
-        if (CircuitBreaker.class.isAssignableFrom(clazz)) {
-            // cast to CircuitBreaker class
-            Class<? extends CircuitBreaker> breakerClass = clazz.asSubclass(CircuitBreaker.class);
+    if (CircuitBreaker.class.isAssignableFrom(clazz)) {
+      // cast to CircuitBreaker class
+      Class<? extends CircuitBreaker> breakerClass = clazz.asSubclass(CircuitBreaker.class);
 
-            try {
-                // try with 0 arg constructor
-                return breakerClass.getDeclaredConstructor().newInstance();
-            } catch (NoSuchMethodException e) {
-                // otherwise, the CircuitBreaker requires a CoreContainer, so let's give it one
-                if (coreContainerOptional != null) {
-                    return breakerClass.getDeclaredConstructor(CoreContainer.class).newInstance(coreContainerOptional);
-                } else {
-                    throw new IllegalArgumentException(
-                            "The CircuitBreaker subclass requires a CoreContainer, but it was not provided"
-                    );
-                }
-            }
+      try {
+        // try with 0 arg constructor
+        return breakerClass.getDeclaredConstructor().newInstance();
+      } catch (NoSuchMethodException e) {
+        // otherwise, the CircuitBreaker requires a CoreContainer, so let's give it one
+        if (coreContainerOptional != null) {
+          return breakerClass
+              .getDeclaredConstructor(CoreContainer.class)
+              .newInstance(coreContainerOptional);
         } else {
-            throw new IllegalArgumentException("Class " + className + " is not a subclass of CircuitBreaker");
+          throw new IllegalArgumentException(
+              "The CircuitBreaker subclass requires a CoreContainer, but it was not provided");
         }
+      }
+    } else {
+      throw new IllegalArgumentException(
+          "Class " + className + " is not a subclass of CircuitBreaker");
     }
+  }
 }

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerManager.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerManager.java
@@ -1,0 +1,118 @@
+package org.apache.solr.util.circuitbreaker;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.common.annotation.JsonProperty;
+import org.apache.solr.common.cloud.ClusterPropertiesListener;
+import org.apache.solr.common.util.Utils;
+import org.apache.solr.util.SolrJacksonAnnotationInspector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.invoke.MethodHandles;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class GlobalCircuitBreakerManager implements ClusterPropertiesListener {
+    protected static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private static final ObjectMapper mapper = SolrJacksonAnnotationInspector.createObjectMapper();
+    private CircuitBreakerRegistry cbRegistry;
+    public CircuitBreakerRegistry getCircuitBreakerRegistry() {
+        return cbRegistry;
+    }
+
+    private GlobalCircuitBreakerConfig currentConfig;
+
+    public GlobalCircuitBreakerManager() {
+        super();
+        this.cbRegistry = new CircuitBreakerRegistry();
+    }
+
+    private static class GlobalCircuitBreakerConfig {
+        static final String CIRCUIT_BREAKER_CLUSTER_PROPS_KEY = "circuit-breakers";
+        @JsonProperty
+        CircuitBreakerConfig load;
+
+        static class CircuitBreakerConfig {
+            @JsonProperty Boolean enabled;
+            @JsonProperty Long updateThreshold;
+            @JsonProperty Long queryThreshold;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("enabled=%s;updateThreshold=%s;queryThreshold=%s;", load.enabled, load.updateThreshold, load.queryThreshold);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof GlobalCircuitBreakerConfig)) {
+                return false;
+            }
+            GlobalCircuitBreakerConfig that = (GlobalCircuitBreakerConfig) obj;
+            return this.load.enabled == that.load.enabled &&
+                    this.load.updateThreshold.equals(that.load.updateThreshold) &&
+                    this.load.queryThreshold.equals(that.load.queryThreshold);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(load.enabled, load.queryThreshold, load.updateThreshold);
+        }
+    }
+
+    // for registering global circuit breakers set in clusterprops
+    @Override
+    public boolean onChange(Map<String, Object> properties) {
+        try {
+            GlobalCircuitBreakerConfig nextConfig = processConfigChange(properties);
+            if (nextConfig != null) {
+                log.info(nextConfig.toString());
+                if (this.currentConfig == null || !this.currentConfig.equals(nextConfig)) {
+                    registerCircuitBreakers(nextConfig);
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return false;
+    }
+
+    private GlobalCircuitBreakerConfig processConfigChange(Map<String, Object> properties) throws IOException {
+        Object cbConfig = properties.get(GlobalCircuitBreakerConfig.CIRCUIT_BREAKER_CLUSTER_PROPS_KEY);
+        GlobalCircuitBreakerConfig globalCBConfig = null;
+        if (cbConfig != null) {
+            log.info(cbConfig.toString());
+            byte[] configInput = Utils.toJSON(properties.get(GlobalCircuitBreakerConfig.CIRCUIT_BREAKER_CLUSTER_PROPS_KEY));
+            if (configInput != null && configInput.length > 0) {
+                globalCBConfig = mapper.readValue(configInput, GlobalCircuitBreakerConfig.class);
+            }
+        }
+        return globalCBConfig;
+    }
+
+    private void registerCircuitBreakers(GlobalCircuitBreakerConfig gbConfig) throws IOException {
+        this.currentConfig = gbConfig;
+        log.info("registering config!");
+        this.cbRegistry.deregisterAll();
+
+        if (gbConfig.load.enabled) {
+            if (gbConfig.load.queryThreshold != null) {
+                LoadAverageCircuitBreaker newQueryLoadCB = new LoadAverageCircuitBreaker();
+                newQueryLoadCB.setThreshold(gbConfig.load.queryThreshold);
+                newQueryLoadCB.setRequestTypes(List.of(SolrRequest.SolrRequestType.QUERY.name()));
+                this.cbRegistry.register(newQueryLoadCB);
+            }
+            if (gbConfig.load.updateThreshold != null) {
+                LoadAverageCircuitBreaker newUpdateLoadCb = new LoadAverageCircuitBreaker();
+                newUpdateLoadCb.setThreshold(gbConfig.load.updateThreshold);
+                newUpdateLoadCb.setRequestTypes(List.of(SolrRequest.SolrRequestType.UPDATE.name()));
+                this.cbRegistry.register(newUpdateLoadCb);
+            }
+        }
+        log.info("registered cbs! {}", this.cbRegistry.circuitBreakerMap);
+    }
+}

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerManager.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerManager.java
@@ -49,7 +49,7 @@ public class GlobalCircuitBreakerManager implements ClusterPropertiesListener {
           return false;
         }
         CircuitBreakerConfig that = (CircuitBreakerConfig) obj;
-        return this.enabled == that.enabled
+        return this.enabled.equals(that.enabled)
             && this.updateThreshold.equals(that.updateThreshold)
             && this.queryThreshold.equals(that.queryThreshold);
       }

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerManager.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerManager.java
@@ -121,7 +121,7 @@ public class GlobalCircuitBreakerManager implements ClusterPropertiesListener {
   }
 
   private void registerCircuitBreakers(GlobalCircuitBreakerConfig gbConfig) throws Exception {
-    CircuitBreakerRegistry.deregisterGlobal();
+    CircuitBreakerRegistry.deregisterZkGlobal();
     for (Map.Entry<String, GlobalCircuitBreakerConfig.CircuitBreakerConfig> entry :
         gbConfig.configs.entrySet()) {
       GlobalCircuitBreakerConfig.CircuitBreakerConfig config =
@@ -180,7 +180,7 @@ public class GlobalCircuitBreakerManager implements ClusterPropertiesListener {
     globalCb.setThreshold(threshold);
     globalCb.setRequestTypes(List.of(type.name()));
     globalCb.setWarnOnly(warnOnly);
-    CircuitBreakerRegistry.registerGlobal(globalCb);
+    CircuitBreakerRegistry.registerZkGlobal(globalCb);
     if (log.isInfoEnabled()) {
       log.info("onChange registered circuit breaker {}", globalCb);
     }

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerManager.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerManager.java
@@ -67,10 +67,7 @@ public class GlobalCircuitBreakerManager implements ClusterPropertiesListener {
     Object cbConfig = properties.get(GlobalCircuitBreakerConfig.CIRCUIT_BREAKER_CLUSTER_PROPS_KEY);
     GlobalCircuitBreakerConfig globalCBConfig = null;
     if (cbConfig != null) {
-      byte[] configInput =
-          Utils.toJSON(
-              properties.get(GlobalCircuitBreakerConfig.CIRCUIT_BREAKER_CLUSTER_PROPS_KEY));
-
+      byte[] configInput = Utils.toJSON(cbConfig);
       int nextHashCode = Arrays.hashCode(configInput);
       if (this.currentConfigHash == nextHashCode) {
         return null;

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerManager.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerManager.java
@@ -48,20 +48,20 @@ public class GlobalCircuitBreakerManager implements ClusterPropertiesListener {
 
     static class CircuitBreakerConfig {
       @JsonProperty Boolean enabled = false;
-      @JsonProperty Boolean debugMode = false;
+      @JsonProperty Boolean warnOnly = false;
       @JsonProperty Double updateThreshold = Double.MAX_VALUE;
       @JsonProperty Double queryThreshold = Double.MAX_VALUE;
 
       @Override
       public int hashCode() {
-        return Objects.hash(enabled, debugMode, updateThreshold, queryThreshold);
+        return Objects.hash(enabled, warnOnly, updateThreshold, queryThreshold);
       }
 
       @Override
       public boolean equals(Object obj) {
         if (obj instanceof CircuitBreakerConfig) {
           CircuitBreakerConfig that = (CircuitBreakerConfig) obj;
-          return that.enabled.equals(this.enabled) && that.debugMode.equals(this.debugMode) && that.updateThreshold.equals(this.updateThreshold) && that.queryThreshold.equals(this.queryThreshold);
+          return that.enabled.equals(this.enabled) && that.warnOnly.equals(this.warnOnly) && that.updateThreshold.equals(this.updateThreshold) && that.queryThreshold.equals(this.queryThreshold);
         }
         return false;
       }
@@ -126,14 +126,14 @@ public class GlobalCircuitBreakerManager implements ClusterPropertiesListener {
                 this.factory.create(entry.getKey()),
                 config.queryThreshold,
                 SolrRequest.SolrRequestType.QUERY,
-                config.debugMode);
+                config.warnOnly);
           }
           if (config.updateThreshold != Double.MAX_VALUE) {
             registerGlobalCircuitBreaker(
                 this.factory.create(entry.getKey()),
                 config.updateThreshold,
                 SolrRequest.SolrRequestType.UPDATE,
-                config.debugMode);
+                config.warnOnly);
           }
         }
       } catch (Exception e) {
@@ -169,10 +169,10 @@ public class GlobalCircuitBreakerManager implements ClusterPropertiesListener {
       CircuitBreaker globalCb,
       double threshold,
       SolrRequest.SolrRequestType type,
-      boolean debugMode) {
+      boolean warnOnly) {
     globalCb.setThreshold(threshold);
     globalCb.setRequestTypes(List.of(type.name()));
-    globalCb.setDebugMode(debugMode);
+    globalCb.setWarnOnly(warnOnly);
     CircuitBreakerRegistry.registerGlobal(globalCb);
     if (log.isInfoEnabled()) {
       log.info("onChange registered circuit breaker {}", globalCb);

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerManager.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerManager.java
@@ -137,12 +137,12 @@ public class GlobalCircuitBreakerManager implements ClusterPropertiesListener {
                 log.warn("error while registering global circuit breaker {}: {}", entry.getKey(), e.getMessage());
             }
         }
-        log.info("onChange registered circuit breakers {}", this.cbRegistry.circuitBreakerMap);
     }
 
     private void registerGlobalCircuitBreaker(CircuitBreaker globalCb, double threshold, SolrRequest.SolrRequestType type) {
         globalCb.setThreshold(threshold);
         globalCb.setRequestTypes(List.of(type.name()));
         this.cbRegistry.register(globalCb);
+        log.info("onChange registered circuit breaker {}", globalCb);
     }
 }

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerManager.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerManager.java
@@ -3,7 +3,9 @@ package org.apache.solr.util.circuitbreaker;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.solr.client.solrj.SolrRequest;
@@ -41,7 +43,8 @@ public class GlobalCircuitBreakerManager implements ClusterPropertiesListener {
 
   private static class GlobalCircuitBreakerConfig {
     static final String CIRCUIT_BREAKER_CLUSTER_PROPS_KEY = "circuit-breakers";
-    @JsonProperty Map<String, CircuitBreakerConfig> configs = new ConcurrentHashMap<>();
+    @JsonProperty
+    Map<String, CircuitBreakerConfig> configs = new ConcurrentHashMap<>();
 
     @JsonProperty
     Map<String, Map<String, CircuitBreakerConfig>> hostOverrides = new ConcurrentHashMap<>();

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerManager.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerManager.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.common.annotation.JsonProperty;
 import org.apache.solr.common.cloud.ClusterPropertiesListener;
@@ -30,7 +29,10 @@ public class GlobalCircuitBreakerManager implements ClusterPropertiesListener {
     if (instance == null) {
       synchronized (GlobalCircuitBreakerManager.class) {
         instance = new GlobalCircuitBreakerManager(coreContainer);
-        coreContainer.getZkController().getZkStateReader().registerClusterPropertiesListener(instance);
+        coreContainer
+            .getZkController()
+            .getZkStateReader()
+            .registerClusterPropertiesListener(instance);
       }
     }
   }
@@ -43,8 +45,7 @@ public class GlobalCircuitBreakerManager implements ClusterPropertiesListener {
 
   private static class GlobalCircuitBreakerConfig {
     static final String CIRCUIT_BREAKER_CLUSTER_PROPS_KEY = "circuit-breakers";
-    @JsonProperty
-    Map<String, CircuitBreakerConfig> configs = new ConcurrentHashMap<>();
+    @JsonProperty Map<String, CircuitBreakerConfig> configs = new ConcurrentHashMap<>();
 
     @JsonProperty
     Map<String, Map<String, CircuitBreakerConfig>> hostOverrides = new ConcurrentHashMap<>();
@@ -64,7 +65,10 @@ public class GlobalCircuitBreakerManager implements ClusterPropertiesListener {
       public boolean equals(Object obj) {
         if (obj instanceof CircuitBreakerConfig) {
           CircuitBreakerConfig that = (CircuitBreakerConfig) obj;
-          return that.enabled.equals(this.enabled) && that.warnOnly.equals(this.warnOnly) && that.updateThreshold.equals(this.updateThreshold) && that.queryThreshold.equals(this.queryThreshold);
+          return that.enabled.equals(this.enabled)
+              && that.warnOnly.equals(this.warnOnly)
+              && that.updateThreshold.equals(this.updateThreshold)
+              && that.queryThreshold.equals(this.queryThreshold);
         }
         return false;
       }

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerManager.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerManager.java
@@ -3,10 +3,9 @@ package org.apache.solr.util.circuitbreaker;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.common.annotation.JsonProperty;
 import org.apache.solr.common.cloud.ClusterPropertiesListener;
@@ -21,8 +20,18 @@ public class GlobalCircuitBreakerManager implements ClusterPropertiesListener {
   private static final ObjectMapper mapper = SolrJacksonAnnotationInspector.createObjectMapper();
   private final GlobalCircuitBreakerFactory factory;
   private final CoreContainer coreContainer;
-  private int currentConfigHash;
+  private GlobalCircuitBreakerConfig currentConfig;
 
+  private static volatile GlobalCircuitBreakerManager instance;
+
+  public static void init(CoreContainer coreContainer) {
+    if (instance == null) {
+      synchronized (GlobalCircuitBreakerManager.class) {
+        instance = new GlobalCircuitBreakerManager(coreContainer);
+        coreContainer.getZkController().getZkStateReader().registerClusterPropertiesListener(instance);
+      }
+    }
+  }
 
   public GlobalCircuitBreakerManager(CoreContainer coreContainer) {
     super();
@@ -42,6 +51,34 @@ public class GlobalCircuitBreakerManager implements ClusterPropertiesListener {
       @JsonProperty Boolean debugMode = false;
       @JsonProperty Double updateThreshold = Double.MAX_VALUE;
       @JsonProperty Double queryThreshold = Double.MAX_VALUE;
+
+      @Override
+      public int hashCode() {
+        return Objects.hash(enabled, debugMode, updateThreshold, queryThreshold);
+      }
+
+      @Override
+      public boolean equals(Object obj) {
+        if (obj instanceof CircuitBreakerConfig) {
+          CircuitBreakerConfig that = (CircuitBreakerConfig) obj;
+          return that.enabled.equals(this.enabled) && that.debugMode.equals(this.debugMode) && that.updateThreshold.equals(this.updateThreshold) && that.queryThreshold.equals(this.queryThreshold);
+        }
+        return false;
+      }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (o instanceof GlobalCircuitBreakerConfig) {
+        GlobalCircuitBreakerConfig that = (GlobalCircuitBreakerConfig) o;
+        return that.configs.equals(this.configs) && that.hostOverrides.equals(this.hostOverrides);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(configs, hostOverrides);
     }
   }
 
@@ -50,7 +87,8 @@ public class GlobalCircuitBreakerManager implements ClusterPropertiesListener {
   public boolean onChange(Map<String, Object> properties) {
     try {
       GlobalCircuitBreakerConfig nextConfig = processConfigChange(properties);
-      if (nextConfig != null) {
+      if (nextConfig != null && !nextConfig.equals(this.currentConfig)) {
+        this.currentConfig = nextConfig;
         registerCircuitBreakers(nextConfig);
       }
     } catch (Exception e) {
@@ -68,12 +106,6 @@ public class GlobalCircuitBreakerManager implements ClusterPropertiesListener {
     GlobalCircuitBreakerConfig globalCBConfig = null;
     if (cbConfig != null) {
       byte[] configInput = Utils.toJSON(cbConfig);
-      int nextHashCode = Arrays.hashCode(configInput);
-      if (this.currentConfigHash == nextHashCode) {
-        return null;
-      }
-      this.currentConfigHash = nextHashCode;
-
       if (configInput != null && configInput.length > 0) {
         globalCBConfig = mapper.readValue(configInput, GlobalCircuitBreakerConfig.class);
       }

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerManager.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerManager.java
@@ -85,6 +85,7 @@ public class GlobalCircuitBreakerManager implements ClusterPropertiesListener {
   }
 
   private void registerCircuitBreakers(GlobalCircuitBreakerConfig gbConfig) throws Exception {
+    CircuitBreakerRegistry.deregisterGlobal();
     for (Map.Entry<String, GlobalCircuitBreakerConfig.CircuitBreakerConfig> entry :
         gbConfig.configs.entrySet()) {
       GlobalCircuitBreakerConfig.CircuitBreakerConfig config =

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerManager.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerManager.java
@@ -1,6 +1,12 @@
 package org.apache.solr.util.circuitbreaker;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.common.annotation.JsonProperty;
 import org.apache.solr.common.cloud.ClusterPropertiesListener;
@@ -10,139 +16,149 @@ import org.apache.solr.util.SolrJacksonAnnotationInspector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.lang.invoke.MethodHandles;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-
 public class GlobalCircuitBreakerManager implements ClusterPropertiesListener {
-    protected static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-    private static final ObjectMapper mapper = SolrJacksonAnnotationInspector.createObjectMapper();
-    private final CircuitBreakerRegistry cbRegistry = new CircuitBreakerRegistry();
-    private final GlobalCircuitBreakerFactory factory;
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final ObjectMapper mapper = SolrJacksonAnnotationInspector.createObjectMapper();
+  private final CircuitBreakerRegistry cbRegistry = new CircuitBreakerRegistry();
+  private final GlobalCircuitBreakerFactory factory;
 
-    public CircuitBreakerRegistry getCircuitBreakerRegistry() {
-        return cbRegistry;
+  public CircuitBreakerRegistry getCircuitBreakerRegistry() {
+    return cbRegistry;
+  }
+
+  private GlobalCircuitBreakerConfig currentConfig = new GlobalCircuitBreakerConfig();
+  ;
+
+  public GlobalCircuitBreakerManager(CoreContainer coreContainer) {
+    super();
+    this.factory = new GlobalCircuitBreakerFactory(coreContainer);
+  }
+
+  private static class GlobalCircuitBreakerConfig {
+    static final String CIRCUIT_BREAKER_CLUSTER_PROPS_KEY = "circuit-breakers";
+    @JsonProperty Map<String, CircuitBreakerConfig> configs = new ConcurrentHashMap<>();
+
+    static class CircuitBreakerConfig {
+      @JsonProperty Boolean enabled = false;
+      @JsonProperty Double updateThreshold = Double.MAX_VALUE;
+      @JsonProperty Double queryThreshold = Double.MAX_VALUE;
+
+      @Override
+      public boolean equals(Object obj) {
+        if (!(obj instanceof CircuitBreakerConfig)) {
+          return false;
+        }
+        CircuitBreakerConfig that = (CircuitBreakerConfig) obj;
+        return this.enabled == that.enabled
+            && this.updateThreshold.equals(that.updateThreshold)
+            && this.queryThreshold.equals(that.queryThreshold);
+      }
+
+      @Override
+      public int hashCode() {
+        return Objects.hash(this.enabled, this.queryThreshold, this.updateThreshold);
+      }
     }
 
-    private GlobalCircuitBreakerConfig currentConfig = new GlobalCircuitBreakerConfig();;
-
-    public GlobalCircuitBreakerManager(CoreContainer coreContainer) {
-        super();
-        this.factory = new GlobalCircuitBreakerFactory(coreContainer);
-    }
-
-    private static class GlobalCircuitBreakerConfig {
-        static final String CIRCUIT_BREAKER_CLUSTER_PROPS_KEY = "circuit-breakers";
-        @JsonProperty
-        Map<String, CircuitBreakerConfig> configs = new ConcurrentHashMap<>();
-
-        static class CircuitBreakerConfig {
-            @JsonProperty Boolean enabled = false;
-            @JsonProperty Double updateThreshold = Double.MAX_VALUE;
-            @JsonProperty Double queryThreshold = Double.MAX_VALUE;
-
-            @Override
-            public boolean equals(Object obj) {
-                if (!(obj instanceof CircuitBreakerConfig)) {
-                    return false;
-                }
-                CircuitBreakerConfig that = (CircuitBreakerConfig) obj;
-                return this.enabled == that.enabled &&
-                        this.updateThreshold.equals(that.updateThreshold) &&
-                        this.queryThreshold.equals(that.queryThreshold);
-            }
-
-            @Override
-            public int hashCode() {
-                return Objects.hash(this.enabled, this.queryThreshold, this.updateThreshold);
-            }
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (!(obj instanceof GlobalCircuitBreakerConfig)) {
-                return false;
-            }
-            GlobalCircuitBreakerConfig that = (GlobalCircuitBreakerConfig) obj;
-            if (that.configs.size() != this.configs.size()) {
-                return false;
-            }
-            for (Map.Entry<String, CircuitBreakerConfig> entry : configs.entrySet()) {
-                CircuitBreakerConfig thisConfig = entry.getValue();
-                CircuitBreakerConfig thatConfig = that.configs.get(entry.getKey());
-                if (thatConfig == null) {
-                    return false;
-                }
-                if (!thisConfig.equals(thatConfig)) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        @Override
-        public int hashCode() {
-            // Map.Entry already overrides hashCode, so let's use that
-            return Objects.hash(configs.entrySet());
-        }
-    }
-
-    // for registering global circuit breakers set in clusterprops
     @Override
-    public boolean onChange(Map<String, Object> properties) {
-        try {
-            GlobalCircuitBreakerConfig nextConfig = processConfigChange(properties);
-            if (nextConfig != null) {
-                if (!this.currentConfig.equals(nextConfig)) {
-                    registerCircuitBreakers(nextConfig);
-                }
-            }
-        } catch (Exception e) {
-            // don't break when things are misconfigured
-            log.warn("error parsing global circuit breaker configuration {}", e.getMessage());
-        }
+    public boolean equals(Object obj) {
+      if (!(obj instanceof GlobalCircuitBreakerConfig)) {
         return false;
-    }
-
-    private GlobalCircuitBreakerConfig processConfigChange(Map<String, Object> properties) throws IOException {
-        Object cbConfig = properties.get(GlobalCircuitBreakerConfig.CIRCUIT_BREAKER_CLUSTER_PROPS_KEY);
-        GlobalCircuitBreakerConfig globalCBConfig = null;
-        if (cbConfig != null) {
-            byte[] configInput = Utils.toJSON(properties.get(GlobalCircuitBreakerConfig.CIRCUIT_BREAKER_CLUSTER_PROPS_KEY));
-            if (configInput != null && configInput.length > 0) {
-                globalCBConfig = mapper.readValue(configInput, GlobalCircuitBreakerConfig.class);
-            }
+      }
+      GlobalCircuitBreakerConfig that = (GlobalCircuitBreakerConfig) obj;
+      if (that.configs.size() != this.configs.size()) {
+        return false;
+      }
+      for (Map.Entry<String, CircuitBreakerConfig> entry : configs.entrySet()) {
+        CircuitBreakerConfig thisConfig = entry.getValue();
+        CircuitBreakerConfig thatConfig = that.configs.get(entry.getKey());
+        if (thatConfig == null) {
+          return false;
         }
-        return globalCBConfig;
-    }
-
-    private void registerCircuitBreakers(GlobalCircuitBreakerConfig gbConfig) throws Exception {
-        this.currentConfig = gbConfig;
-        this.cbRegistry.deregisterAll();
-        for (Map.Entry<String, GlobalCircuitBreakerConfig.CircuitBreakerConfig> entry : this.currentConfig.configs.entrySet()) {
-            GlobalCircuitBreakerConfig.CircuitBreakerConfig config = entry.getValue();
-            try {
-                if (config.enabled) {
-                    if (config.queryThreshold != Double.MAX_VALUE) {
-                        registerGlobalCircuitBreaker(this.factory.create(entry.getKey()), config.queryThreshold, SolrRequest.SolrRequestType.QUERY);
-                    }
-                    if (config.updateThreshold != Double.MAX_VALUE) {
-                        registerGlobalCircuitBreaker(this.factory.create(entry.getKey()), config.updateThreshold, SolrRequest.SolrRequestType.UPDATE);
-                    }
-                }
-            } catch (Exception e) {
-                log.warn("error while registering global circuit breaker {}: {}", entry.getKey(), e.getMessage());
-            }
+        if (!thisConfig.equals(thatConfig)) {
+          return false;
         }
+      }
+      return true;
     }
 
-    private void registerGlobalCircuitBreaker(CircuitBreaker globalCb, double threshold, SolrRequest.SolrRequestType type) {
-        globalCb.setThreshold(threshold);
-        globalCb.setRequestTypes(List.of(type.name()));
-        this.cbRegistry.register(globalCb);
-        log.info("onChange registered circuit breaker {}", globalCb);
+    @Override
+    public int hashCode() {
+      // Map.Entry already overrides hashCode, so let's use that
+      return Objects.hash(configs.entrySet());
     }
+  }
+
+  // for registering global circuit breakers set in clusterprops
+  @Override
+  public boolean onChange(Map<String, Object> properties) {
+    try {
+      GlobalCircuitBreakerConfig nextConfig = processConfigChange(properties);
+      if (nextConfig != null) {
+        if (!this.currentConfig.equals(nextConfig)) {
+          registerCircuitBreakers(nextConfig);
+        }
+      }
+    } catch (Exception e) {
+      if (log.isWarnEnabled()) {
+        // don't break when things are misconfigured
+        log.warn("error parsing global circuit breaker configuration {}", e);
+      }
+    }
+    return false;
+  }
+
+  private GlobalCircuitBreakerConfig processConfigChange(Map<String, Object> properties)
+      throws IOException {
+    Object cbConfig = properties.get(GlobalCircuitBreakerConfig.CIRCUIT_BREAKER_CLUSTER_PROPS_KEY);
+    GlobalCircuitBreakerConfig globalCBConfig = null;
+    if (cbConfig != null) {
+      byte[] configInput =
+          Utils.toJSON(
+              properties.get(GlobalCircuitBreakerConfig.CIRCUIT_BREAKER_CLUSTER_PROPS_KEY));
+      if (configInput != null && configInput.length > 0) {
+        globalCBConfig = mapper.readValue(configInput, GlobalCircuitBreakerConfig.class);
+      }
+    }
+    return globalCBConfig;
+  }
+
+  private void registerCircuitBreakers(GlobalCircuitBreakerConfig gbConfig) throws Exception {
+    this.currentConfig = gbConfig;
+    this.cbRegistry.deregisterAll();
+    for (Map.Entry<String, GlobalCircuitBreakerConfig.CircuitBreakerConfig> entry :
+        this.currentConfig.configs.entrySet()) {
+      GlobalCircuitBreakerConfig.CircuitBreakerConfig config = entry.getValue();
+      try {
+        if (config.enabled) {
+          if (config.queryThreshold != Double.MAX_VALUE) {
+            registerGlobalCircuitBreaker(
+                this.factory.create(entry.getKey()),
+                config.queryThreshold,
+                SolrRequest.SolrRequestType.QUERY);
+          }
+          if (config.updateThreshold != Double.MAX_VALUE) {
+            registerGlobalCircuitBreaker(
+                this.factory.create(entry.getKey()),
+                config.updateThreshold,
+                SolrRequest.SolrRequestType.UPDATE);
+          }
+        }
+      } catch (Exception e) {
+        if (log.isWarnEnabled()) {
+          log.warn("error while registering global circuit breaker {}: {}", entry.getKey(), e);
+        }
+      }
+    }
+  }
+
+  private void registerGlobalCircuitBreaker(
+      CircuitBreaker globalCb, double threshold, SolrRequest.SolrRequestType type) {
+    globalCb.setThreshold(threshold);
+    globalCb.setRequestTypes(List.of(type.name()));
+    this.cbRegistry.register(globalCb);
+    if (log.isInfoEnabled()) {
+      log.info("onChange registered circuit breaker {}", globalCb);
+    }
+  }
 }

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerManager.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/GlobalCircuitBreakerManager.java
@@ -43,6 +43,7 @@ public class GlobalCircuitBreakerManager implements ClusterPropertiesListener {
 
     static class CircuitBreakerConfig {
       @JsonProperty Boolean enabled = false;
+      @JsonProperty Boolean debugMode = false;
       @JsonProperty Double updateThreshold = Double.MAX_VALUE;
       @JsonProperty Double queryThreshold = Double.MAX_VALUE;
     }
@@ -99,13 +100,15 @@ public class GlobalCircuitBreakerManager implements ClusterPropertiesListener {
             registerGlobalCircuitBreaker(
                 this.factory.create(entry.getKey()),
                 config.queryThreshold,
-                SolrRequest.SolrRequestType.QUERY);
+                SolrRequest.SolrRequestType.QUERY,
+                config.debugMode);
           }
           if (config.updateThreshold != Double.MAX_VALUE) {
             registerGlobalCircuitBreaker(
                 this.factory.create(entry.getKey()),
                 config.updateThreshold,
-                SolrRequest.SolrRequestType.UPDATE);
+                SolrRequest.SolrRequestType.UPDATE,
+                config.debugMode);
           }
         }
       } catch (Exception e) {
@@ -130,9 +133,13 @@ public class GlobalCircuitBreakerManager implements ClusterPropertiesListener {
   }
 
   private void registerGlobalCircuitBreaker(
-      CircuitBreaker globalCb, double threshold, SolrRequest.SolrRequestType type) {
+      CircuitBreaker globalCb,
+      double threshold,
+      SolrRequest.SolrRequestType type,
+      boolean debugMode) {
     globalCb.setThreshold(threshold);
     globalCb.setRequestTypes(List.of(type.name()));
+    globalCb.setDebugMode(debugMode);
     this.cbRegistry.register(globalCb);
     if (log.isInfoEnabled()) {
       log.info("onChange registered circuit breaker {}", globalCb);

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/LoadAverageCircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/LoadAverageCircuitBreaker.java
@@ -78,11 +78,12 @@ public class LoadAverageCircuitBreaker extends CircuitBreaker {
         + allowedLoadAverage.get();
   }
 
-  public void setThreshold(double thresholdValueUnbounded) {
+  public LoadAverageCircuitBreaker setThreshold(double thresholdValueUnbounded) {
     if (thresholdValueUnbounded <= 0) {
       throw new IllegalStateException("Threshold cannot be less than or equal to zero");
     }
     loadAverageThreshold = thresholdValueUnbounded;
+    return this;
   }
 
   public double getLoadAverageThreshold() {

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/LoadAverageCircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/LoadAverageCircuitBreaker.java
@@ -20,6 +20,7 @@ package org.apache.solr.util.circuitbreaker;
 import java.lang.invoke.MethodHandles;
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
+import java.util.Locale;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,5 +94,15 @@ public class LoadAverageCircuitBreaker extends CircuitBreaker {
 
   protected double calculateLiveLoadAverage() {
     return operatingSystemMXBean.getSystemLoadAverage();
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        Locale.ROOT,
+        "%s(threshold=%f, warnOnly=%b)",
+        getClass().getSimpleName(),
+        loadAverageThreshold,
+        isWarnOnly());
   }
 }

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/LoadAverageCircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/LoadAverageCircuitBreaker.java
@@ -78,6 +78,7 @@ public class LoadAverageCircuitBreaker extends CircuitBreaker {
         + allowedLoadAverage.get();
   }
 
+  @Override
   public void setThreshold(double thresholdValueUnbounded) {
     if (thresholdValueUnbounded <= 0) {
       throw new IllegalStateException("Threshold cannot be less than or equal to zero");

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/MemoryCircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/MemoryCircuitBreaker.java
@@ -77,7 +77,7 @@ public class MemoryCircuitBreaker extends CircuitBreaker {
     }
   }
 
-  public void setThreshold(double thresholdValueInPercentage) {
+  public MemoryCircuitBreaker setThreshold(double thresholdValueInPercentage) {
     long currentMaxHeap = MEMORY_MX_BEAN.getHeapMemoryUsage().getMax();
 
     if (currentMaxHeap <= 0) {
@@ -90,6 +90,7 @@ public class MemoryCircuitBreaker extends CircuitBreaker {
     if (heapMemoryThreshold <= 0) {
       throw new IllegalStateException("Memory limit cannot be less than or equal to zero");
     }
+    return this;
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/MemoryCircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/MemoryCircuitBreaker.java
@@ -77,6 +77,7 @@ public class MemoryCircuitBreaker extends CircuitBreaker {
     }
   }
 
+  @Override
   public void setThreshold(double thresholdValueInPercentage) {
     long currentMaxHeap = MEMORY_MX_BEAN.getHeapMemoryUsage().getMax();
 

--- a/solr/core/src/java/org/apache/solr/util/circuitbreaker/MemoryCircuitBreaker.java
+++ b/solr/core/src/java/org/apache/solr/util/circuitbreaker/MemoryCircuitBreaker.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
+import java.util.Locale;
 import org.apache.solr.util.RefCounted;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -131,5 +132,15 @@ public class MemoryCircuitBreaker extends CircuitBreaker {
         averagingMetricProvider.decref();
       }
     }
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        Locale.ROOT,
+        "%s(threshold=%d, warnOnly=%b)",
+        getClass().getSimpleName(),
+        heapMemoryThreshold,
+        isWarnOnly());
   }
 }

--- a/solr/core/src/test/org/apache/solr/util/BaseTestCircuitBreaker.java
+++ b/solr/core/src/test/org/apache/solr/util/BaseTestCircuitBreaker.java
@@ -31,10 +31,11 @@ import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.util.ExecutorUtil;
 import org.apache.solr.common.util.SolrNamedThreadFactory;
-import org.apache.solr.core.SolrCore;
+import org.apache.solr.core.CoreContainer;
 import org.apache.solr.util.circuitbreaker.CPUCircuitBreaker;
 import org.apache.solr.util.circuitbreaker.CircuitBreaker;
 import org.apache.solr.util.circuitbreaker.CircuitBreakerManager;
+import org.apache.solr.util.circuitbreaker.CircuitBreakerRegistry;
 import org.apache.solr.util.circuitbreaker.LoadAverageCircuitBreaker;
 import org.apache.solr.util.circuitbreaker.MemoryCircuitBreaker;
 import org.hamcrest.MatcherAssert;
@@ -80,6 +81,16 @@ public abstract class BaseTestCircuitBreaker extends SolrTestCaseJ4 {
     CircuitBreaker circuitBreaker = new MockCircuitBreaker(true);
 
     h.getCore().getCircuitBreakerRegistry().register(circuitBreaker);
+
+    expectThrows(SolrException.class, () -> h.query(req("name:\"john smith\"")));
+  }
+
+  public void testGlobalCBAlwaysTrips() {
+    removeAllExistingCircuitBreakers();
+
+    CircuitBreaker circuitBreaker = new MockCircuitBreaker(true);
+
+    CircuitBreakerRegistry.registerGlobal(circuitBreaker);
 
     expectThrows(
         SolrException.class,
@@ -135,7 +146,7 @@ public abstract class BaseTestCircuitBreaker extends SolrTestCaseJ4 {
   }
 
   public void testFakeCPUCircuitBreaker() {
-    CPUCircuitBreaker circuitBreaker = new FakeCPUCircuitBreaker(h.getCore());
+    CPUCircuitBreaker circuitBreaker = new FakeCPUCircuitBreaker(h.getCore().getCoreContainer());
     circuitBreaker.setThreshold(75);
 
     assertThatHighQueryLoadTrips(circuitBreaker, 5);
@@ -318,8 +329,8 @@ public abstract class BaseTestCircuitBreaker extends SolrTestCaseJ4 {
   }
 
   private static class FakeCPUCircuitBreaker extends CPUCircuitBreaker {
-    public FakeCPUCircuitBreaker(SolrCore core) {
-      super(core);
+    public FakeCPUCircuitBreaker(CoreContainer coreContainer) {
+      super(coreContainer);
     }
 
     @Override

--- a/solr/core/src/test/org/apache/solr/util/BaseTestCircuitBreaker.java
+++ b/solr/core/src/test/org/apache/solr/util/BaseTestCircuitBreaker.java
@@ -22,11 +22,16 @@ import static org.hamcrest.CoreMatchers.containsString;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.util.ExecutorUtil;
@@ -97,6 +102,73 @@ public abstract class BaseTestCircuitBreaker extends SolrTestCaseJ4 {
         () -> {
           h.query(req("name:\"john smith\""));
         });
+  }
+
+  public void testCBsCanBeMarkedAsWarnOnly() throws Exception {
+    removeAllExistingCircuitBreakers();
+
+    final var warnCircuitBreaker = new MockCircuitBreaker(true);
+    CircuitBreakerRegistry.registerGlobal(warnCircuitBreaker);
+
+    // CB is warnOnly=false by default, so error is thrown.
+    expectThrows(
+        SolrException.class,
+        () -> {
+          h.query(req("name:\"john smith\""));
+        });
+
+    // When warnOnly=true is set, CB will trip but requests will not fail
+    warnCircuitBreaker.setWarnOnly(true);
+    final var tripList =
+        h.getCore().getCircuitBreakerRegistry().checkTripped(SolrRequest.SolrRequestType.QUERY);
+    assertEquals(1, tripList.size());
+    assertEquals(warnCircuitBreaker, tripList.get(0));
+    h.query(req("name:\"john smith\""));
+  }
+
+  public void testGlobalCBsCanBeParsedFromSystemProperties() {
+    final var props = new Properties();
+    props.setProperty("solr.circuitbreaker.query.mem", "12");
+    props.setProperty("solr.circuitbreaker.update.loadavg", "3.4");
+    props.setProperty("solr.circuitbreaker.update.cpu", "56");
+    // Ensure 'warnOnly' property is picked up.
+    props.setProperty("solr.circuitbreaker.update.cpu.warnonly", "true");
+    System.setProperties(props);
+
+    try {
+      final var parsedBreakers =
+          CircuitBreakerRegistry.parseCircuitBreakersFromProperties(h.getCoreContainer()).stream()
+              .sorted(Comparator.comparing(breaker -> breaker.toString()))
+              .collect(Collectors.toList());
+
+      assertEquals(3, parsedBreakers.size());
+
+      assertTrue(
+          "Expected CPUCircuitBreaker, but got " + parsedBreakers.get(0).getClass().getName(),
+          parsedBreakers.get(0) instanceof CPUCircuitBreaker);
+      final var cpuBreaker = (CPUCircuitBreaker) parsedBreakers.get(0);
+      assertEquals(56.0, cpuBreaker.getCpuUsageThreshold(), 0.1);
+      assertEquals(true, cpuBreaker.isWarnOnly());
+      assertEquals(Set.of(SolrRequest.SolrRequestType.UPDATE), cpuBreaker.getRequestTypes());
+
+      assertTrue(
+          "Expected LoadAverageCircuitBreaker, but got "
+              + parsedBreakers.get(1).getClass().getName(),
+          parsedBreakers.get(1) instanceof LoadAverageCircuitBreaker);
+      final var loadAvgBreaker = (LoadAverageCircuitBreaker) parsedBreakers.get(1);
+      assertEquals(3.4, loadAvgBreaker.getLoadAverageThreshold(), 0.1);
+      assertEquals(false, loadAvgBreaker.isWarnOnly());
+      assertEquals(Set.of(SolrRequest.SolrRequestType.UPDATE), loadAvgBreaker.getRequestTypes());
+
+      assertTrue(
+          "Expected MemoryCircuitBreaker, but got " + parsedBreakers.get(2).getClass().getName(),
+          parsedBreakers.get(2) instanceof MemoryCircuitBreaker);
+      final var memBreaker = (MemoryCircuitBreaker) parsedBreakers.get(2);
+      assertEquals(false, memBreaker.isWarnOnly());
+      assertEquals(Set.of(SolrRequest.SolrRequestType.QUERY), memBreaker.getRequestTypes());
+    } finally {
+      props.keySet().stream().forEach(k -> System.clearProperty((String) k));
+    }
   }
 
   public void testCBFakeMemoryPressure() throws Exception {

--- a/solr/core/src/test/org/apache/solr/util/TestGlobalCircuitBreaker.java
+++ b/solr/core/src/test/org/apache/solr/util/TestGlobalCircuitBreaker.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.util;
+
+import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.util.circuitbreaker.CircuitBreakerRegistry;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/** Tests the pluggable circuit breaker implementation. The actual tests are in base class. */
+public class TestGlobalCircuitBreaker extends SolrTestCaseJ4 {
+  @BeforeClass
+  public static void setUpClass() throws Exception {
+    System.setProperty("filterCache.enabled", "false");
+    System.setProperty("queryResultCache.enabled", "false");
+    System.setProperty("documentCache.enabled", "true");
+
+    // Set a global update breaker for a low CPU, which will trip during indexing
+    System.setProperty(CircuitBreakerRegistry.SYSPROP_UPDATE_LOADAVG, "0.1");
+
+    initCore("solrconfig-basic.xml", "schema.xml");
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    System.clearProperty(CircuitBreakerRegistry.SYSPROP_UPDATE_LOADAVG);
+    // Deregister the global breaker to not interfere with other tests
+    CircuitBreakerRegistry.deregisterGlobal();
+  }
+
+  @Test
+  public void testGloalCbRegistered() {
+    assertEquals(1, CircuitBreakerRegistry.listGlobal().size());
+  }
+
+  @Test
+  public void testIndexingTripsCpuCb() {
+    try {
+      for (int i = 0; i < 100; i++) {
+        assertU(adoc("name", "john smith", "id", "1"));
+        assertU(adoc("name", "johathon smith", "id", "2"));
+        assertU(adoc("name", "john percival smith", "id", "3"));
+        assertU(adoc("id", "1", "title", "this is a title.", "inStock_b1", "true"));
+        assertU(adoc("id", "2", "title", "this is another title.", "inStock_b1", "true"));
+        assertU(adoc("id", "3", "title", "Mary had a little lamb.", "inStock_b1", "false"));
+
+        // commit inside the loop to get multiple segments to make search as realistic as possible
+        assertU(commit());
+      }
+      fail("Should have tripped");
+    } catch (SolrException e) {
+      // We get a load average above 0.1, which trips the breaker
+      assertEquals(SolrException.ErrorCode.TOO_MANY_REQUESTS.code, e.code());
+    }
+  }
+}

--- a/solr/solr-ref-guide/modules/deployment-guide/pages/circuit-breakers.adoc
+++ b/solr/solr-ref-guide/modules/deployment-guide/pages/circuit-breakers.adoc
@@ -23,17 +23,41 @@ resource configuration.
 == When To Use Circuit Breakers
 Circuit breakers should be used when the user wishes to trade request throughput for a higher Solr stability.
 If circuit breakers are enabled, requests may be rejected under the condition of high node duress with HTTP error code 429 'Too Many Requests'.
-
 It is up to the client to handle this error and potentially build retry logic as this should be a transient situation.
 
-In a sharded collection, when a circuit breaker trips on one shard, the entire query will fail,
-even if the other shard requests succeed. This will multiply the failures seen by the end users.
-Setting the `shards.tolerant=true` parameter on requests can help with graceful degradation when
-circuit breaker thresholds are reached on some nodes. See the <<shards.tolerant Parameter>> for details.
+Individual circuit breakers may also be enabled in a "warn only" mode.
+"Warn only" breakers whose threshold has been exceeded are logged, but are not used to block or short-circuit requests.
+This may be used as a way to tune circuit breaker thresholds without impacting traffic.
+
+In a request to a sharded collection, the circuit breaker is only checked on the node handling the initial request, not for inter-node requests. It is therefore recommended to load balance client requests across Solr nodes to avoid hotspots.
 
 == Circuit Breaker Configurations
-All circuit breaker configurations are listed as independent `<circuitBreaker>` entries in `solrconfig.xml` as shown below.
-A circuit breaker can register itself to trip for query requests and/or update requests. By default only search requests are affected. A user may register multiple circuit breakers of the same type with different thresholds for each request type.
+Circuit breakers can be configured globally for the entire node, or for each collection individually, or a combination. Per-collection circuit breakers are checked before global circuit breakers, and if there is a conflict, the per-collection circuit breaker takes precedence.
+Typically, any per-collection circuit breaker thresholds are set lower than global thresholds.
+
+A circuit breaker can register itself to be checked for query requests and/or update requests. A user may register circuit breakers of the same type with different thresholds for each request type.
+
+=== Global Circuit Breakers
+Circuit breakers can be configured globally using environment variables, e.g. in `solr.in.sh`, or system properties. The variables available are:
+
+[options="header"]
+|===
+|Name |Environment Variable Name |System Property Name
+|JVM Heap Usage |`SOLR_CIRCUITBREAKER_QUERY_MEM`, `SOLR_CIRCUITBREAKER_UPDATE_MEM` |`solr.circuitbreaker.query.mem`, `solr.circuitbreaker.update.mem`
+|System CPU Usage |`SOLR_CIRCUITBREAKER_QUERY_CPU`, `SOLR_CIRCUITBREAKER_UPDATE_CPU` |`solr.circuitbreaker.query.cpu`, `solr.circuitbreaker.update.cpu`
+|System Load Average |`SOLR_CIRCUITBREAKER_QUERY_LOADAVG`, `SOLR_CIRCUITBREAKER_UPDATE_LOADAVG` |`solr.circuitbreaker.query.loadavg`, `solr.circuitbreaker.update.loadavg`
+|===
+
+Circuit breakers can be configured in "warn only" mode by adding a "warnonly"-suffixed environment variable or system property with a boolean value.
+
+For example, you can enable a global CPU circuit breaker that rejects update requests when above 95% CPU load, by setting the following environment variable: `SOLR_CIRCUITBREAKER_UPDATE_CPU=95`.
+If "warn only" mode is desired for this circuit breaker, the `SOLR_CIRCUITBREAKER_UPDATE_CPU_WARNONLY=true` environment variable or `solr.circuitbreaker.update.cpu.warnonly=true` system property could be set.
+
+=== Per Collection Circuit Breakers
+Circuit breakers are configured as independent `<circuitBreaker>` entries in `solrconfig.xml` as shown in the below examples.
+By default, only search requests are affected.
+The syntax and semantics of available configuration options differs slightly based on the type of circuit breaker being configured.
+However all circuit breakers support a boolean "warnOnly" setting" that can be used to set the circuit breaker into "warn only" mode (e.g. `<bool name="warnOnly">true</bool>`)
 
 == Currently Supported Circuit Breakers
 
@@ -52,11 +76,18 @@ The main configuration for this circuit breaker is controlling the threshold per
 
 To enable and configure the JVM heap usage based circuit breaker, add the following:
 
+.Per collection in `solrconfig.xml`
 [source,xml]
 ----
 <circuitBreaker class="org.apache.solr.util.circuitbreaker.MemoryCircuitBreaker">
  <double name="threshold">75</double>
 </circuitBreaker>
+----
+
+.Global in `solr.in.sh`
+[source,bash]
+----
+SOLR_CIRCUITBREAKER_QUERY_MEM=75
 ----
 
 The `threshold` is defined as a percentage of the max heap allocated to the JVM.
@@ -81,11 +112,18 @@ disabled and log an error message. An alternative can then be to use the <<syste
 
 To enable and configure the CPU utilization based circuit breaker:
 
+.Per collection in `solrconfig.xml`
 [source,xml]
 ----
 <circuitBreaker class="org.apache.solr.util.circuitbreaker.CPUCircuitBreaker">
  <double  name="threshold">75</double>
 </circuitBreaker>
+----
+
+.Global in `solr.in.sh`
+[source,bash]
+----
+SOLR_CIRCUITBREAKER_QUERY_CPU=75
 ----
 
 The triggering threshold is defined in percent CPU usage. A value of "0" maps to 0% usage
@@ -101,8 +139,9 @@ usually averaged over one minute. Some systems include processes waiting on IO i
 documentation for your system and JVM to understand this metric. For more information, see the
 https://en.wikipedia.org/wiki/Load_(computing)[Wikipedia page for Load],
 
-To enable and configure the CPU utilization based circuit breaker:
+To enable and configure the Load average circuit breaker:
 
+.Per collection in `solrconfig.xml`
 [source,xml]
 ----
 <circuitBreaker class="org.apache.solr.util.circuitbreaker.LoadAverageCircuitBreaker">
@@ -110,14 +149,26 @@ To enable and configure the CPU utilization based circuit breaker:
 </circuitBreaker>
 ----
 
+.Global in `solr.in.sh`
+[source,bash]
+----
+SOLR_CIRCUITBREAKER_QUERY_LOADAVG=8.0
+----
+
 The triggering threshold is a floating point number matching load average.
 The example circuit breaker above will trip when the load average is equal to or greater than 8.0.
+
+[NOTE]
+====
+The System Load Average Circuit breaker behavior is dependent on the operating system, and may not work on some operating systems like Microsoft Windows. See https://docs.oracle.com/en/java/javase/17/docs/api/java.management/java/lang/management/OperatingSystemMXBean.html#getSystemLoadAverage()[JavaDoc] for more.
+====
 
 == Advanced example
 
 In this example we will prevent update requests above 80% CPU load, and prevent query requests above 95% CPU load. Supported request types are `query` and `update`.
 This would prevent expensive bulk updates from impacting search. Note also the support for short-form class name.
 
+.Per collection in `solrconfig.xml`
 [source,xml]
 ----
 <config>
@@ -135,6 +186,13 @@ This would prevent expensive bulk updates from impacting search. Note also the s
    </arr>
   </circuitBreaker>
 </config>
+----
+
+.Global in `solr.in.sh`
+[source,bash]
+----
+SOLR_CIRCUITBREAKER_UPDATE_CPU=80
+SOLR_CIRCUITBREAKER_QUERY_CPU=95
 ----
 
 == Performance Considerations

--- a/solr/solrj/src/java/org/apache/solr/common/util/EnvUtils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/EnvUtils.java
@@ -1,0 +1,271 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.solr.common.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.apache.solr.common.SolrException;
+
+/**
+ * This class is a unified provider of environment variables and system properties. It exposes a
+ * mutable copy of the environment variables. It also converts 'SOLR_FOO' variables to system
+ * properties 'solr.foo' and provide various convenience accessors for them.
+ */
+public class EnvUtils {
+  private static final SortedMap<String, String> ENV = new TreeMap<>(System.getenv());
+  private static final Map<String, String> CUSTOM_MAPPINGS = new HashMap<>();
+  private static final Map<String, String> camelCaseToDotsMap = new ConcurrentHashMap<>();
+
+  static {
+    try {
+      Properties props = new Properties();
+      try (InputStream stream =
+          EnvUtils.class.getClassLoader().getResourceAsStream("EnvToSyspropMappings.properties")) {
+        props.load(new InputStreamReader(Objects.requireNonNull(stream), StandardCharsets.UTF_8));
+        for (String key : props.stringPropertyNames()) {
+          CUSTOM_MAPPINGS.put(key, props.getProperty(key));
+        }
+        init(false);
+      }
+    } catch (IOException e) {
+      throw new SolrException(
+          SolrException.ErrorCode.INVALID_STATE, "Failed loading env.var->properties mapping", e);
+    }
+  }
+
+  /**
+   * Get Solr's mutable copy of all environment variables.
+   *
+   * @return sorted map of environment variables
+   */
+  public static SortedMap<String, String> getEnvs() {
+    return ENV;
+  }
+
+  /** Get a single environment variable as string */
+  public static String getEnv(String key) {
+    return ENV.get(key);
+  }
+
+  /** Get a single environment variable as string, or default */
+  public static String getEnv(String key, String defaultValue) {
+    return ENV.getOrDefault(key, defaultValue);
+  }
+
+  /** Get an environment variable as long */
+  public static long getEnvAsLong(String key) {
+    return Long.parseLong(ENV.get(key));
+  }
+
+  /** Get an environment variable as long, or default value */
+  public static long getEnvAsLong(String key, long defaultValue) {
+    String value = ENV.get(key);
+    if (value == null) {
+      return defaultValue;
+    }
+    return Long.parseLong(value);
+  }
+
+  /** Get an env var as boolean */
+  public static boolean getEnvAsBool(String key) {
+    return StrUtils.parseBool(ENV.get(key));
+  }
+
+  /** Get an env var as boolean, or default value */
+  public static boolean getEnvAsBool(String key, boolean defaultValue) {
+    String value = ENV.get(key);
+    if (value == null) {
+      return defaultValue;
+    }
+    return StrUtils.parseBool(value);
+  }
+
+  /** Get comma separated strings from env as List */
+  public static List<String> getEnvAsList(String key) {
+    return getEnv(key) != null ? stringValueToList(getEnv(key)) : null;
+  }
+
+  /** Get comma separated strings from env as List */
+  public static List<String> getEnvAsList(String key, List<String> defaultValue) {
+    return ENV.get(key) != null ? getEnvAsList(key) : defaultValue;
+  }
+
+  /** Set an environment variable */
+  public static void setEnv(String key, String value) {
+    ENV.put(key, value);
+  }
+
+  /** Set all environment variables */
+  public static synchronized void setEnvs(Map<String, String> env) {
+    ENV.clear();
+    ENV.putAll(env);
+  }
+
+  /** Get all Solr system properties as a sorted map */
+  public static SortedMap<String, String> getProperties() {
+    return System.getProperties().entrySet().stream()
+        .collect(
+            Collectors.toMap(
+                entry -> entry.getKey().toString(),
+                entry -> entry.getValue().toString(),
+                (e1, e2) -> e1,
+                TreeMap::new));
+  }
+
+  /** Get a property as string */
+  public static String getProperty(String key) {
+    return getProperty(key, null);
+  }
+
+  /**
+   * Get a property as string with a fallback value. All other getProperty* methods use this.
+   *
+   * @param key property key, which treats 'camelCase' the same as 'camel.case'
+   * @param defaultValue fallback value if property is not found
+   */
+  public static String getProperty(String key, String defaultValue) {
+    String value = getPropertyWithCamelCaseFallback(key);
+    return value != null ? value : defaultValue;
+  }
+
+  /**
+   * Get a property from given key or an alias key converted from CamelCase to dot separated.
+   *
+   * @return property value or value of dot-separated alias key or null if not found
+   */
+  private static String getPropertyWithCamelCaseFallback(String key) {
+    String value = System.getProperty(key);
+    if (value != null) {
+      return value;
+    } else {
+      // Figure out if string is CamelCase and convert to dot separated
+      String altKey = camelCaseToDotSeparated(key);
+      return System.getProperty(altKey);
+    }
+  }
+
+  private static String camelCaseToDotSeparated(String key) {
+    return camelCaseToDotsMap.computeIfAbsent(
+        key,
+        (k) -> String.join(".", k.split("(?=[A-Z])")).replace("..", ".").toLowerCase(Locale.ROOT));
+  }
+
+  /** Get property as integer */
+  public static Long getPropertyAsLong(String key) {
+    return getPropertyAsLong(key, null);
+  }
+
+  /** Get property as long, or default value */
+  public static Long getPropertyAsLong(String key, Long defaultValue) {
+    String value = getProperty(key);
+    if (value == null) {
+      return defaultValue;
+    }
+    return Long.parseLong(value);
+  }
+
+  /** Get property as boolean */
+  public static Boolean getPropertyAsBool(String key) {
+    return getPropertyAsBool(key, null);
+  }
+
+  /** Get property as boolean, or default value */
+  public static Boolean getPropertyAsBool(String key, Boolean defaultValue) {
+    String value = getProperty(key);
+    if (value == null) {
+      return defaultValue;
+    }
+    return StrUtils.parseBool(value);
+  }
+
+  /**
+   * Get comma separated strings from sysprop as List
+   *
+   * @return list of strings, or null if not found
+   */
+  public static List<String> getPropertyAsList(String key) {
+    return getPropertyAsList(key, null);
+  }
+
+  /**
+   * Get comma separated strings from sysprop as List, or default value
+   *
+   * @return list of strings, or provided default if not found
+   */
+  public static List<String> getPropertyAsList(String key, List<String> defaultValue) {
+    return getProperty(key) != null ? stringValueToList(getProperty(key)) : defaultValue;
+  }
+
+  /** Set a system property. Shim to {@link System#setProperty(String, String)} */
+  public static void setProperty(String key, String value) {
+    System.setProperty(key, value);
+    System.setProperty(camelCaseToDotSeparated(key), value);
+  }
+
+  /**
+   * Re-reads environment variables and updates the internal map. Mainly for internal and test use.
+   *
+   * @param overwrite if true, overwrite existing system properties with environment variables
+   */
+  static synchronized void init(boolean overwrite) {
+    // Convert eligible environment variables to system properties
+    for (String key : ENV.keySet()) {
+      if (key.startsWith("SOLR_") || CUSTOM_MAPPINGS.containsKey(key)) {
+        String sysPropKey = envNameToSyspropName(key);
+        // Existing system properties take precedence
+        if (!sysPropKey.isBlank() && (overwrite || getProperty(sysPropKey, null) == null)) {
+          setProperty(sysPropKey, ENV.get(key));
+        }
+      }
+    }
+  }
+
+  protected static String envNameToSyspropName(String envName) {
+    return CUSTOM_MAPPINGS.containsKey(envName)
+        ? CUSTOM_MAPPINGS.get(envName)
+        : envName.toLowerCase(Locale.ROOT).replace("_", ".");
+  }
+
+  /**
+   * Convert a string to a List&lt;String&gt;. If the string is a JSON array, it will be parsed as
+   * such. String splitting uses "splitSmart" which supports backslash escaped characters.
+   */
+  @SuppressWarnings("unchecked")
+  private static List<String> stringValueToList(String string) {
+    if (string.startsWith("[") && string.endsWith("]")) {
+      // Convert a JSON string to a List<String> using Noggit parser
+      return (List<String>) Utils.fromJSONString(string);
+    } else {
+      return StrUtils.splitSmart(string, ",", true).stream()
+          .map(String::trim)
+          .collect(Collectors.toList());
+    }
+  }
+}

--- a/solr/solrj/src/resources/EnvToSyspropMappings.properties
+++ b/solr/solrj/src/resources/EnvToSyspropMappings.properties
@@ -1,0 +1,97 @@
+# Mapping from Environment variable to system property
+# This file only contains non-standard mappings that do not follow the standard naming convention
+# Map to nothing to avoid setting any system property for the env.variable
+# CamelCase properties are mapped to dot separated lowercase
+# This way, env SOLR_FOO_BAR will also match property 'solr.foo.bar' without a mapping in this file
+# TODO: Deprecate non-standard sysprops and standardize on solr.foo.bar in Solr 10
+AWS_PROFILE=aws.profile
+DEFAULT_CONFDIR=solr.default.confdir
+SOLR_ADMIN_UI_DISABLED=disableAdminUI
+SOLR_ALWAYS_ON_TRACE_ID=solr.alwaysOnTraceId
+SOLR_AUTH_JWT_ALLOW_OUTBOUND_HTTP=solr.auth.jwt.allowOutboundHttp
+SOLR_CONFIG_SET_FORBIDDEN_FILE_TYPES=solrConfigSetForbiddenFileTypes
+SOLR_DELETE_UNKNOWN_CORES=solr.deleteUnknownCores
+SOLR_DISABLE_REQUEST_ID=solr.disableRequestId
+SOLR_ENABLE_PACKAGES=enable.packages
+SOLR_ENABLE_REMOTE_STREAMING=solr.enableRemoteStreaming
+SOLR_ENABLE_STREAM_BODY=solr.enableStreamBody
+SOLR_HADOOP_CREDENTIAL_PROVIDER_PATH=hadoop.security.credential.provider.path
+SOLR_HIDDEN_SYS_PROPS=solr.hiddenSysProps
+SOLR_HOME=solr.solr.home
+SOLR_HOST=host
+SOLR_HTTP_DISABLE_COOKIES=solr.http.disableCookies
+SOLR_IP_ALLOWLIST=solr.jetty.inetaccess.includes
+SOLR_IP_DENYLIST=solr.jetty.inetaccess.excludes
+SOLR_LOGS_DIR=solr.log.dir
+SOLR_OTEL_DEFAULT_CONFIGURATOR=solr.otelDefaultConfigurator
+SOLR_PORT=jetty.port
+SOLR_TIMEZONE=user.timezone
+SOLR_TIP=solr.install.dir
+SOLR_TIP_SYM=solr.install.symDir
+SOLR_WAIT_FOR_ZK=waitForZk
+ZK_CLIENT_TIMEOUT=zkClientTimeout
+ZK_CREATE_CHROOT=createZkChroot
+ZK_CREDENTIALS_INJECTOR=zkCredentialsInjector
+ZK_CREDENTIALS_PROVIDER=zkCredentialsProvider
+ZK_DIGEST=PASSWORD=zkDigestPassword
+ZK_DIGEST_CREDENTIALS_FILE=zkDigestCredentialsFile
+ZK_DIGEST_READONLY_PASSWORD=zkDigestReadonlyPassword
+ZK_DIGEST_READONLY_USERNAME=zkDigestReadonlyUsername
+ZK_DIGEST_USERNAME=zkDigestUsername
+ZK_HOST=zkHost
+
+# Commonly used in solr.xml
+SOLR_ALLOW_PATHS=solr.allowPaths
+SOLR_ALLOW_URLS=solr.allowUrls
+SOLR_MAX_BOOLEAN_CLAUSES=solr.max.booleanClauses
+SOLR_METRICS_ENABLED=metricsEnabled
+SOLR_SHARED_LIB=solr.sharedLib
+SOLR_ZK_ACL_PROVIDER=zkACLProvider
+SOLR_ZK_CLIENT_TIMEOUT=solr.zkclienttimeout
+SOLR_ZK_CREDENTIALS_INJECTOR=zkCredentialsInjector
+SOLR_ZK_CREDENTIALS_PROVIDER=zkCredentialsProvider
+
+# Commonly used in solrconfig.xml
+SOLR_AUTO_SOFT_COMMIT_MAX_TIME=solr.autoSoftCommit.maxTime
+SOLR_AUTO_COMMIT_MAX_TIME=solr.autoCommit.maxTime
+SOLR_COMMITWITHIN_SOFTCOMMIT=solr.commitwithin.softcommit
+SOLR_DIRECTORY_FACTORY=solr.directoryFactory
+
+# These should not be mapped to system properties
+CLOUD_MODE_OPTS=
+SOLR_ADDL_ARGS=
+SOLR_AUTHENTICATION_CLIENT_BUILDER=
+SOLR_AUTHENTICATION_OPTS=
+SOLR_HEAP=
+SOLR_HEAP_DUMP=
+SOLR_HEAP_DUMP_DIR=
+SOLR_INCLUDE=
+SOLR_JAVA_MEM=
+SOLR_JAVA_STACK_SIZE=
+SOLR_JETTY_CONFIG=
+SOLR_OPTS=
+SOLR_OPTS_INTERNAL=
+SOLR_REQUESTLOG_ENABLED=
+SOLR_SECURITY_MANAGER_ENABLED=
+SOLR_SERVER_DIR=
+SOLR_SSL_CHECK_PEER_NAME=
+SOLR_SSL_CLIENT_HOSTNAME_VERIFICATION=
+SOLR_SSL_CLIENT_KEY_STORE=
+SOLR_SSL_CLIENT_KEY_STORE_PASSWORD=
+SOLR_SSL_CLIENT_KEY_STORE_TYPE=
+SOLR_SSL_CLIENT_TRUST_STORE=
+SOLR_SSL_CLIENT_TRUST_STORE_PASSWORD=
+SOLR_SSL_CLIENT_TRUST_STORE_TYPE=
+SOLR_SSL_ENABLED=
+SOLR_SSL_KEY_STORE=
+SOLR_SSL_KEY_STORE_PASSWORD=
+SOLR_SSL_KEY_STORE_TYPE=
+SOLR_SSL_NEED_CLIENT_AUTH=
+SOLR_SSL_OPTS=
+SOLR_SSL_TRUST_STORE=
+SOLR_SSL_TRUST_STORE_PASSWORD=
+SOLR_SSL_TRUST_STORE_TYPE=
+SOLR_SSL_WANT_CLIENT_AUTH=
+SOLR_START_OPTS=
+SOLR_START_WAIT=
+SOLR_STOP_WAIT=


### PR DESCRIPTION
This PR adds global CircuitBreakers that are configured through Zookeeper. Global circuit breakers apply to every collection on every node. You may also add to the `hostOverrides` object to override circuit breakers for a specific node. 

A circuit breaker config looks like this:
```
"org.apache.solr.util.circuitbreaker.CPUCircuitBreaker": {
        "enabled": true,
        "queryThreshold": 95.0,
        "updateThreshold": 85.0, // if either threshold left out, it will not circuit break on that request type
        "warnOnly": false // if true, only print if the circuit would have broken
      }
```

To configure a circuit breaker, edit `clusterprops.json`:

```
{
...
  "circuit-breakers": {
    "configs": {
      "org.apache.solr.util.circuitbreaker.CPUCircuitBreaker": {
        "enabled": false,
        "queryThreshold": 2,
        "updateThreshold": 1
      },
      "org.apache.solr.util.circuitbreaker.LoadAverageCircuitBreaker": {
        "enabled": false,
        "queryThreshold": 1
      }
    },
   "hostOverrides": {
      "localhost": {
         "org.apache.solr.util.circuitbreaker.LoadAverageCircuitBreaker": {
            "enabled": true,
            "queryThreshold": 1
         }
      }
   }
  }
...
}
```

###  Backport info
This PR backports [SOLR-16974: Global Circuit Breakers](https://github.com/apache/solr/pull/1919) from upstream. In this PR, global circuit breakers can be configured via env var.

This PR also backports [SOLR-17277: Add 'warnOnly' mode to CircuitBreakers](https://github.com/apache/solr/pull/2476). This PR is the upstream version of our `debugMode` we had added. 