### PR TITLE
SAI-5162: Experimental downnode approach to use CoreContainer if available

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/ZkController.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ZkController.java
@@ -2903,7 +2903,8 @@ public class ZkController implements Closeable {
    */
   public Collection<String> publishNodeAsDown(String nodeName) {
     log.info("Publish node={} as DOWN", nodeName);
-    Map<DocCollection, List<Replica>> replicasPerCollectionOnNode = getReplicasPerCollectionOnThisNode();
+    Map<DocCollection, List<Replica>> replicasPerCollectionOnNode =
+        getReplicasPerCollectionOnThisNode();
 
     if (distributedClusterStateUpdater.isDistributedStateUpdate()) {
       // Note that with the current implementation, when distributed cluster state updates are
@@ -2926,7 +2927,8 @@ public class ZkController implements Closeable {
                         coll.getZNode(), zkClient, coll.getPerReplicaStates()))
                 .persist(coll.getZNode(), zkClient);
           } else {
-            // if this node contains any non PRS collection, then we need to notify the overseer as overseer
+            // if this node contains any non PRS collection, then we need to notify the overseer as
+            // overseer
             // manages the replica state for non PRS collections
             sendToOverseer = true;
           }
@@ -2955,7 +2957,9 @@ public class ZkController implements Closeable {
         log.warn("Could not publish node as down: ", e);
       }
     }
-    return replicasPerCollectionOnNode.keySet().stream().map(DocCollection::getName).collect(Collectors.toSet());
+    return replicasPerCollectionOnNode.keySet().stream()
+        .map(DocCollection::getName)
+        .collect(Collectors.toSet());
   }
 
   private Map<DocCollection, List<Replica>> getReplicasPerCollectionOnThisNode() {
@@ -2966,29 +2970,29 @@ public class ZkController implements Closeable {
         String collName = cd.getCollectionName();
         DocCollection coll;
         if (collName != null
-                && processedCollections.add(collName)
-                && (coll = zkStateReader.getCollection(collName)) != null) {
+            && processedCollections.add(collName)
+            && (coll = zkStateReader.getCollection(collName)) != null) {
           final List<Replica> replicasOnThisNode = new ArrayList<>();
           coll.forEachReplica(
-                  (s, replica) -> {
-                    if (replica.getNodeName().equals(nodeName)) {
-                      replicasOnThisNode.add(replica);
-                    }
-                  });
+              (s, replica) -> {
+                if (replica.getNodeName().equals(nodeName)) {
+                  replicasOnThisNode.add(replica);
+                }
+              });
           result.put(coll, replicasOnThisNode);
         }
       }
     } else {
       getClusterState().getCollectionStates().values().stream()
-              .map(ClusterState.CollectionRef::get)
-              .filter(Objects::nonNull)
-              .forEach(
-                      col -> {
-                        List<Replica> replicas = col.getReplicas(nodeName);
-                        if (replicas != null && !replicas.isEmpty()) {
-                          result.put(col, replicas);
-                        }
-                      });
+          .map(ClusterState.CollectionRef::get)
+          .filter(Objects::nonNull)
+          .forEach(
+              col -> {
+                List<Replica> replicas = col.getReplicas(nodeName);
+                if (replicas != null && !replicas.isEmpty()) {
+                  result.put(col, replicas);
+                }
+              });
     }
     return result;
   }

--- a/solr/core/src/java/org/apache/solr/cloud/ZkController.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ZkController.java
@@ -2962,7 +2962,7 @@ public class ZkController implements Closeable {
         .collect(Collectors.toSet());
   }
 
-  private Map<DocCollection, List<Replica>> getReplicasPerCollectionOnThisNode() {
+  Map<DocCollection, List<Replica>> getReplicasPerCollectionOnThisNode() {
     Map<DocCollection, List<Replica>> result = new HashMap<>();
     if (cc.isStatusLoadComplete()) {
       Set<String> processedCollections = new HashSet<>();

--- a/solr/core/src/test/org/apache/solr/cloud/ZkControllerTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ZkControllerTest.java
@@ -394,10 +394,15 @@ public class ZkControllerTest extends SolrCloudTestCase {
         zkController.getZkStateReader().forciblyRefreshAllClusterStateSlow();
         ClusterState clusterState = zkController.getClusterState();
 
-        Map<String, List<Replica>> replicasOnNode =
-            clusterState.getReplicaNamesPerCollectionOnNode(nodeName);
+        Map<DocCollection, List<Replica>> replicasOnNode =
+            zkController.getReplicasPerCollectionOnThisNode();
         assertNotNull("There should be replicas on the existing node", replicasOnNode);
-        List<Replica> replicas = replicasOnNode.get(collectionName);
+        List<Replica> replicas =
+            replicasOnNode.get(
+                replicasOnNode.keySet().stream()
+                    .filter(docColl -> collectionName.equals(docColl.getName()))
+                    .findFirst()
+                    .get());
         assertNotNull("There should be replicas for the collection on the existing node", replicas);
         assertEquals(
             "Wrong number of replicas for the collection on the existing node", 1, replicas.size());

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/ClusterState.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/ClusterState.java
@@ -211,21 +211,6 @@ public class ClusterState implements MapWriter {
     return null;
   }
 
-  public Map<String, List<Replica>> getReplicaNamesPerCollectionOnNode(final String nodeName) {
-    Map<String, List<Replica>> replicaNamesPerCollectionOnNode = new HashMap<>();
-    collectionStates.values().stream()
-        .map(CollectionRef::get)
-        .filter(Objects::nonNull)
-        .forEach(
-            col -> {
-              List<Replica> replicas = col.getReplicas(nodeName);
-              if (replicas != null && !replicas.isEmpty()) {
-                replicaNamesPerCollectionOnNode.put(col.getName(), replicas);
-              }
-            });
-    return replicaNamesPerCollectionOnNode;
-  }
-
   /** Check if node is alive. */
   public boolean liveNodesContain(String name) {
     return liveNodes.contains(name);

--- a/solr/solrj/src/java/org/apache/solr/common/cloud/ClusterState.java
+++ b/solr/solrj/src/java/org/apache/solr/common/cloud/ClusterState.java
@@ -28,7 +28,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;


### PR DESCRIPTION
## Description
As introduced in this [fix](https://github.com/apache/solr/pull/2432), downnode calls will now discover replicas on a node via zk which is more reliable then `CoreContainer`, which might not have the full picture of the replicas if it's not loaded yet (during startup). This however, might impose some extra overhead for big cluster with alot of collections, especially when a large number of collections do NOT have actual replica on the target node, since those are "lazy" collection ref that has no watch which might require a full collection state fetch (exists, and fetch from ZK).

A detailed breakdown of the overhead changes with such fix:

### Node shutdown
Before fix : No ZK fetch as it gets list of replicas from CoreContainer which only contains replicas this node hosts. Therefore they are watched already (no lazy collection ref).
After fix: No ZK fetch on collections that have replica on this node since they are watched by the `ZkStateReader`, however other collections will trigger full ZK fetch on state

### Node startup
Before fix: No ZK fetch, as the downnode has no effect due to the bug 
After fix: Zk fetch on all collections since none of them is being watched yet (core was not loaded/registered to the container yet)


## Solution
_**This is purely just an experiment to understand the scope of code change required to implement the approach to use core container if possible**_ . We might not want such code complexity if the new overhead is not great enough to justify the change!

In theory, we can still use the `CoreContainer` approach for non-startup. Factored out a new method `getReplicasPerCollectionOnThisNode` to achieve that

## Remarks
Take note that this PR also slightly optimizes the existing flow of reading from ZK. Since the existing code actually does a full fetch once and then does another exists check (docCollection is obtained twice), while this PR fetches doCollection only once. 

Though this likely makes little difference as it only saves an `exists` call, which is fast.