### PR TITLE
Add RateLimiter config property to enable limiting on specific nodes

### DIFF
--- a/solr/core/src/java/org/apache/solr/servlet/CoreContainerProvider.java
+++ b/solr/core/src/java/org/apache/solr/servlet/CoreContainerProvider.java
@@ -241,7 +241,9 @@ public class CoreContainerProvider implements ServletContextListener {
 
       Builder builder = new Builder(zkClient);
 
-      this.rateLimitManager = builder.build();
+      String hostname = zkController != null ? zkController.getHostName() : "";
+
+      this.rateLimitManager = builder.build(hostname);
 
       if (zkController != null) {
         zkController.zkStateReader.registerClusterPropertiesListener(this.rateLimitManager);

--- a/solr/core/src/java/org/apache/solr/servlet/RateLimitManager.java
+++ b/solr/core/src/java/org/apache/solr/servlet/RateLimitManager.java
@@ -84,7 +84,7 @@ public class RateLimitManager implements ClusterPropertiesListener {
         throw new UncheckedIOException(e);
       }
     }
-    rateLimiterMeta.overrideNodeProperty(hostname);
+    rateLimiterMeta.maybeEnableForHost(hostname);
     // Hack: We only support query rate limiting for now
     requestRateLimiterMap.compute(
         rateLimiterMeta.priorityBasedEnabled
@@ -254,7 +254,7 @@ public class RateLimitManager implements ClusterPropertiesListener {
 
         RateLimiterPayload rateLimiterMeta =
             mapper.readValue(configInput, RateLimiterPayload.class);
-        rateLimiterMeta.overrideNodeProperty(hostname);
+        rateLimiterMeta.maybeEnableForHost(hostname);
         return rateLimiterMeta.priorityBasedEnabled
             ? new RateLimiterConfig(SolrRequest.SolrRequestType.PRIORITY_BASED, rateLimiterMeta)
             : new RateLimiterConfig(SolrRequest.SolrRequestType.QUERY, rateLimiterMeta);

--- a/solr/core/src/java/org/apache/solr/servlet/RateLimitManager.java
+++ b/solr/core/src/java/org/apache/solr/servlet/RateLimitManager.java
@@ -62,7 +62,10 @@ public class RateLimitManager implements ClusterPropertiesListener {
   public static final long DEFAULT_SLOT_ACQUISITION_TIMEOUT_MS = -1;
   private final ConcurrentHashMap<String, RequestRateLimiter> requestRateLimiterMap;
 
-  public RateLimitManager() {
+  private final String hostname;
+
+  public RateLimitManager(String hostname) {
+    this.hostname = hostname;
     this.requestRateLimiterMap = new ConcurrentHashMap<>();
   }
 
@@ -81,7 +84,7 @@ public class RateLimitManager implements ClusterPropertiesListener {
         throw new UncheckedIOException(e);
       }
     }
-
+    rateLimiterMeta.overrideNodeProperty(hostname);
     // Hack: We only support query rate limiting for now
     requestRateLimiterMap.compute(
         rateLimiterMeta.priorityBasedEnabled
@@ -209,10 +212,10 @@ public class RateLimitManager implements ClusterPropertiesListener {
       this.solrZkClient = solrZkClient;
     }
 
-    public RateLimitManager build() {
-      RateLimitManager rateLimitManager = new RateLimitManager();
+    public RateLimitManager build(String hostname) {
+      RateLimitManager rateLimitManager = new RateLimitManager(hostname);
 
-      RateLimiterConfig rateLimiterConfig = constructQueryRateLimiterConfig(solrZkClient);
+      RateLimiterConfig rateLimiterConfig = constructQueryRateLimiterConfig(solrZkClient, hostname);
 
       if (rateLimiterConfig.priorityBasedEnabled) {
         rateLimitManager.registerRequestRateLimiter(
@@ -228,7 +231,8 @@ public class RateLimitManager implements ClusterPropertiesListener {
 
     // To be used in initialization
     @SuppressWarnings({"unchecked"})
-    private static RateLimiterConfig constructQueryRateLimiterConfig(SolrZkClient zkClient) {
+    private static RateLimiterConfig constructQueryRateLimiterConfig(
+        SolrZkClient zkClient, String hostname) {
       try {
 
         if (zkClient == null) {
@@ -250,6 +254,7 @@ public class RateLimitManager implements ClusterPropertiesListener {
 
         RateLimiterPayload rateLimiterMeta =
             mapper.readValue(configInput, RateLimiterPayload.class);
+        rateLimiterMeta.overrideNodeProperty(hostname);
         return rateLimiterMeta.priorityBasedEnabled
             ? new RateLimiterConfig(SolrRequest.SolrRequestType.PRIORITY_BASED, rateLimiterMeta)
             : new RateLimiterConfig(SolrRequest.SolrRequestType.QUERY, rateLimiterMeta);

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/RateLimiterPayload.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/RateLimiterPayload.java
@@ -75,7 +75,7 @@ public class RateLimiterPayload implements ReflectMapWriter {
         priorityBasedEnabled);
   }
 
-  public void overrideNodeProperty(String hostname) {
+  public void maybeEnableForHost(String hostname) {
     if (!this.enabled && !hostname.isEmpty()) {
       if (this.nodesEnabled != null && !this.nodesEnabled.isEmpty()) {
         String[] hosts = this.nodesEnabled.split(",");

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/RateLimiterPayload.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/RateLimiterPayload.java
@@ -35,6 +35,8 @@ public class RateLimiterPayload implements ReflectMapWriter {
 
   @JsonProperty public Boolean priorityBasedEnabled;
 
+  @JsonProperty public String nodesEnabled;
+
   public RateLimiterPayload copy() {
     RateLimiterPayload result = new RateLimiterPayload();
 
@@ -44,6 +46,7 @@ public class RateLimiterPayload implements ReflectMapWriter {
     result.slotBorrowingEnabled = slotBorrowingEnabled;
     result.slotAcquisitionTimeoutInMS = slotAcquisitionTimeoutInMS;
     result.priorityBasedEnabled = priorityBasedEnabled;
+    result.nodesEnabled = nodesEnabled;
     return result;
   }
 
@@ -70,5 +73,19 @@ public class RateLimiterPayload implements ReflectMapWriter {
         slotBorrowingEnabled,
         slotAcquisitionTimeoutInMS,
         priorityBasedEnabled);
+  }
+
+  public void overrideNodeProperty(String hostname) {
+    if (!this.enabled && hostname != "") {
+      if (this.nodesEnabled != null && !this.nodesEnabled.isEmpty()) {
+        String[] hosts = this.nodesEnabled.split(",");
+        for (String host : hosts) {
+          if (host.trim().equals(hostname)) {
+            this.enabled = true;
+            break;
+          }
+        }
+      }
+    }
   }
 }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/RateLimiterPayload.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/RateLimiterPayload.java
@@ -76,7 +76,7 @@ public class RateLimiterPayload implements ReflectMapWriter {
   }
 
   public void overrideNodeProperty(String hostname) {
-    if (!this.enabled && hostname != "") {
+    if (!this.enabled && hostname.isEmpty()) {
       if (this.nodesEnabled != null && !this.nodesEnabled.isEmpty()) {
         String[] hosts = this.nodesEnabled.split(",");
         for (String host : hosts) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/RateLimiterPayload.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/request/beans/RateLimiterPayload.java
@@ -76,7 +76,7 @@ public class RateLimiterPayload implements ReflectMapWriter {
   }
 
   public void overrideNodeProperty(String hostname) {
-    if (!this.enabled && hostname.isEmpty()) {
+    if (!this.enabled && !hostname.isEmpty()) {
       if (this.nodesEnabled != null && !this.nodesEnabled.isEmpty()) {
         String[] hosts = this.nodesEnabled.split(",");
         for (String host : hosts) {


### PR DESCRIPTION
1. Added ratelimiter config property `nodesEnabled`
2. App can set comma separated list of solr nodes to enable ratelimiter on those nodes only. Example `"nodesEnabled": "localhost"`