### PR TITLE
dedicated storedFields executor experiment

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -178,7 +178,8 @@ public class CoreContainer {
 
   final SolrCores solrCores;
 
-  private final ExecutorService storedFieldsExecutor = ExecutorUtil.newMDCAwareCachedThreadPool("storedFieldsExecutor");
+  private final ExecutorService storedFieldsExecutor =
+      ExecutorUtil.newMDCAwareCachedThreadPool("storedFieldsExecutor");
 
   public void storedFieldsExecute(Callable<Void> callable) throws IOException {
     Future<Void> future = storedFieldsExecutor.submit(callable);

--- a/solr/core/src/java/org/apache/solr/handler/component/RealTimeGetComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/RealTimeGetComponent.java
@@ -235,10 +235,24 @@ public class RealTimeGetComponent extends SearchComponent {
 
     try {
 
-      req.getCoreContainer().storedFieldsExecute(() -> {
-        extracted(rb, reqIds, fieldType, params, searcherInfo, ulog, mustUseRealtimeSearcher, core, transformer, rsp, req, docList);
-        return null;
-      });
+      req.getCoreContainer()
+          .storedFieldsExecute(
+              () -> {
+                extracted(
+                    rb,
+                    reqIds,
+                    fieldType,
+                    params,
+                    searcherInfo,
+                    ulog,
+                    mustUseRealtimeSearcher,
+                    core,
+                    transformer,
+                    rsp,
+                    req,
+                    docList);
+                return null;
+              });
 
     } finally {
       searcherInfo.clear();
@@ -247,7 +261,20 @@ public class RealTimeGetComponent extends SearchComponent {
     addDocListToResponse(rb, docList);
   }
 
-  private static void extracted(ResponseBuilder rb, IdsRequested reqIds, FieldType fieldType, SolrParams params, SearcherInfo searcherInfo, UpdateLog ulog, boolean mustUseRealtimeSearcher, SolrCore core, DocTransformer transformer, SolrQueryResponse rsp, SolrQueryRequest req, SolrDocumentList docList) throws IOException {
+  private static void extracted(
+      ResponseBuilder rb,
+      IdsRequested reqIds,
+      FieldType fieldType,
+      SolrParams params,
+      SearcherInfo searcherInfo,
+      UpdateLog ulog,
+      boolean mustUseRealtimeSearcher,
+      SolrCore core,
+      DocTransformer transformer,
+      SolrQueryResponse rsp,
+      SolrQueryRequest req,
+      SolrDocumentList docList)
+      throws IOException {
     // this is initialized & set on the context *after* any searcher (re-)opening
     ResultContext resultContext = null;
     boolean opennedRealtimeSearcher = false;
@@ -320,8 +347,7 @@ public class RealTimeGetComponent extends SearchComponent {
             case UpdateLog.DELETE:
               break;
             default:
-              throw new SolrException(
-                  ErrorCode.SERVER_ERROR, "Unknown Operation! " + oper);
+              throw new SolrException(ErrorCode.SERVER_ERROR, "Unknown Operation! " + oper);
           }
           if (o != null) continue;
         }
@@ -363,8 +389,7 @@ public class RealTimeGetComponent extends SearchComponent {
           searcherInfo.getSearcher().doc(docid, rsp.getReturnFields().getLuceneFieldNames());
       SolrDocument doc = toSolrDoc(luceneDocument, core.getLatestSchema());
       SolrDocumentFetcher docFetcher = searcherInfo.getSearcher().getDocFetcher();
-      docFetcher.decorateDocValueFields(
-          doc, docid, docFetcher.getNonStoredDVs(true), reuseDvIters);
+      docFetcher.decorateDocValueFields(doc, docid, docFetcher.getNonStoredDVs(true), reuseDvIters);
       if (null != transformer) {
         if (null == resultContext) {
           // either first pass, or we've re-opened searcher - either way now we setContext

--- a/solr/core/src/java/org/apache/solr/response/QueryResponseWriterUtil.java
+++ b/solr/core/src/java/org/apache/solr/response/QueryResponseWriterUtil.java
@@ -49,20 +49,23 @@ public final class QueryResponseWriterUtil {
       String contentType)
       throws IOException {
 
-    if (responseWriter instanceof JacksonJsonWriter) {
-      JacksonJsonWriter binWriter = (JacksonJsonWriter) responseWriter;
-      BufferedOutputStream bos = new BufferedOutputStream(new NonFlushingStream(outputStream));
-      binWriter.write(bos, solrRequest, solrResponse);
-      bos.flush();
-    } else if (responseWriter instanceof BinaryQueryResponseWriter) {
-      BinaryQueryResponseWriter binWriter = (BinaryQueryResponseWriter) responseWriter;
-      binWriter.write(outputStream, solrRequest, solrResponse);
-    } else {
-      OutputStream out = new NonFlushingStream(outputStream);
-      Writer writer = buildWriter(out, ContentStreamBase.getCharsetFromContentType(contentType));
-      responseWriter.write(writer, solrRequest, solrResponse);
-      writer.flush();
-    }
+    solrRequest.getCoreContainer().storedFieldsExecute(() -> {
+      if (responseWriter instanceof JacksonJsonWriter) {
+        JacksonJsonWriter binWriter = (JacksonJsonWriter) responseWriter;
+        BufferedOutputStream bos = new BufferedOutputStream(new NonFlushingStream(outputStream));
+        binWriter.write(bos, solrRequest, solrResponse);
+        bos.flush();
+      } else if (responseWriter instanceof BinaryQueryResponseWriter) {
+        BinaryQueryResponseWriter binWriter = (BinaryQueryResponseWriter) responseWriter;
+        binWriter.write(outputStream, solrRequest, solrResponse);
+      } else {
+        OutputStream out = new NonFlushingStream(outputStream);
+        Writer writer = buildWriter(out, ContentStreamBase.getCharsetFromContentType(contentType));
+        responseWriter.write(writer, solrRequest, solrResponse);
+        writer.flush();
+      }
+      return null;
+    });
   }
 
   private static Writer buildWriter(OutputStream outputStream, String charset)

--- a/solr/core/src/java/org/apache/solr/response/QueryResponseWriterUtil.java
+++ b/solr/core/src/java/org/apache/solr/response/QueryResponseWriterUtil.java
@@ -49,23 +49,28 @@ public final class QueryResponseWriterUtil {
       String contentType)
       throws IOException {
 
-    solrRequest.getCoreContainer().storedFieldsExecute(() -> {
-      if (responseWriter instanceof JacksonJsonWriter) {
-        JacksonJsonWriter binWriter = (JacksonJsonWriter) responseWriter;
-        BufferedOutputStream bos = new BufferedOutputStream(new NonFlushingStream(outputStream));
-        binWriter.write(bos, solrRequest, solrResponse);
-        bos.flush();
-      } else if (responseWriter instanceof BinaryQueryResponseWriter) {
-        BinaryQueryResponseWriter binWriter = (BinaryQueryResponseWriter) responseWriter;
-        binWriter.write(outputStream, solrRequest, solrResponse);
-      } else {
-        OutputStream out = new NonFlushingStream(outputStream);
-        Writer writer = buildWriter(out, ContentStreamBase.getCharsetFromContentType(contentType));
-        responseWriter.write(writer, solrRequest, solrResponse);
-        writer.flush();
-      }
-      return null;
-    });
+    solrRequest
+        .getCoreContainer()
+        .storedFieldsExecute(
+            () -> {
+              if (responseWriter instanceof JacksonJsonWriter) {
+                JacksonJsonWriter binWriter = (JacksonJsonWriter) responseWriter;
+                BufferedOutputStream bos =
+                    new BufferedOutputStream(new NonFlushingStream(outputStream));
+                binWriter.write(bos, solrRequest, solrResponse);
+                bos.flush();
+              } else if (responseWriter instanceof BinaryQueryResponseWriter) {
+                BinaryQueryResponseWriter binWriter = (BinaryQueryResponseWriter) responseWriter;
+                binWriter.write(outputStream, solrRequest, solrResponse);
+              } else {
+                OutputStream out = new NonFlushingStream(outputStream);
+                Writer writer =
+                    buildWriter(out, ContentStreamBase.getCharsetFromContentType(contentType));
+                responseWriter.write(writer, solrRequest, solrResponse);
+                writer.flush();
+              }
+              return null;
+            });
   }
 
   private static Writer buildWriter(OutputStream outputStream, String charset)

--- a/solr/core/src/java/org/apache/solr/util/SolrPluginUtils.java
+++ b/solr/core/src/java/org/apache/solr/util/SolrPluginUtils.java
@@ -252,12 +252,14 @@ public class SolrPluginUtils {
       // get documents
       DocIterator iter = docs.iterator();
       Set<String> fieldFilterF = fieldFilter;
-      req.getCoreContainer().storedFieldsExecute(() -> {
-        for (int i = 0; i < docs.size(); i++) {
-          searcher.doc(iter.nextDoc(), fieldFilterF);
-        }
-        return null;
-      });
+      req.getCoreContainer()
+          .storedFieldsExecute(
+              () -> {
+                for (int i = 0; i < docs.size(); i++) {
+                  searcher.doc(iter.nextDoc(), fieldFilterF);
+                }
+                return null;
+              });
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/util/SolrPluginUtils.java
+++ b/solr/core/src/java/org/apache/solr/util/SolrPluginUtils.java
@@ -251,9 +251,13 @@ public class SolrPluginUtils {
 
       // get documents
       DocIterator iter = docs.iterator();
-      for (int i = 0; i < docs.size(); i++) {
-        searcher.doc(iter.nextDoc(), fieldFilter);
-      }
+      Set<String> fieldFilterF = fieldFilter;
+      req.getCoreContainer().storedFieldsExecute(() -> {
+        for (int i = 0; i < docs.size(); i++) {
+          searcher.doc(iter.nextDoc(), fieldFilterF);
+        }
+        return null;
+      });
     }
   }
 


### PR DESCRIPTION
This is a _very_ simple change (best viewed [ignoring whitespace](https://github.com/cowpaths/fullstory-solr/pull/225/files?diff=unified&w=1)) that simply wraps the parts of the code that instantiate ThreadLocal storedFields and delegates them to a dedicated executor.

Consolidating in this way, and with an executor that allows its threads to die (at least for initial POC) should all but eliminate the "ThreadLocal storedFields cartesian product accumulation over time" problem, to hold us over until we have non-ThreadLocal storedFields in solr 9.7.

I determined these locations by analyzing GCP profiler (to identify code that in practice instantiates ThreadLocal storedFields).