### PR TITLE
SAI-4995: Add logging on json POST body for top level query

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -16,8 +16,6 @@
  */
 package org.apache.solr.core;
 
-import static org.apache.solr.common.params.CommonParams.DISTRIB;
-import static org.apache.solr.common.params.CommonParams.JSON;
 import static org.apache.solr.common.params.CommonParams.PATH;
 
 import com.codahale.metrics.Counter;
@@ -2991,13 +2989,6 @@ public class SolrCore implements SolrInfoBean, Closeable {
     // TODO should check that responseHeader has not been replaced by handler
     NamedList<Object> responseHeader = rsp.getResponseHeader();
     if (responseHeader == null) return;
-
-    SolrParams params = req.getParams();
-    if (params.getParams(JSON) != null && params.getBool(DISTRIB, true)) {
-      //log JSON for top level query, this includes query embedded in POST query
-      rsp.getToLog().add("json", String.join(" ", params.getParams(JSON)));
-    }
-
     final int qtime = (int) (req.getRequestTimer().getTime());
     int status = 0;
     Exception exception = rsp.getException();

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -3004,6 +3004,7 @@ public class SolrCore implements SolrInfoBean, Closeable {
       rsp.getToLog().add("QTime", qtime);
     }
 
+    SolrParams params = req.getParams();
     if (null != handler && params.getBool(CommonParams.HEADER_ECHO_HANDLER, false)) {
       responseHeader.add("handler", handler.getName());
     }

--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -16,6 +16,8 @@
  */
 package org.apache.solr.core;
 
+import static org.apache.solr.common.params.CommonParams.DISTRIB;
+import static org.apache.solr.common.params.CommonParams.JSON;
 import static org.apache.solr.common.params.CommonParams.PATH;
 
 import com.codahale.metrics.Counter;
@@ -2989,6 +2991,13 @@ public class SolrCore implements SolrInfoBean, Closeable {
     // TODO should check that responseHeader has not been replaced by handler
     NamedList<Object> responseHeader = rsp.getResponseHeader();
     if (responseHeader == null) return;
+
+    SolrParams params = req.getParams();
+    if (params.getParams(JSON) != null && params.getBool(DISTRIB, true)) {
+      //log JSON for top level query, this includes query embedded in POST query
+      rsp.getToLog().add("json", String.join(" ", params.getParams(JSON)));
+    }
+
     final int qtime = (int) (req.getRequestTimer().getTime());
     int status = 0;
     Exception exception = rsp.getException();
@@ -3004,7 +3013,6 @@ public class SolrCore implements SolrInfoBean, Closeable {
       rsp.getToLog().add("QTime", qtime);
     }
 
-    SolrParams params = req.getParams();
     if (null != handler && params.getBool(CommonParams.HEADER_ECHO_HANDLER, false)) {
       responseHeader.add("handler", handler.getName());
     }

--- a/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
@@ -221,8 +221,10 @@ public abstract class RequestHandlerBase
         req.getContext().put(USEPARAM, pluginInfo.attributes.get(USEPARAM));
       SolrPluginUtils.setDefaults(this, req, defaults, appends, invariants);
       SolrParams params = req.getParams();
-      if (params.getParams(CommonParams.JSON) != null && params.getBool(CommonParams.DISTRIB, true)) {
-        //log JSON for top level query, this includes query embedded in POST query, which is available after SolrPluginUtils.setDefaults
+      if (params.getParams(CommonParams.JSON) != null
+          && params.getBool(CommonParams.DISTRIB, true)) {
+        // log JSON for top level query, this includes query embedded in POST query, which is
+        // available after SolrPluginUtils.setDefaults
         rsp.getToLog().add("json", String.join(" ", params.getParams(CommonParams.JSON)));
       }
 

--- a/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
@@ -28,6 +28,7 @@ import org.apache.solr.api.Api;
 import org.apache.solr.api.ApiBag;
 import org.apache.solr.api.ApiSupport;
 import org.apache.solr.common.SolrException;
+import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SuppressForbidden;
@@ -219,6 +220,12 @@ public abstract class RequestHandlerBase
       if (pluginInfo != null && pluginInfo.attributes.containsKey(USEPARAM))
         req.getContext().put(USEPARAM, pluginInfo.attributes.get(USEPARAM));
       SolrPluginUtils.setDefaults(this, req, defaults, appends, invariants);
+      SolrParams params = req.getParams();
+      if (params.getParams(CommonParams.JSON) != null && params.getBool(CommonParams.DISTRIB, true)) {
+        //log JSON for top level query, this includes query embedded in POST query, which is available after SolrPluginUtils.setDefaults
+        rsp.getToLog().add("json", String.join(" ", params.getParams(CommonParams.JSON)));
+      }
+
       req.getContext().remove(USEPARAM);
       rsp.setHttpCaching(httpCaching);
       handleRequestBody(req, rsp);


### PR DESCRIPTION
# Description

The existing logging does not log what the POST body, which our other cogs (alexa etc) uses for querying

This makes it difficult to monitor the queries directly via logs in our solr cluster

# Solution

Include the JSON body in the response log message if it is the top query node (query distributor, ie qa node in our case, or the data node if the query hits the node directly)

Take note that the first attempt was to add the logic in `SolrCore#postDecorateResponse` since most of the log entries are injected there (and `SolrCore#preDecorateResponse` too, but the POST body was not yet read in `preDecorateResponse`). However, this results as the `JSON` entry shows up after the `hits=...` pair, which is not ideal.

Therefore I have decided to add the logic in `RequestHandlerBase#handleRequest` right after the invocation of `SolrPluginUtils.setDefaults`

# Remarks

Tested locally (by using a temp branch based on fs/branch_9_3). Triggered queries by going the FSTA site (https://app.fullstory.test:8043/)

Check the query aggregator log, and it now logs:
```
2024-06-24 22:49:15.434 INFO  (qtp1200906406-34) [c:local s: r:127.0.0.1 x: rid:73c88a5dbe044561a36b83da7060eeb1-703929c13149bc32] o.a.s.c.S.Request webapp=/solr path=/select params={indent=off&shards.tolerant=true&timeAllowed=59999&wat=daily_actives:DailyActives&rid=73c88a5dbe044561a36b83da7060eeb1-703929c13149bc32&shards.preference=replica.type:NRT,replica.type:PULL&wt=json} json={
  "query": "Kind:event",
  "filter": [
    "(Kind:event AND EventStart:[2024\\-06\\-24T07\\:00\\:00Z TO 2024\\-06\\-25T07\\:00\\:00Z})"
  ],
  "limit": 0,
  "facet": {
    "_f0": {
      "type": "range",
      "field": "EventStart",
      "ranges": [
        {
          "from": "2024-06-24T07:00:00Z",
          "to": "2024-06-25T07:00:00Z"
        }
      ],
      "dv": true,
      "facet": {
        "uniqueIndvs": "unique(IndvId,0)"
      }
    },
    "processEmpty": true
  },
  "params": {
    "NOW": "1719269355249",
    "TZ": "America/Los_Angeles",
    "echoParams": "none",
    "wat": "DailyActives"
  }
} rid=73c88a5dbe044561a36b83da7060eeb1-703929c13149bc32 hits=155 status=0 QTime=169
```

Take note that we cannot build the fs-solr with this PR (based on fs/branch_9x), as it misses certain commits/classes, which the current fs-solr main relies on (such as `CompressingDirectoryFactory`)

Some queries could get pretty long and added a considerable amount of log data. However, that should be manageable as we do already log the full query in Alexa level at https://github.com/cowpaths/mn/blob/7d88f7dbdd98739c3b4c1bffe93dfa180e7dbc11/projects/fullstory/go/src/fs/solr/solrcloud/client.go#L584

By evaluating the log size on the solr query message on a busy day on Alexa (Jun 18 Tue), there are around 2.4GB of data
```
SELECT 
  SUM(LENGTH(jsonPayload.message)) / (1024 * 1024) as field_size_MB
FROM 
  `fullstoryapp.stackdriver_logs.k8s_alexa_20240618_H*` WHERE TRUE
  AND jsonPayload.message LIKE '%Querying Solr via select%
```

That's still pretty small comparing to the same date of log data on solr data node. which is at 1.1TB