### PR TITLE
Update fs/branch_9x 's github build workflow from actions/cache@v2 to actions/cache@v4

### DIFF
--- a/.github/workflows/bin-solr-test.yml
+++ b/.github/workflows/bin-solr-test.yml
@@ -26,7 +26,7 @@ jobs:
         java-package: jdk
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -34,7 +34,7 @@ jobs:
       run: sudo apt-get install acl
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches

--- a/.github/workflows/gradle-precommit.yml
+++ b/.github/workflows/gradle-precommit.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches

--- a/.github/workflows/solrj-test.yml
+++ b/.github/workflows/solrj-test.yml
@@ -25,7 +25,7 @@ jobs:
         java-package: jdk
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches


### PR DESCRIPTION
To address issues such as this https://github.com/cowpaths/fullstory-solr/actions/runs/13731730682/job/38409929804?pr=246