### PR TITLE
SAI-5163 : ConcurrentModificationException from metrics callers

### DIFF
--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -97,7 +97,8 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
     ResultContext resultContext = new ResultContext(metrics);
 
     AtomicInteger qTime = new AtomicInteger();
-    // callers might be invoked sequentially in the same thread as some of them might have dependencies on eachother
+    // callers might be invoked sequentially in the same thread as some of them might have
+    // dependencies on eachother
     for (MetricsApiCaller caller : callers) {
       caller.call(qTime, resultContext, request);
     }
@@ -857,7 +858,7 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
       JsonNode nodeMetricNode = metricsNode.get("solr.node");
 
       if (nodeMetricNode != null) {
-        resultContext.missingCoreMetrics = new ArrayList<>(); //explicitly set missing core metrics
+        resultContext.missingCoreMetrics = new ArrayList<>(); // explicitly set missing core metrics
         for (CoreMetric metric : CoreMetric.values()) {
           Number value =
               metric.property != null
@@ -914,7 +915,8 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
 
     private List<CoreMetric> getTargetCoreMetrics(ResultContext resultContext) {
       List<CoreMetric> targetCoreMetrics = resultContext.missingCoreMetrics;
-      if (targetCoreMetrics == null) { //if not explicitly defined by other callers, then just get everything
+      if (targetCoreMetrics
+          == null) { // if not explicitly defined by other callers, then just get everything
         targetCoreMetrics = Arrays.asList(CoreMetric.values());
       }
       return targetCoreMetrics;
@@ -950,7 +952,7 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
     protected void handle(ResultContext resultContext, JsonNode metrics) throws IOException {
       List<PrometheusMetric> results = resultContext.resultMetrics;
       Map<CoreMetric, Long> accumulative = new LinkedHashMap<>();
-      for (CoreMetric missingCoreMetric :getTargetCoreMetrics(resultContext)) {
+      for (CoreMetric missingCoreMetric : getTargetCoreMetrics(resultContext)) {
         for (JsonNode coreMetricNode : metrics) {
           Number val =
               missingCoreMetric.property != null
@@ -1056,12 +1058,12 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
   abstract static class MetricsApiCaller {
 
     // use HttpSolrCall to simulate a call to the metrics api.
-    void call(
-        AtomicInteger qTime, ResultContext resultContext, HttpServletRequest originalRequest)
+    void call(AtomicInteger qTime, ResultContext resultContext, HttpServletRequest originalRequest)
         throws IOException, UnavailableException {
       SolrDispatchFilter filter = getSolrDispatchFilter(originalRequest);
       CoreContainer cores = filter.getCores();
-      HttpServletRequest request = new MetricsApiRequest(originalRequest, buildQueryString(resultContext));
+      HttpServletRequest request =
+          new MetricsApiRequest(originalRequest, buildQueryString(resultContext));
       MetricsApiResponse response = new MetricsApiResponse();
       SolrDispatchFilter.Action action =
           new HttpSolrCall(filter, cores, request, response, false).call();
@@ -1087,7 +1089,6 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
       qTime.addAndGet(getNumber(header, "QTime").intValue());
       handle(resultContext, response.path("metrics"));
     }
-
 
     abstract void handle(ResultContext resultContext, JsonNode metrics) throws IOException;
 
@@ -1370,8 +1371,8 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
   }
 
   /**
-   * Context that carries the metrics results as well as information that needs to be propagated in the MetricsApiCaller
-   * call chain
+   * Context that carries the metrics results as well as information that needs to be propagated in
+   * the MetricsApiCaller call chain
    */
   static class ResultContext {
     final List<PrometheusMetric> resultMetrics;

--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -72,16 +72,14 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
   private final List<MetricsApiCaller> callers = getCallers();
 
   private List<MetricsApiCaller> getCallers() {
-    AggregateMetricsApiCaller aggregateMetricsApiCaller = new AggregateMetricsApiCaller();
     return List.of(
         new GarbageCollectorMetricsApiCaller(),
         new MemoryMetricsApiCaller(),
         new OsMetricsApiCaller(),
         new ThreadMetricsApiCaller(),
         new StatusCodeMetricsApiCaller(),
-        aggregateMetricsApiCaller,
-        new CoresMetricsApiCaller(
-            Collections.unmodifiableList(aggregateMetricsApiCaller.missingCoreMetrics)));
+        new AggregateMetricsApiCaller(),
+        new CoresMetricsApiCaller());
   }
 
   private final Map<String, PrometheusMetricType> cacheMetricTypes =
@@ -96,9 +94,11 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response)
       throws IOException, UnavailableException {
     List<PrometheusMetric> metrics = new ArrayList<>();
+    ResultContext resultContext = new ResultContext(metrics);
+
     AtomicInteger qTime = new AtomicInteger();
     for (MetricsApiCaller caller : callers) {
-      caller.call(qTime, metrics, request);
+      caller.call(qTime, resultContext, request);
     }
     getCompressingDirectoryPoolMetrics(metrics);
     getCircuitBreakerMetrics(metrics);
@@ -289,7 +289,8 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
         "memory.pools.G1-Survivor-Space.used-after-gc":20971520}}}
        */
     @Override
-    protected void handle(List<PrometheusMetric> results, JsonNode metrics) throws IOException {
+    protected void handle(ResultContext resultContext, JsonNode metrics) throws IOException {
+      List<PrometheusMetric> results = resultContext.resultMetrics;
       JsonNode parent = metrics.path("solr.jvm");
       results.add(
           new PrometheusMetric(
@@ -375,7 +376,8 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
         "memory.non-heap.used":93135560}}}
        */
     @Override
-    protected void handle(List<PrometheusMetric> results, JsonNode metrics) throws IOException {
+    protected void handle(ResultContext resultContext, JsonNode metrics) throws IOException {
+      List<PrometheusMetric> results = resultContext.resultMetrics;
       JsonNode parent = metrics.path("solr.jvm");
       results.add(
           new PrometheusMetric(
@@ -430,7 +432,8 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
         "os.version":"10.15.7"}}}
        */
     @Override
-    protected void handle(List<PrometheusMetric> results, JsonNode metrics) throws IOException {
+    protected void handle(ResultContext resultContext, JsonNode metrics) throws IOException {
+      List<PrometheusMetric> results = resultContext.resultMetrics;
       JsonNode parent = metrics.path("solr.jvm");
       results.add(
           new PrometheusMetric(
@@ -468,7 +471,8 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
         "threads.waiting.count":1756}}}
        */
     @Override
-    protected void handle(List<PrometheusMetric> results, JsonNode metrics) throws IOException {
+    protected void handle(ResultContext resultContext, JsonNode metrics) throws IOException {
+      List<PrometheusMetric> results = resultContext.resultMetrics;
       JsonNode parent = metrics.path("solr.jvm");
       results.add(
           new PrometheusMetric(
@@ -534,7 +538,8 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
         ...
        */
     @Override
-    protected void handle(List<PrometheusMetric> results, JsonNode metrics) throws IOException {
+    protected void handle(ResultContext resultContext, JsonNode metrics) throws IOException {
+      List<PrometheusMetric> results = resultContext.resultMetrics;
       JsonNode parent = metrics.path("solr.jetty");
       results.add(
           new PrometheusMetric(
@@ -826,7 +831,6 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
     },
     ...
     */
-    List<CoreMetric> missingCoreMetrics = new ArrayList<>();
 
     AggregateMetricsApiCaller() {
       super("solr.node", buildPrefix(), buildProperty());
@@ -847,11 +851,12 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
     }
 
     @Override
-    protected void handle(List<PrometheusMetric> results, JsonNode metricsNode) throws IOException {
-      missingCoreMetrics.clear();
+    protected void handle(ResultContext resultContext, JsonNode metricsNode) throws IOException {
+      List<PrometheusMetric> results = resultContext.resultMetrics;
       JsonNode nodeMetricNode = metricsNode.get("solr.node");
 
       if (nodeMetricNode != null) {
+        resultContext.missingCoreMetrics = new ArrayList<>(); //explicitly set missing core metrics
         for (CoreMetric metric : CoreMetric.values()) {
           Number value =
               metric.property != null
@@ -860,13 +865,12 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
           if (!INVALID_NUMBER.equals(value)) {
             results.add(metric.createPrometheusMetric(value, "[node aggregated]"));
           } else {
-            missingCoreMetrics.add(metric);
+            resultContext.missingCoreMetrics.add(metric);
           }
         }
       } else {
         log.warn(
             "Cannot find the solr.node metrics, going to fall back to getting metrics from all cores");
-        missingCoreMetrics.addAll(Arrays.asList(CoreMetric.values()));
       }
     }
   }
@@ -881,20 +885,15 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
    * concurrently with it.
    */
   static class CoresMetricsApiCaller extends MetricsApiCaller {
-    private final List<CoreMetric> missingCoreMetricsView;
-
-    CoresMetricsApiCaller(List<CoreMetric> missingCoreMetricsView) {
-      this.missingCoreMetricsView = missingCoreMetricsView;
-    }
-
     @Override
-    protected String buildQueryString() {
+    protected String buildQueryString(ResultContext resultContext) {
       List<String> prefixes = new ArrayList<>();
       List<String> properties = new ArrayList<>();
-      for (CoreMetric missingMetric : missingCoreMetricsView) {
-        prefixes.add(missingMetric.key);
-        if (missingMetric.property != null) {
-          properties.add(missingMetric.property);
+
+      for (CoreMetric targetMetric : getTargetCoreMetrics(resultContext)) {
+        prefixes.add(targetMetric.key);
+        if (targetMetric.property != null) {
+          properties.add(targetMetric.property);
         }
       }
 
@@ -910,6 +909,14 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
           "core",
           URLEncoder.encode(String.join(",", prefixes), StandardCharsets.UTF_8),
           propertyClause);
+    }
+
+    private List<CoreMetric> getTargetCoreMetrics(ResultContext resultContext) {
+      List<CoreMetric> targetCoreMetrics = resultContext.missingCoreMetrics;
+      if (targetCoreMetrics == null) { //if not explicitly defined by other callers, then just get everything
+        targetCoreMetrics = Arrays.asList(CoreMetric.values());
+      }
+      return targetCoreMetrics;
     }
 
     /*
@@ -939,9 +946,10 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
      */
 
     @Override
-    protected void handle(List<PrometheusMetric> results, JsonNode metrics) throws IOException {
+    protected void handle(ResultContext resultContext, JsonNode metrics) throws IOException {
+      List<PrometheusMetric> results = resultContext.resultMetrics;
       Map<CoreMetric, Long> accumulative = new LinkedHashMap<>();
-      for (CoreMetric missingCoreMetric : missingCoreMetricsView) {
+      for (CoreMetric missingCoreMetric :getTargetCoreMetrics(resultContext)) {
         for (JsonNode coreMetricNode : metrics) {
           Number val =
               missingCoreMetric.property != null
@@ -1048,11 +1056,11 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
 
     // use HttpSolrCall to simulate a call to the metrics api.
     void call(
-        AtomicInteger qTime, List<PrometheusMetric> results, HttpServletRequest originalRequest)
+        AtomicInteger qTime, ResultContext resultContext, HttpServletRequest originalRequest)
         throws IOException, UnavailableException {
       SolrDispatchFilter filter = getSolrDispatchFilter(originalRequest);
       CoreContainer cores = filter.getCores();
-      HttpServletRequest request = new MetricsApiRequest(originalRequest, buildQueryString());
+      HttpServletRequest request = new MetricsApiRequest(originalRequest, buildQueryString(resultContext));
       MetricsApiResponse response = new MetricsApiResponse();
       SolrDispatchFilter.Action action =
           new HttpSolrCall(filter, cores, request, response, false).call();
@@ -1064,10 +1072,10 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
                 action,
                 SolrDispatchFilter.Action.RETURN));
       }
-      handleResponse(qTime, results, response.getJsonNode());
+      handleResponse(qTime, resultContext, response.getJsonNode());
     }
 
-    void handleResponse(AtomicInteger qTime, List<PrometheusMetric> results, JsonNode response)
+    void handleResponse(AtomicInteger qTime, ResultContext resultContext, JsonNode response)
         throws IOException {
       JsonNode header = response.path("responseHeader");
       int status = getNumber(header, "status").intValue();
@@ -1076,13 +1084,13 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
             String.format(Locale.ROOT, "metrics api response status is %d; expected 0.", status));
       }
       qTime.addAndGet(getNumber(header, "QTime").intValue());
-      handle(results, response.path("metrics"));
+      handle(resultContext, response.path("metrics"));
     }
 
-    protected abstract void handle(List<PrometheusMetric> results, JsonNode metrics)
-        throws IOException;
 
-    protected abstract String buildQueryString();
+    abstract void handle(ResultContext resultContext, JsonNode metrics) throws IOException;
+
+    abstract String buildQueryString(ResultContext resultContext);
   }
 
   private abstract static class MetricsByPrefixApiCaller extends MetricsApiCaller {
@@ -1099,7 +1107,7 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
     }
 
     @Override
-    protected String buildQueryString() {
+    protected String buildQueryString(ResultContext resultContext) {
       String propertyClause =
           String.join(
               "&property=",
@@ -1357,6 +1365,19 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
     @Override
     public Locale getLocale() {
       return Locale.ROOT;
+    }
+  }
+
+  /**
+   * Context that carries the metrics results as well as information that needs to be propagated from MetricsApiCaller
+   * to MetricsApiCaller
+   */
+  static class ResultContext {
+    final List<PrometheusMetric> resultMetrics;
+    List<CoreMetric> missingCoreMetrics;
+
+    ResultContext(List<PrometheusMetric> resultMetrics) {
+      this.resultMetrics = resultMetrics;
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -97,8 +97,8 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
     ResultContext resultContext = new ResultContext(metrics);
 
     AtomicInteger qTime = new AtomicInteger();
-    // callers might be invoked sequentially in the same thread as some of them might have
-    // dependencies on eachother
+    // callers should be invoked sequentially in the same thread there could be dependencies among
+    // them
     for (MetricsApiCaller caller : callers) {
       caller.call(qTime, resultContext, request);
     }

--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -97,6 +97,7 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
     ResultContext resultContext = new ResultContext(metrics);
 
     AtomicInteger qTime = new AtomicInteger();
+    // callers might be invoked sequentially in the same thread as some of them might have dependencies on eachother
     for (MetricsApiCaller caller : callers) {
       caller.call(qTime, resultContext, request);
     }
@@ -1369,8 +1370,8 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
   }
 
   /**
-   * Context that carries the metrics results as well as information that needs to be propagated from MetricsApiCaller
-   * to MetricsApiCaller
+   * Context that carries the metrics results as well as information that needs to be propagated in the MetricsApiCaller
+   * call chain
    */
   static class ResultContext {
     final List<PrometheusMetric> resultMetrics;

--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -915,8 +915,8 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
 
     private List<CoreMetric> getTargetCoreMetrics(ResultContext resultContext) {
       List<CoreMetric> targetCoreMetrics = resultContext.missingCoreMetrics;
-      if (targetCoreMetrics
-          == null) { // if not explicitly defined by other callers, then just get everything
+      // if not explicitly defined by other callers, then just get everything
+      if (targetCoreMetrics == null) {
         targetCoreMetrics = Arrays.asList(CoreMetric.values());
       }
       return targetCoreMetrics;

--- a/solr/core/src/test/org/apache/solr/servlet/PrometheusMetricsServletTest.java
+++ b/solr/core/src/test/org/apache/solr/servlet/PrometheusMetricsServletTest.java
@@ -20,16 +20,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import org.apache.solr.common.util.ExecutorUtil;
 import org.apache.solr.common.util.SolrNamedThreadFactory;
-import org.apache.solr.response.ResultContext;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -47,12 +43,12 @@ public class PrometheusMetricsServletTest {
   }
 
   static void assertMetricsApiCaller(
-          PrometheusMetricsServlet.MetricsApiCaller caller,
-          PrometheusMetricsServlet.ResultContext resultContext,
-          String json,
-          int expectedQTime,
-          String expectedOutput)
-          throws Exception {
+      PrometheusMetricsServlet.MetricsApiCaller caller,
+      PrometheusMetricsServlet.ResultContext resultContext,
+      String json,
+      int expectedQTime,
+      String expectedOutput)
+      throws Exception {
     AtomicInteger qTime = new AtomicInteger();
 
     List<PrometheusMetricsServlet.PrometheusMetric> metrics;
@@ -410,11 +406,7 @@ public class PrometheusMetricsServletTest {
             + "# HELP update_errors cumulative number of errors during updates across cores\n"
             + "# TYPE update_errors counter\n"
             + "update_errors 4\n";
-    assertMetricsApiCaller(
-        new PrometheusMetricsServlet.CoresMetricsApiCaller(),
-        json,
-        14,
-        output);
+    assertMetricsApiCaller(new PrometheusMetricsServlet.CoresMetricsApiCaller(), json, 14, output);
   }
 
   @Test
@@ -514,86 +506,87 @@ public class PrometheusMetricsServletTest {
             + "# HELP update_errors cumulative number of errors during updates across cores\n"
             + "# TYPE update_errors counter\n"
             + "update_errors 0\n";
-    assertMetricsApiCaller(
-        new PrometheusMetricsServlet.CoresMetricsApiCaller(),
-        json,
-        25,
-        output);
+    assertMetricsApiCaller(new PrometheusMetricsServlet.CoresMetricsApiCaller(), json, 25, output);
   }
-
 
   @Test
   public void testConcurrentCallers() throws Exception {
     String coreJson =
-            "{\n"
-                    + "  \"responseHeader\":{\n"
-                    + "    \"status\":0,\n"
-                    + "    \"QTime\":25},\n"
-                    + "  \"metrics\":{\n"
-                    + "    \"solr.core.loadtest.shard1_1.replica_n8\":{\n"
-                    + "      \"QUERY./get.requestTimes\":{\"count\":29},\n"
-                    + "      \"QUERY./get[shard].requestTimes\":{\"count\":1},\n"
-                    + "      \"UPDATE./update.requestTimes\":{\"count\":2},\n" +
-                      "      \"UPDATE./update[local].requestTimes\":{\"count\":1}}}}";
+        "{\n"
+            + "  \"responseHeader\":{\n"
+            + "    \"status\":0,\n"
+            + "    \"QTime\":25},\n"
+            + "  \"metrics\":{\n"
+            + "    \"solr.core.loadtest.shard1_1.replica_n8\":{\n"
+            + "      \"QUERY./get.requestTimes\":{\"count\":29},\n"
+            + "      \"QUERY./get[shard].requestTimes\":{\"count\":1},\n"
+            + "      \"UPDATE./update.requestTimes\":{\"count\":2},\n"
+            + "      \"UPDATE./update[local].requestTimes\":{\"count\":1}}}}";
     String nodeJson =
-            "{\n"
-                    + "  \"responseHeader\":{\n"
-                    + "    \"status\":0,\n"
-                    + "    \"QTime\":25},\n"
-                    + "  \"metrics\":{\n"
-                    + "\"solr.node\":{\n" +
-                    "      \"UPDATE./update.requestTimes\":{\"count\":20},\n" +
-                    "      \"UPDATE./update[local].requestTimes\":{\"count\":10}}}}";
+        "{\n"
+            + "  \"responseHeader\":{\n"
+            + "    \"status\":0,\n"
+            + "    \"QTime\":25},\n"
+            + "  \"metrics\":{\n"
+            + "\"solr.node\":{\n"
+            + "      \"UPDATE./update.requestTimes\":{\"count\":20},\n"
+            + "      \"UPDATE./update[local].requestTimes\":{\"count\":10}}}}";
 
+    String nodeOutput =
+        "# HELP distributed_requests_update cumulative number of distributed updates across cores[node aggregated]\n"
+            + "# TYPE distributed_requests_update counter\n"
+            + "distributed_requests_update 20\n"
+            + "# HELP local_requests_update cumulative number of local updates across cores[node aggregated]\n"
+            + "# TYPE local_requests_update counter\n"
+            + "local_requests_update 10\n";
 
-    String nodeOutput = "# HELP distributed_requests_update cumulative number of distributed updates across cores[node aggregated]\n" +
-            "# TYPE distributed_requests_update counter\n" +
-            "distributed_requests_update 20\n" +
-            "# HELP local_requests_update cumulative number of local updates across cores[node aggregated]\n" +
-            "# TYPE local_requests_update counter\n" +
-            "local_requests_update 10\n";
-
-    //core CoresMetricsApiCaller output, it should contain both the nodeOutput and the new metrics added by the core
-    String coreOutput = "# HELP distributed_requests_update cumulative number of distributed updates across cores[node aggregated]\n" +
-            "# TYPE distributed_requests_update counter\n" +
-            "distributed_requests_update 20\n" +
-            "# HELP local_requests_update cumulative number of local updates across cores[node aggregated]\n" +
-            "# TYPE local_requests_update counter\n" +
-            "local_requests_update 10\n" +
-            "# HELP top_level_requests_get cumulative number of top-level gets across cores\n" +
-            "# TYPE top_level_requests_get counter\n" +
-            "top_level_requests_get 29\n" +
-            "# HELP sub_shard_requests_get cumulative number of sub (spawned by re-distributing a top-level req) gets across cores\n" +
-            "# TYPE sub_shard_requests_get counter\n" +
-            "sub_shard_requests_get 1\n";
+    // core CoresMetricsApiCaller output, it should contain both the nodeOutput and the new metrics
+    // added by the core
+    String coreOutput =
+        "# HELP distributed_requests_update cumulative number of distributed updates across cores[node aggregated]\n"
+            + "# TYPE distributed_requests_update counter\n"
+            + "distributed_requests_update 20\n"
+            + "# HELP local_requests_update cumulative number of local updates across cores[node aggregated]\n"
+            + "# TYPE local_requests_update counter\n"
+            + "local_requests_update 10\n"
+            + "# HELP top_level_requests_get cumulative number of top-level gets across cores\n"
+            + "# TYPE top_level_requests_get counter\n"
+            + "top_level_requests_get 29\n"
+            + "# HELP sub_shard_requests_get cumulative number of sub (spawned by re-distributing a top-level req) gets across cores\n"
+            + "# TYPE sub_shard_requests_get counter\n"
+            + "sub_shard_requests_get 1\n";
 
     final int THREAD_COUNT = 100;
-    ExecutorService executorService = ExecutorUtil.newMDCAwareFixedThreadPool(
+    ExecutorService executorService =
+        ExecutorUtil.newMDCAwareFixedThreadPool(
             THREAD_COUNT, new SolrNamedThreadFactory("test-concurrent-metric-callers"));
 
     List<Future<?>> futures = new ArrayList<>();
-    for (int i = 0 ; i < THREAD_COUNT; i ++) {
-      futures.add(executorService.submit(() -> {
-        PrometheusMetricsServlet.ResultContext resultContext = new PrometheusMetricsServlet.ResultContext(new ArrayList<>());
-        assertMetricsApiCaller(
-                new PrometheusMetricsServlet.AggregateMetricsApiCaller(),
-                resultContext,
-                nodeJson,
-                25,
-                nodeOutput);
+    for (int i = 0; i < THREAD_COUNT; i++) {
+      futures.add(
+          executorService.submit(
+              () -> {
+                PrometheusMetricsServlet.ResultContext resultContext =
+                    new PrometheusMetricsServlet.ResultContext(new ArrayList<>());
+                assertMetricsApiCaller(
+                    new PrometheusMetricsServlet.AggregateMetricsApiCaller(),
+                    resultContext,
+                    nodeJson,
+                    25,
+                    nodeOutput);
 
-        assertMetricsApiCaller(
-                new PrometheusMetricsServlet.CoresMetricsApiCaller(),
-                resultContext,
-                coreJson,
-                25,
-                coreOutput);
-        return null;
-      }));
+                assertMetricsApiCaller(
+                    new PrometheusMetricsServlet.CoresMetricsApiCaller(),
+                    resultContext,
+                    coreJson,
+                    25,
+                    coreOutput);
+                return null;
+              }));
     }
 
     for (Future<?> future : futures) {
-      future.get(); //this should not throw any concurrent exceptions or ComparisonFailure
+      future.get(); // this should not throw any concurrent exceptions or ComparisonFailure
     }
   }
 }

--- a/solr/core/src/test/org/apache/solr/servlet/PrometheusMetricsServletTest.java
+++ b/solr/core/src/test/org/apache/solr/servlet/PrometheusMetricsServletTest.java
@@ -567,12 +567,12 @@ public class PrometheusMetricsServletTest {
             "# TYPE sub_shard_requests_get counter\n" +
             "sub_shard_requests_get 1\n";
 
-    final int THREAD_COUNT = 10;
+    final int THREAD_COUNT = 100;
     ExecutorService executorService = ExecutorUtil.newMDCAwareFixedThreadPool(
             THREAD_COUNT, new SolrNamedThreadFactory("test-concurrent-metric-callers"));
 
     List<Future<?>> futures = new ArrayList<>();
-    for (int i = 0 ; i < 10; i ++) {
+    for (int i = 0 ; i < THREAD_COUNT; i ++) {
       futures.add(executorService.submit(() -> {
         PrometheusMetricsServlet.ResultContext resultContext = new PrometheusMetricsServlet.ResultContext(new ArrayList<>());
         assertMetricsApiCaller(


### PR DESCRIPTION
# Description

During deployment of our prod cluster, we have found exception

```
java.util.ConcurrentModificationException: null
        at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1095) ~[?:?]
        at java.util.ArrayList$Itr.next(ArrayList.java:1049) ~[?:?]
        at java.util.Collections$UnmodifiableCollection$1.next(Collections.java:1078) ~[?:?]
        at org.apache.solr.servlet.PrometheusMetricsServlet$CoresMetricsApiCaller.buildQueryString(PrometheusMetricsServlet.java:894)
        at org.apache.solr.servlet.PrometheusMetricsServlet$MetricsApiCaller.call(PrometheusMetricsServlet.java:1055)
        at org.apache.solr.servlet.PrometheusMetricsServlet.doGet(PrometheusMetricsServlet.java:101)
...
```

# Cause
This is caused by change introduced in #220, which [passes the `missingCoreMetrics` list](https://github.com/cowpaths/fullstory-solr/pull/220/files#diff-9737132fe0eb694e080cc7c8d228078ee23cc1e0708080ed7cc6dc8e0fe8ba32R83-R85) from `AggregatedMetricsApiCaller` to `CoreMetricsApiCaller`.

This could cause concurrent modification exception if 2 calls come in from different threads while one invokes the `AggregatedMetricsApiCaller.call` which modifies the `missingCoreMetrics` list and the other one invokes the `CoreMetricsApiCaller.call` which iterates on such list. Those 2 calls can operate on the same servlet instance hence same  `missingCoreMetrics` instance too and trigger the `ConcurrentModificationException`

In our environment, we only invoke the metrics endpoint once in a while (every 30 secs?). So this likely only happen during restarts which some metrics calls were retried and caused the concurrency issue.


# Solution

Instead of tying the `missingCoreMetrics` list to the caller instance, we will pass on a new `ResultContext` which contains the `missingCoreMetrics` and `result` (`List<PrometheusMetrics`), such context is a replacement of the `List<PrometheusMetric>` which gets passed around to accumulate the metric results. Having `missingCoreMetrics` in `ResultContext` is a bit specific but I decided not to over-engineer it to make it generic for now. 

With the `ResultContext` passed to `call` (also `buildQuery` and `handle`), we can ensure metrics callers in the chain operate on a `ResultContext` specific to the incoming request instead of the whole servlet instance, hence avoiding the `ConcurrentModificationException`

# Tests

Added new unit test case `testConcurrentCallers` to test the `AggregatedMetricsApiCaller` -> `CoreMetricsApiCaller` chain

# TODO
setting this to base [fs/branch_9x](https://github.com/cowpaths/fullstory-solr/tree/fs/branch_9x), it might show a lot of changes but it should clear up once https://github.com/cowpaths/fullstory-solr/pull/226 is merged 