### PR TITLE
Updated actions/cache@v2 to actions/cache@v4

### DIFF
--- a/.github/workflows/bin-solr-test.yml
+++ b/.github/workflows/bin-solr-test.yml
@@ -32,7 +32,7 @@ jobs:
         java-package: jdk
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -36,7 +36,7 @@ jobs:
       run: sudo apt-get install acl
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches

--- a/.github/workflows/gradle-precommit.yml
+++ b/.github/workflows/gradle-precommit.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches

--- a/.github/workflows/solr-test.yml
+++ b/.github/workflows/solr-test.yml
@@ -24,7 +24,7 @@ jobs:
         java-package: jdk
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches

--- a/.github/workflows/solrj-test.yml
+++ b/.github/workflows/solrj-test.yml
@@ -29,7 +29,7 @@ jobs:
         java-package: jdk
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches


### PR DESCRIPTION
## Description
To address build issue such as this https://github.com/cowpaths/fullstory-solr/actions/runs/13731730682/job/38409929804?pr=246


>Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v2`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

## Solution
Updated Lucene workflow with this PR https://github.com/cowpaths/lucene/pull/29

Then update the references in Solr workflows as well