### PR TITLE
SAI-5162: Add sysprop `solrcloud.publishDownOnStart` to controller whether publish down on node start or not

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/ZkController.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ZkController.java
@@ -2909,7 +2909,7 @@ public class ZkController implements Closeable {
     final RTimer zkFetchTimer = new RTimer();
     Map<String, List<Replica>> replicasPerCollectionOnNode =
         clusterState.getReplicaNamesPerCollectionOnNode(nodeName);
-    long zkFetchDuration = (long)zkFetchTimer.getTime();
+    long zkFetchDuration = (long) zkFetchTimer.getTime();
     log.info("Spent {} ms on ClusterState#getReplicaNamesPerCollectionOnNode", zkFetchDuration);
     if (distributedClusterStateUpdater.isDistributedStateUpdate()) {
       // Note that with the current implementation, when distributed cluster state updates are
@@ -2963,7 +2963,7 @@ public class ZkController implements Closeable {
         log.warn("Could not publish node as down: ", e);
       }
     }
-    long publishDownDuration = (long)publishDownTimer.getTime();
+    long publishDownDuration = (long) publishDownTimer.getTime();
     log.info("Spent {} ms on ZKController#publishNodeAsDown", publishDownDuration);
 
     return replicasPerCollectionOnNode.keySet();

--- a/solr/core/src/java/org/apache/solr/cloud/ZkController.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ZkController.java
@@ -1023,8 +1023,8 @@ public class ZkController implements Closeable {
       }
 
       Stat stat = zkClient.exists(ZkStateReader.LIVE_NODES_ZKNODE, null, true);
-      boolean skipPublishDownOnStart = Boolean.getBoolean("solrcloud.skipPublishDownOnStart");
-      if (stat != null && stat.getNumChildren() > 0 && !skipPublishDownOnStart) {
+      boolean publishDownOnStart = Boolean.getBoolean("solrcloud.publishDownOnStart");
+      if (stat != null && stat.getNumChildren() > 0 && publishDownOnStart) {
         publishAndWaitForDownStates();
       }
 

--- a/solr/core/src/java/org/apache/solr/cloud/ZkController.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ZkController.java
@@ -2905,10 +2905,10 @@ public class ZkController implements Closeable {
     log.info("Publish node={} as DOWN", nodeName);
 
     ClusterState clusterState = getClusterState();
-    long startZkFetch = System.currentTimeMillis();
+    final RTimer startZkFetchTimer = new RTimer();
     Map<String, List<Replica>> replicasPerCollectionOnNode =
         clusterState.getReplicaNamesPerCollectionOnNode(nodeName);
-    long zkFetchDuration = System.currentTimeMillis() - startZkFetch;
+    long zkFetchDuration = (long)startZkFetchTimer.getTime();
     log.info("Spent {} ms on ClusterState#getReplicaNamesPerCollectionOnNode", zkFetchDuration);
     if (distributedClusterStateUpdater.isDistributedStateUpdate()) {
       // Note that with the current implementation, when distributed cluster state updates are

--- a/solr/core/src/java/org/apache/solr/cloud/ZkController.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ZkController.java
@@ -2902,13 +2902,14 @@ public class ZkController implements Closeable {
    * @return the names of the collections that have replicas on the given node
    */
   public Collection<String> publishNodeAsDown(String nodeName) {
+    final RTimer publishDownTimer = new RTimer();
     log.info("Publish node={} as DOWN", nodeName);
 
     ClusterState clusterState = getClusterState();
-    final RTimer startZkFetchTimer = new RTimer();
+    final RTimer zkFetchTimer = new RTimer();
     Map<String, List<Replica>> replicasPerCollectionOnNode =
         clusterState.getReplicaNamesPerCollectionOnNode(nodeName);
-    long zkFetchDuration = (long)startZkFetchTimer.getTime();
+    long zkFetchDuration = (long)zkFetchTimer.getTime();
     log.info("Spent {} ms on ClusterState#getReplicaNamesPerCollectionOnNode", zkFetchDuration);
     if (distributedClusterStateUpdater.isDistributedStateUpdate()) {
       // Note that with the current implementation, when distributed cluster state updates are
@@ -2962,6 +2963,9 @@ public class ZkController implements Closeable {
         log.warn("Could not publish node as down: ", e);
       }
     }
+    long publishDownDuration = (long)publishDownTimer.getTime();
+    log.info("Spent {} ms on ZKController#publishNodeAsDown", publishDownDuration);
+
     return replicasPerCollectionOnNode.keySet();
   }
 


### PR DESCRIPTION
## Descriptions

Detailed in https://fullstory.atlassian.net/browse/SAI-5162

We are adding a sys prop `solrcloud.publishDownOnStart` to give us an option to bypass downnode publishing upon node start. If set to `true`, it will publish down on start (as in the 9.7 behavior). However, if set to `false` or undefined, it will NOT publish down on start (bypass the fix in 9.7)


Also adding logging to assess actual overhead of the downnode call to determine if we need further action


This change is likely to be temporary, depending on the latency reported, we might pursue further optimization or just take 9.7 change as is. 