### PR TITLE
SAI-5089 : Track active shardRequest in a higher level (instead of actor)

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
@@ -63,7 +63,6 @@ public class HttpShardHandler extends ShardHandler {
   private HttpShardHandlerFactory httpShardHandlerFactory;
   private Map<ShardResponse, CompletableFuture<LBSolrClient.Rsp>> responseFutureMap;
   private BlockingQueue<ShardResponse> responses;
-  protected final AtomicInteger processedResponseCount = new AtomicInteger(0);
   private AtomicInteger pending;
   private Map<String, List<String>> shardToURLs;
   private LBHttp2SolrClient lbClient;
@@ -151,7 +150,6 @@ public class HttpShardHandler extends ShardHandler {
               SolrException.ErrorCode.SERVICE_UNAVAILABLE, "no servers hosting shard: " + shard);
       srsp.setException(exception);
       srsp.setResponseCode(exception.code());
-      processedResponseCount.incrementAndGet();
       responses.add(srsp);
       return;
     }
@@ -171,13 +169,10 @@ public class HttpShardHandler extends ShardHandler {
             srsp.setShardAddress(rsp.getServer());
             ssr.elapsedTime =
                 TimeUnit.MILLISECONDS.convert(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
-            synchronized(HttpShardHandler.this) {
-              processedResponseCount.incrementAndGet();
-              if (callback != null) {
-                callback.onResponse(rsp, ssr.elapsedTime);
-              }
-              responses.add(srsp);
+            if (callback != null) {
+              callback.onResponse(rsp, ssr.elapsedTime);
             }
+            responses.add(srsp);
           } else if (throwable != null) {
             ssr.elapsedTime =
                 TimeUnit.MILLISECONDS.convert(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
@@ -185,13 +180,10 @@ public class HttpShardHandler extends ShardHandler {
             if (throwable instanceof SolrException) {
               srsp.setResponseCode(((SolrException) throwable).code());
             }
-            synchronized(HttpShardHandler.this) {
-              processedResponseCount.incrementAndGet();
-              if (callback != null) {
-                callback.onException(throwable, ssr.elapsedTime);
-              }
-              responses.add(srsp);
+            if (callback != null) {
+              callback.onException(throwable, ssr.elapsedTime);
             }
+            responses.add(srsp);
           }
         });
 

--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
@@ -63,6 +63,7 @@ public class HttpShardHandler extends ShardHandler {
   private HttpShardHandlerFactory httpShardHandlerFactory;
   private Map<ShardResponse, CompletableFuture<LBSolrClient.Rsp>> responseFutureMap;
   private BlockingQueue<ShardResponse> responses;
+  protected final AtomicInteger processedResponseCount = new AtomicInteger(0);
   private AtomicInteger pending;
   private Map<String, List<String>> shardToURLs;
   private LBHttp2SolrClient lbClient;
@@ -150,6 +151,7 @@ public class HttpShardHandler extends ShardHandler {
               SolrException.ErrorCode.SERVICE_UNAVAILABLE, "no servers hosting shard: " + shard);
       srsp.setException(exception);
       srsp.setResponseCode(exception.code());
+      processedResponseCount.incrementAndGet();
       responses.add(srsp);
       return;
     }
@@ -169,10 +171,13 @@ public class HttpShardHandler extends ShardHandler {
             srsp.setShardAddress(rsp.getServer());
             ssr.elapsedTime =
                 TimeUnit.MILLISECONDS.convert(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
-            if (callback != null) {
-              callback.onResponse(rsp, ssr.elapsedTime);
+            synchronized(HttpShardHandler.this) {
+              processedResponseCount.incrementAndGet();
+              if (callback != null) {
+                callback.onResponse(rsp, ssr.elapsedTime);
+              }
+              responses.add(srsp);
             }
-            responses.add(srsp);
           } else if (throwable != null) {
             ssr.elapsedTime =
                 TimeUnit.MILLISECONDS.convert(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
@@ -180,10 +185,13 @@ public class HttpShardHandler extends ShardHandler {
             if (throwable instanceof SolrException) {
               srsp.setResponseCode(((SolrException) throwable).code());
             }
-            if (callback != null) {
-              callback.onException(throwable, ssr.elapsedTime);
+            synchronized(HttpShardHandler.this) {
+              processedResponseCount.incrementAndGet();
+              if (callback != null) {
+                callback.onException(throwable, ssr.elapsedTime);
+              }
+              responses.add(srsp);
             }
-            responses.add(srsp);
           }
         });
 

--- a/solr/core/src/java/org/apache/solr/handler/component/SlowNodeDetector.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SlowNodeDetector.java
@@ -258,4 +258,9 @@ class RequestStats {
     responseLatencies.add(new NodeLatency(node, latency));
     responseCountByNode.compute(node, (k, c) -> c != null ? c + 1 : 1);
   }
+
+  void clear() {
+    responseLatencies.clear();
+    responseCountByNode.clear();
+  }
 }

--- a/solr/core/src/java/org/apache/solr/handler/component/TimeLimitingHttpShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/TimeLimitingHttpShardHandler.java
@@ -63,16 +63,16 @@ class TimeLimitingHttpShardHandler extends HttpShardHandler {
       ShardRequest shardRequest,
       List<String> shardUrls,
       ModifiableSolrParams params) {
+    boolean shardsTolerant = shardRequest.params != null && ShardParams.getShardsTolerantAsBool(shardRequest.params);
     ShardRequestTrackingCallback callback =
-        new ShardRequestTrackingCallback(future, shardRequest, shardUrls);
+        new ShardRequestTrackingCallback(future, shardRequest, shardsTolerant, shardUrls);
     List<ShardRequestActor> shardRequestActors =
         actorsByShardRequest.computeIfAbsent(
             shardRequest,
             k -> {
               List<ShardRequestActor> actors = new ArrayList<>();
               actors.add(new NodeStatsCollector(slowNodeDetector));
-              if (shardRequest.params != null
-                  && ShardParams.getShardsTolerantAsBool(shardRequest.params)) {
+              if (shardsTolerant) {
                 actors.add(
                     new SlowNodeTimeoutActor(
                         slowNodeTimeout, dryRun, slowNodeDetector.getSlowNodes(), timeoutCallback));
@@ -95,37 +95,38 @@ class TimeLimitingHttpShardHandler extends HttpShardHandler {
     private final ShardRequest shardRequest;
     private final Future<LBSolrClient.Rsp> future;
     private final List<String> shardUrls;
+    private final boolean shardsTolerant;
 
     ShardRequestTrackingCallback(
-        Future<LBSolrClient.Rsp> future, ShardRequest shardRequest, List<String> shardUrls) {
+        Future<LBSolrClient.Rsp> future, ShardRequest shardRequest, boolean shardsTolerant, List<String> shardUrls) {
       this.future = future;
       this.shardRequest = shardRequest;
       this.shardUrls = shardUrls;
+      this.shardsTolerant = shardsTolerant;
     }
 
     @Override
     public void onResponse(LBSolrClient.Rsp response, long elapsedTime) {
-      onComplete(elapsedTime, response.getServer());
+      onComplete(elapsedTime, response.getServer(), false);
     }
 
     @Override
     public void onException(Throwable exception, long elapsedTime) {
       // TODO is it possible to infer the selected node? If it has timed out, perhaps we can assume
       // all shardNodes are slow?
-      onComplete(elapsedTime, null);
+      onComplete(elapsedTime, null, true);
     }
 
-    private void onComplete(long elapsedTime, String selectedShardUrl) {
+    private void onComplete(long elapsedTime, String selectedShardUrl, boolean isException) {
       try {
         actorsByShardRequest.compute(
             shardRequest,
             (k, actors) -> {
               if (actors != null) {
-                actors.removeIf(
-                    actor ->
-                        actor.onRequestCompleted(selectedShardUrl, shardUrls, future, elapsedTime));
-                if (actors.isEmpty()) {
-                  return null;
+                actors.forEach(actor -> actor.onRequestCompleted(selectedShardUrl, shardUrls, future, elapsedTime));
+                if (isLastResponse(isException)) {
+                  actors.forEach(ShardRequestActor::flush);
+                  return null; //remove this shardRequest from the map on last response
                 }
               }
               return actors;
@@ -134,6 +135,12 @@ class TimeLimitingHttpShardHandler extends HttpShardHandler {
         log.warn("Failed to notify stats to slowNodeDetector", e);
       }
     }
+    private boolean isLastResponse(boolean isException) {
+      if (!shardsTolerant && isException) {
+        return true;
+      }
+      return processedResponseCount.get() == shardRequest.actualShards.length;
+    }
   }
 }
 
@@ -141,8 +148,13 @@ class TimeLimitingHttpShardHandler extends HttpShardHandler {
 interface ShardRequestActor {
   void onRequestSubmitted(List<String> shardUrls, Future<?> future);
 
-  boolean onRequestCompleted(
+  void onRequestCompleted(
       String selectedShardUrl, List<String> shardUrls, Future<?> future, long timeElapsed);
+
+  /**
+   * Flushes when the last response for a shardRequest is received
+   */
+  void flush();
 }
 
 class Util {
@@ -163,9 +175,7 @@ class Util {
  * when all of them complete
  */
 class NodeStatsCollector implements ShardRequestActor {
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private final SlowNodeDetector detector;
-  private final AtomicInteger pendingCount = new AtomicInteger(0);
   final RequestStats stats = new RequestStats();
 
   NodeStatsCollector(SlowNodeDetector detector) {
@@ -174,22 +184,21 @@ class NodeStatsCollector implements ShardRequestActor {
 
   @Override
   public void onRequestSubmitted(List<String> shardUrls, Future<?> future) {
-    pendingCount.incrementAndGet();
+
   }
 
   @Override
-  public synchronized boolean onRequestCompleted(
+  public synchronized void onRequestCompleted(
       String selectedShardUrl, List<String> shardUrls, Future<?> future, long timeElapsed) {
     if (selectedShardUrl != null) { // might be null if exception occurred
       stats.recordLatency(Util.getNode(selectedShardUrl), timeElapsed);
     }
-    if (pendingCount.decrementAndGet() == 0) {
-      detector.notifyRequestStats(
-          stats); // notify the slowNodeDetector of the execution stats of all the submissions by
-      // this shard request
-      return true;
-    }
-    return false;
+  }
+
+  @Override
+  public void flush() {
+    detector.notifyRequestStats(stats);
+    stats.clear();
   }
 }
 
@@ -255,16 +264,9 @@ class SlowNodeTimeoutActor implements ShardRequestActor {
   }
 
   @Override
-  public synchronized boolean onRequestCompleted(
+  public synchronized void onRequestCompleted(
       String selectedShardUrl, List<String> shardUrls, Future<?> future, long timeElapsed) {
     pendingFutures.remove(future);
-    if (pendingFutures.isEmpty()) { // every submitted futures are processed
-      if (timeoutTask != null) {
-        timeoutTask.cancel(true);
-      }
-      return true;
-    }
-
     if (!hasSlowNodeShardUrl(shardUrls)) {
       pendingFutureCountFromFastNode.decrementAndGet();
     }
@@ -319,8 +321,14 @@ class SlowNodeTimeoutActor implements ShardRequestActor {
         }
       }
     }
+  }
 
-    return false;
+  @Override
+  public void flush() {
+    if (timeoutTask != null) { //should no longer attempt to timeout as all responses are completed
+      timeoutTask.cancel(true);
+    }
+    pendingFutures.clear();
   }
 }
 

--- a/solr/core/src/java/org/apache/solr/handler/component/TimeLimitingHttpShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/TimeLimitingHttpShardHandler.java
@@ -23,6 +23,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A {@link HttpShardHandler} that detects slow nodes and times out requests to them if applicable.
+ *
+ * <p>Should only be used for SearchHandler
  */
 class TimeLimitingHttpShardHandler extends HttpShardHandler {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());

--- a/solr/core/src/java/org/apache/solr/handler/component/TimeLimitingHttpShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/TimeLimitingHttpShardHandler.java
@@ -72,8 +72,7 @@ class TimeLimitingHttpShardHandler extends HttpShardHandler {
               List<ShardRequestActor> actors = new ArrayList<>();
               actors.add(new NodeStatsCollector(slowNodeDetector));
               if (shardRequest.params != null
-                  && "true"
-                      .equalsIgnoreCase(shardRequest.params.get(ShardParams.SHARDS_TOLERANT))) {
+                  && ShardParams.getShardsTolerantAsBool(shardRequest.params)) {
                 actors.add(
                     new SlowNodeTimeoutActor(
                         slowNodeTimeout, dryRun, slowNodeDetector.getSlowNodes(), timeoutCallback));

--- a/solr/core/src/java/org/apache/solr/handler/component/TimeLimitingHttpShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/TimeLimitingHttpShardHandler.java
@@ -1,6 +1,5 @@
 package org.apache.solr.handler.component;
 
-import com.github.benmanes.caffeine.cache.Caffeine;
 import java.lang.invoke.MethodHandles;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -30,8 +29,8 @@ class TimeLimitingHttpShardHandler extends HttpShardHandler {
   private final long slowNodeTimeout;
   private final boolean dryRun;
 
-  private final ConcurrentMap<ShardRequest, List<ShardRequestActor>> actorsByShardRequest =
-      Caffeine.newBuilder().weakKeys().<ShardRequest, List<ShardRequestActor>>build().asMap();
+  private final ConcurrentMap<ShardRequest, ShardRequestTracker> activeShardRequests =
+      new ConcurrentHashMap<>();
 
   private final SlowNodeDetector slowNodeDetector;
   private final TimeoutCallback timeoutCallback;
@@ -63,23 +62,28 @@ class TimeLimitingHttpShardHandler extends HttpShardHandler {
       ShardRequest shardRequest,
       List<String> shardUrls,
       ModifiableSolrParams params) {
-    boolean shardsTolerant = shardRequest.params != null && ShardParams.getShardsTolerantAsBool(shardRequest.params);
+    boolean shardsTolerant =
+        shardRequest.params != null && ShardParams.getShardsTolerantAsBool(shardRequest.params);
     ShardRequestTrackingCallback callback =
         new ShardRequestTrackingCallback(future, shardRequest, shardsTolerant, shardUrls);
-    List<ShardRequestActor> shardRequestActors =
-        actorsByShardRequest.computeIfAbsent(
-            shardRequest,
-            k -> {
-              List<ShardRequestActor> actors = new ArrayList<>();
-              actors.add(new NodeStatsCollector(slowNodeDetector));
-              if (shardsTolerant) {
-                actors.add(
-                    new SlowNodeTimeoutActor(
-                        slowNodeTimeout, dryRun, slowNodeDetector.getSlowNodes(), timeoutCallback));
-              }
-              return actors;
-            });
-    shardRequestActors.forEach(actor -> actor.onRequestSubmitted(shardUrls, future));
+    activeShardRequests.compute(
+        shardRequest,
+        (k, tracker) -> {
+          if (tracker == null) {
+            List<ShardRequestActor> actors = new ArrayList<>();
+            actors.add(new NodeStatsCollector(slowNodeDetector));
+            if (shardsTolerant) {
+              actors.add(
+                  new SlowNodeTimeoutActor(
+                      slowNodeTimeout, dryRun, slowNodeDetector.getSlowNodes(), timeoutCallback));
+            }
+            tracker = new ShardRequestTracker(actors);
+          }
+          tracker.actors.forEach(actor -> actor.onRequestSubmitted(shardUrls, future));
+          tracker.outstandingRequestCount.incrementAndGet();
+          return tracker;
+        });
+
     return callback;
   }
 
@@ -98,7 +102,10 @@ class TimeLimitingHttpShardHandler extends HttpShardHandler {
     private final boolean shardsTolerant;
 
     ShardRequestTrackingCallback(
-        Future<LBSolrClient.Rsp> future, ShardRequest shardRequest, boolean shardsTolerant, List<String> shardUrls) {
+        Future<LBSolrClient.Rsp> future,
+        ShardRequest shardRequest,
+        boolean shardsTolerant,
+        List<String> shardUrls) {
       this.future = future;
       this.shardRequest = shardRequest;
       this.shardUrls = shardUrls;
@@ -119,27 +126,40 @@ class TimeLimitingHttpShardHandler extends HttpShardHandler {
 
     private void onComplete(long elapsedTime, String selectedShardUrl, boolean isException) {
       try {
-        actorsByShardRequest.compute(
+        activeShardRequests.compute(
             shardRequest,
-            (k, actors) -> {
-              if (actors != null) {
-                actors.forEach(actor -> actor.onRequestCompleted(selectedShardUrl, shardUrls, future, elapsedTime));
-                if (isLastResponse(isException)) {
-                  actors.forEach(ShardRequestActor::flush);
-                  return null; //remove this shardRequest from the map on last response
+            (k, tracker) -> {
+              if (tracker != null) {
+                tracker.actors.forEach(
+                    actor ->
+                        actor.onRequestCompleted(selectedShardUrl, shardUrls, future, elapsedTime));
+                int outstandingRequestCount = tracker.outstandingRequestCount.decrementAndGet();
+                if (isLastResponse(isException, outstandingRequestCount)) {
+                  tracker.actors.forEach(ShardRequestActor::flush);
+                  return null; // remove this shardRequest from the map on last response
                 }
               }
-              return actors;
+              return tracker;
             });
       } catch (Exception e) {
         log.warn("Failed to notify stats to slowNodeDetector", e);
       }
     }
-    private boolean isLastResponse(boolean isException) {
+
+    private boolean isLastResponse(boolean isException, int outstandingRequestCount) {
       if (!shardsTolerant && isException) {
         return true;
       }
-      return processedResponseCount.get() == shardRequest.actualShards.length;
+      return outstandingRequestCount <= 0;
+    }
+  }
+
+  static class ShardRequestTracker {
+    final List<ShardRequestActor> actors;
+    final AtomicInteger outstandingRequestCount = new AtomicInteger(0);
+
+    ShardRequestTracker(List<ShardRequestActor> actors) {
+      this.actors = actors;
     }
   }
 }
@@ -152,7 +172,14 @@ interface ShardRequestActor {
       String selectedShardUrl, List<String> shardUrls, Future<?> future, long timeElapsed);
 
   /**
-   * Flushes when the last response for a shardRequest is received
+   * Flushes when the last response is received.
+   *
+   * <p>This happens either when all submitted requests are completed or an exception occurred while
+   * the handler is not shard fault-tolerant
+   *
+   * <p>In an edge case, there could be pauses with request submissions such that flush is triggered
+   * before all the requests are submitted for a particular ShardRequest. In such case, flush could
+   * be invoked more than once.
    */
   void flush();
 }
@@ -183,9 +210,7 @@ class NodeStatsCollector implements ShardRequestActor {
   }
 
   @Override
-  public void onRequestSubmitted(List<String> shardUrls, Future<?> future) {
-
-  }
+  public void onRequestSubmitted(List<String> shardUrls, Future<?> future) {}
 
   @Override
   public synchronized void onRequestCompleted(
@@ -325,7 +350,7 @@ class SlowNodeTimeoutActor implements ShardRequestActor {
 
   @Override
   public void flush() {
-    if (timeoutTask != null) { //should no longer attempt to timeout as all responses are completed
+    if (timeoutTask != null) { // should no longer attempt to timeout as all responses are completed
       timeoutTask.cancel(true);
     }
     pendingFutures.clear();

--- a/solr/core/src/test/org/apache/solr/handler/component/TestTimeLimitingShardHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TestTimeLimitingShardHandler.java
@@ -81,11 +81,8 @@ public class TestTimeLimitingShardHandler extends SolrTestCaseJ4 {
           handler.takeCompletedIncludingErrors();
       assertEquals(SHARD_COUNT, response.getShardRequest().responses.size());
 
-      //      List<Throwable> exceptions = response.getShardRequest().responses.stream().filter(r ->
-      // r.getException() != null).map(ShardResponse::getException).collect(Collectors.toList());
-      assertNull(
-          response
-              .getException()); // no exception, since the slow nodes are not detected yet before
+      // no exception, since the slow nodes are not detected yet before
+      assertNull(response.getException());
       // execution of this shard request
       assertEquals(Set.of("solr-10:8983", "solr-11:8983"), fixture.slowNodeDetector.getSlowNodes());
       assertEquals(


### PR DESCRIPTION
## Description
 Track active shardRequest in a higher level (instead of actor) to avoid `ConcurrentModification` issue as described in [here](https://github.com/cowpaths/fullstory-solr/pull/246#discussion_r2023028414)

Take note that we have attempted to use `actualShards` from `ShardRequest` for the check, however it gets tricky to handle the exceptional case of empty urls.

Therefore this PR simply "pulls" the request tracking to `TimeLimitingHttpShardHandler` level, and checks whether it's the last response of currently submitted requests in `ShardRequestTrackingCallback`. If so, call `flush` on the corresponding actors (so actors are dumber 🤪 ). Since actor no longer de-register itself, it avoids the `ConcurrentModification` issue.

Also used simple `ConcurrentHashMap` instead of `Caffeine` as the Handler is short-lived and should only be configured against SearchHandler