### PR TITLE
SAI-5089 : Avoid creating many instances for `HttpShardHandlerFactory`

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -209,7 +209,8 @@ public class SearchHandler extends RequestHandlerBase
     } else {
       shardHandlerFactory = core.createInitInstance(shfInfo, ShardHandlerFactory.class, null, null);
       if (shardHandlerFactory instanceof WrappedHttpShardHandlerFactory) {
-        ((WrappedHttpShardHandlerFactory) shardHandlerFactory).setHandlerFactory(core.getCoreContainer().getShardHandlerFactory());
+        ((WrappedHttpShardHandlerFactory) shardHandlerFactory)
+            .setHandlerFactory(core.getCoreContainer().getShardHandlerFactory());
       }
       if (shardHandlerFactory instanceof SolrMetricProducer) {
         SolrMetricProducer metricProducer = (SolrMetricProducer) shardHandlerFactory;

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -208,6 +208,9 @@ public class SearchHandler extends RequestHandlerBase
       shardHandlerFactory = core.getCoreContainer().getShardHandlerFactory();
     } else {
       shardHandlerFactory = core.createInitInstance(shfInfo, ShardHandlerFactory.class, null, null);
+      if (shardHandlerFactory instanceof WrappedHttpShardHandlerFactory) {
+        ((WrappedHttpShardHandlerFactory) shardHandlerFactory).setHandlerFactory(core.getCoreContainer().getShardHandlerFactory());
+      }
       if (shardHandlerFactory instanceof SolrMetricProducer) {
         SolrMetricProducer metricProducer = (SolrMetricProducer) shardHandlerFactory;
         metricProducer.initializeMetrics(solrMetricsContext, "httpShardHandler");

--- a/solr/core/src/java/org/apache/solr/handler/component/WrappedHttpShardHandlerFactory.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/WrappedHttpShardHandlerFactory.java
@@ -1,10 +1,12 @@
 package org.apache.solr.handler.component;
 
 /**
- * Wrapping a HttpShardHandlerFactory to avoid many instances of HttpShardHandlerFactory created by each SolrCore
+ * Wrapping a HttpShardHandlerFactory to avoid many instances of HttpShardHandlerFactory created by
+ * each SolrCore
  */
-public class WrappedHttpShardHandlerFactory extends ShardHandlerFactory{
+public class WrappedHttpShardHandlerFactory extends ShardHandlerFactory {
   private ShardHandlerFactory handlerFactory;
+
   void setHandlerFactory(ShardHandlerFactory handlerFactory) {
     this.handlerFactory = handlerFactory;
   }
@@ -15,7 +17,5 @@ public class WrappedHttpShardHandlerFactory extends ShardHandlerFactory{
   }
 
   @Override
-  public void close() {
-
-  }
+  public void close() {}
 }

--- a/solr/core/src/java/org/apache/solr/handler/component/WrappedHttpShardHandlerFactory.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/WrappedHttpShardHandlerFactory.java
@@ -1,0 +1,21 @@
+package org.apache.solr.handler.component;
+
+/**
+ * Wrapping a HttpShardHandlerFactory to avoid many instances of HttpShardHandlerFactory created by each SolrCore
+ */
+public class WrappedHttpShardHandlerFactory extends ShardHandlerFactory{
+  private ShardHandlerFactory handlerFactory;
+  void setHandlerFactory(ShardHandlerFactory handlerFactory) {
+    this.handlerFactory = handlerFactory;
+  }
+
+  @Override
+  public ShardHandler getShardHandler() {
+    return handlerFactory.getShardHandler();
+  }
+
+  @Override
+  public void close() {
+
+  }
+}


### PR DESCRIPTION
## Description
A concern is raised at [here](https://github.com/cowpaths/mn/pull/87285#discussion_r2035899771), that for data node, each of the SolrCore would create one `HttpShardHandlerFactory` instance. Such instance might contain expensive fields.

## Solution
Added a new `WrappedHttpShardHandlerFactory` which `SearchHandler` will sets the same instance of `HttpShardHandlerFactory` from the core container

## Remarks
Tried another solution to have a lookup map based on the pluginInfo, so we only create one instance per pluginInfo (which should be all the same for all the cores). However, it gets tricky in life cycle management, so the attempt was abandoned 😓 


## Test
Tested locally:
1. Set the solrconfig.xml of _FS7 to use `WrappedHttpShardHandlerFactory`
2. Start data node with debugger. Put break point on `shardHandlerFactory = core.createInitInstance`...
3. Each core on that node would trigger such breakpoint, it creates a new instance of `WrappedHttpShardHandlerFactory` for each
4. However, they all call `((WrappedHttpShardHandlerFactory) shardHandlerFactory).setHandlerFactory(core.getCoreContainer().getShardHandlerFactory())`. which is the same instance
5. Confirmed the query from QA node still works

playpen test will be posed in https://github.com/cowpaths/mn/pull/87285