### PR TITLE
no longer persist credentials

### DIFF
--- a/.github/workflows/bin-solr-test.yml
+++ b/.github/workflows/bin-solr-test.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     # Setup
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     # Setup
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:

--- a/.github/workflows/gradle-precommit.yml
+++ b/.github/workflows/gradle-precommit.yml
@@ -16,6 +16,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
+        persist-credentials: false
 
     - name: Set up JDK 11
       uses: actions/setup-java@v2

--- a/.github/workflows/solr-test.yml
+++ b/.github/workflows/solr-test.yml
@@ -16,6 +16,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
+        persist-credentials: false
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:

--- a/.github/workflows/solrj-test.yml
+++ b/.github/workflows/solrj-test.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
     # Setup
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:


### PR DESCRIPTION
This PR sets persist-credentials to false to protect against the risk of leaking or persisting github credentials in our workflows
