### PR TITLE
SAI-5041: Skip "DirectoryReader#isCurrent" call for LukeRequestHandler

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/admin/LukeRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/LukeRequestHandler.java
@@ -629,7 +629,9 @@ public class LukeRequestHandler extends RequestHandlerBase {
     // TODO? Is this different then: IndexReader.getCurrentVersion( dir )?
     indexInfo.add("version", reader.getVersion());
     indexInfo.add("segmentCount", reader.leaves().size());
-    indexInfo.add("current", closeSafe(reader::isCurrent));
+
+    // bypass for now as reader::isCurrent could be slow, and we don't need this info
+    //indexInfo.add("current", closeSafe(reader::isCurrent));
     indexInfo.add("hasDeletions", reader.hasDeletions());
     indexInfo.add("directory", dir);
     IndexCommit indexCommit = reader.getIndexCommit();

--- a/solr/core/src/java/org/apache/solr/handler/admin/LukeRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/LukeRequestHandler.java
@@ -631,7 +631,7 @@ public class LukeRequestHandler extends RequestHandlerBase {
     indexInfo.add("segmentCount", reader.leaves().size());
 
     // bypass for now as reader::isCurrent could be slow, and we don't need this info
-    //indexInfo.add("current", closeSafe(reader::isCurrent));
+    // indexInfo.add("current", closeSafe(reader::isCurrent));
     indexInfo.add("hasDeletions", reader.hasDeletions());
     indexInfo.add("directory", dir);
     IndexCommit indexCommit = reader.getIndexCommit();


### PR DESCRIPTION
# Description

Skipping `DirectoryReader#isCurrent` call for `LukeRequestHandler#getIndexInfo` as the call could be slow (especially with JDK 21 slow closing on memory segment) and we don't really use that piece of info from our Solr tools

Take note that this PR is on fs/branch_9x (which will be cherry-picked to 9_3) as we probably want this change beyond 9.3

## Remarks
Some test results: https://fullstory.atlassian.net/browse/SAI-5037