### PR TITLE
add index disk usage to core status call

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
@@ -29,7 +29,6 @@ import org.apache.solr.api.ApiBag;
 import org.apache.solr.api.ApiSupport;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.CommonParams;
-import org.apache.solr.common.params.ShardParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SuppressForbidden;

--- a/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
+++ b/solr/core/src/java/org/apache/solr/handler/RequestHandlerBase.java
@@ -29,6 +29,7 @@ import org.apache.solr.api.ApiBag;
 import org.apache.solr.api.ApiSupport;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.CommonParams;
+import org.apache.solr.common.params.ShardParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SuppressForbidden;

--- a/solr/core/src/java/org/apache/solr/handler/admin/StatusOp.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/StatusOp.java
@@ -18,6 +18,8 @@
 package org.apache.solr.handler.admin;
 
 import java.io.Closeable;
+import java.io.File;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -27,6 +29,7 @@ import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.core.CoreContainer;
+import org.apache.solr.core.NodeConfig;
 
 class StatusOp implements CoreAdminHandler.CoreAdminOp {
   @Override
@@ -39,6 +42,14 @@ class StatusOp implements CoreAdminHandler.CoreAdminOp {
     String reconcile = params.get(CoreAdminParams.RECONCILE_THRESHOLD);
     boolean isIndexInfoNeeded = Boolean.parseBoolean(null == indexInfo ? "true" : indexInfo);
     NamedList<Object> status = new SimpleOrderedMap<>();
+    NamedList<Object> nodeStatus = new SimpleOrderedMap<>();
+    if (it.handler.coreContainer != null) {
+      Path solrDataHome = it.handler.coreContainer.getCoreRootDirectory();
+      File dataDir = solrDataHome.toFile();
+      nodeStatus.add("indexDiskSizeTotal", dataDir.getTotalSpace());
+      nodeStatus.add("indexDiskSizeAvailable", dataDir.getUsableSpace());
+    }
+    it.rsp.add("nodeStatus", nodeStatus);
     Map<String, Exception> failures = new HashMap<>();
     for (Map.Entry<String, CoreContainer.CoreLoadFailure> failure :
         it.handler.coreContainer.getCoreInitFailures().entrySet()) {

--- a/solr/core/src/java/org/apache/solr/handler/admin/StatusOp.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/StatusOp.java
@@ -29,7 +29,6 @@ import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.core.CoreContainer;
-import org.apache.solr.core.NodeConfig;
 
 class StatusOp implements CoreAdminHandler.CoreAdminOp {
   @Override


### PR DESCRIPTION
This PR adds the index disk size to the core status call.

```
{
  "responseHeader":{
    "status":0,
    "QTime":0
  },
  "nodeStatus":{
    "indexDiskSizeTotal":994662584320,
    "indexDiskSizeAvailable":88891129856
  },
  "initFailures":{ },
  "status":{
....
}
```

Tested locally and in playpen. 