### PR TITLE
Facet refine handle unknown shard.

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/facet/FacetMerger.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetMerger.java
@@ -71,7 +71,7 @@ public abstract class FacetMerger {
       Integer shardNum = shardmap.get(shard);
       boolean hasShard = shardNum != null;
       this.shardNum = hasShard ? shardNum : -1;
-      return  hasShard;
+      return hasShard;
     }
 
     public int getNewBucketNumber() {

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetMerger.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetMerger.java
@@ -67,8 +67,11 @@ public abstract class FacetMerger {
       this.bucketWasMissing = false;
     }
 
-    public void setShard(String shard) {
-      this.shardNum = shardmap.get(shard);
+    public boolean setShard(String shard) {
+      Integer shardNum = shardmap.get(shard);
+      boolean hasShard = shardNum != null;
+      this.shardNum = hasShard ? shardNum : -1;
+      return  hasShard;
     }
 
     public int getNewBucketNumber() {

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetModule.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetModule.java
@@ -193,7 +193,11 @@ public class FacetModule extends SearchComponent {
 
     assert rb.shards.length == facetState.mcontext.numShards;
     for (String shard : rb.shards) {
-      facetState.mcontext.setShard(shard);
+      if (!facetState.mcontext.setShard(shard)) {
+        // for some reason or another (most likely a failed shard request), we do not know about this shard
+        // there is no need to make a refinement request as we didn't even complete the initial request
+        continue;
+      }
 
       // shard-specific refinement
       Map<String, Object> refinement = facetState.merger.getRefinement(facetState.mcontext);
@@ -319,7 +323,10 @@ public class FacetModule extends SearchComponent {
         // System.err.println("REFINE FACET RESULT FROM SHARD = " + facet);
         // call merge again with a diff flag set on the context???
         facetState.mcontext.root = facet;
-        facetState.mcontext.setShard(shardRsp.getShard()); // TODO: roll newShard into setShard?
+        if (!facetState.mcontext.setShard(shardRsp.getShard())) { // TODO: roll newShard into setShard?
+          throw new SolrException(
+              SolrException.ErrorCode.SERVER_ERROR, "received refinement results for unknown shard: " + shardRsp.getShard());
+        }
         facetState.merger.merge(facet, facetState.mcontext);
         return;
       }

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetModule.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetModule.java
@@ -194,8 +194,10 @@ public class FacetModule extends SearchComponent {
     assert rb.shards.length == facetState.mcontext.numShards;
     for (String shard : rb.shards) {
       if (!facetState.mcontext.setShard(shard)) {
-        // for some reason or another (most likely a failed shard request), we do not know about this shard
-        // there is no need to make a refinement request as we didn't even complete the initial request
+        // for some reason or another (most likely a failed shard request),
+        // we do not know about this shard
+        // there is no need to make a refinement request
+        // as we didn't even complete the initial request
         continue;
       }
 
@@ -323,9 +325,11 @@ public class FacetModule extends SearchComponent {
         // System.err.println("REFINE FACET RESULT FROM SHARD = " + facet);
         // call merge again with a diff flag set on the context???
         facetState.mcontext.root = facet;
-        if (!facetState.mcontext.setShard(shardRsp.getShard())) { // TODO: roll newShard into setShard?
+        if (!facetState.mcontext.setShard(
+            shardRsp.getShard())) { // TODO: roll newShard into setShard?
           throw new SolrException(
-              SolrException.ErrorCode.SERVER_ERROR, "received refinement results for unknown shard: " + shardRsp.getShard());
+              SolrException.ErrorCode.SERVER_ERROR,
+              "received refinement results for unknown shard: " + shardRsp.getShard());
         }
         facetState.merger.merge(facet, facetState.mcontext);
         return;


### PR DESCRIPTION
Shards with failed requests may not be in the shard map. We should handle those cleanly.
