### PR TITLE
SAI-5329: Fixed property param used for aggregated metrics

### DIFF
--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -835,21 +835,16 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
     */
 
     AggregateMetricsApiCaller() {
-      super("solr.node", buildPrefix(), buildProperty());
+      super("solr.node", buildPrefix(), Arrays.stream(CoreMetric.values())
+              .filter(m -> m.property != null)
+              .map(m -> m.property)
+              .distinct()
+              .toArray(String[]::new));
     }
 
     private static String buildPrefix() {
       return String.join(
           ",", Arrays.stream(CoreMetric.values()).map(m -> m.key).toArray(String[]::new));
-    }
-
-    private static String buildProperty() {
-      return String.join(
-          ",",
-          Arrays.stream(CoreMetric.values())
-              .filter(m -> m.property != null)
-              .map(m -> m.property)
-              .collect(Collectors.toSet()));
     }
 
     @Override
@@ -1112,9 +1107,9 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
     protected String buildQueryString(ResultContext resultContext) {
       String propertyClause =
           Arrays.stream(properties)
-              .map(p -> URLEncoder.encode(p, StandardCharsets.UTF_8))
               .distinct()
-              .collect(Collectors.joining(",", "&property=", ""));
+              .map(p -> "&property=" + URLEncoder.encode(p, StandardCharsets.UTF_8))
+              .collect(Collectors.joining());
       return String.format(
           Locale.ROOT,
           "wt=json&indent=false&compact=true&group=%s&prefix=%s%s",

--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -835,7 +835,10 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
     */
 
     AggregateMetricsApiCaller() {
-      super("solr.node", buildPrefix(), Arrays.stream(CoreMetric.values())
+      super(
+          "solr.node",
+          buildPrefix(),
+          Arrays.stream(CoreMetric.values())
               .filter(m -> m.property != null)
               .map(m -> m.property)
               .distinct()


### PR DESCRIPTION
## Description
It is found that after upgrading to the latest version of fs-solr 9.7, the node aggregated metrics are no longer showing

## Cause
There was a fix earlier to properly generate the `property` param for metrics query, however it was using `,` as delimiter, which is different from the solr [doc](https://solr.apache.org/guide/solr/latest/deployment-guide/metrics-reporting.html) . The format should be in `&property=p99_ms&property=p999_ms` etc

## Solution
1. Fixed the code logic in `AggregateMetricsApiCaller` to pass on an array of properties instead of a single property string of multiple properties concatenated with `,` delimited
2. in `buildQueryString`, prefix each property value with  `&property=` and join them all to form the property clause


## Test
Tested locally to ensure the correct property clause is formed and that node aggregated metrics started showing again via http://localhost:8983/solr/metrics