### PR TITLE
SAI-5505 : Added logic to detect if slow nodes have been recovered

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/SlowNodeDetector.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SlowNodeDetector.java
@@ -1,10 +1,12 @@
 package org.apache.solr.handler.component;
 
+import com.carrotsearch.hppc.ObjectIntHashMap;
+import com.carrotsearch.hppc.ObjectIntMap;
+import com.carrotsearch.hppc.cursors.ObjectIntCursor;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -102,7 +104,7 @@ class SlowNodeDetector implements SolrMetricProducer {
 
     Long previousLatency = null;
     boolean foundLatencyDrop = false;
-    Map<String, Integer> iteratedResponseCountByNode = new HashMap<>();
+    ObjectIntMap<String> iteratedResponseCountByNode = new ObjectIntHashMap<>();
 
     // iterate response to find slow nodes
     int index = 0;
@@ -129,20 +131,18 @@ class SlowNodeDetector implements SolrMetricProducer {
       }
 
       previousLatency = current.latency;
-      iteratedResponseCountByNode.compute(current.node, (k, v) -> v == null ? 1 : v + 1);
+      iteratedResponseCountByNode.putOrAdd(current.node, 1, 1);
     }
 
     Set<String> slowNodes = new HashSet<>();
-    if (foundLatencyDrop) { // then that means there are some nodes that are significantly slower
-      // than others
-      for (Map.Entry<String, Integer> nodeWithSlowResponseCount :
-          iteratedResponseCountByNode.entrySet()) {
-        String potentialSlowNode = nodeWithSlowResponseCount.getKey();
+    if (foundLatencyDrop) {
+      // then that means there are some nodes that are significantly slower than others
+      for (ObjectIntCursor<String> nodeWithSlowResponseCount : iteratedResponseCountByNode) {
+        String potentialSlowNode = nodeWithSlowResponseCount.key;
 
-        // all responses of this node is slow, it is a slow node
-        if (nodeWithSlowResponseCount
-            .getValue()
-            .equals(stats.responseCountByNode.get(potentialSlowNode))) {
+        if (nodeWithSlowResponseCount.value
+            == stats.responseCountByNode.getOrDefault(potentialSlowNode, 0)) {
+          // all responses of this node is slow, it is a slow node
           slowNodes.add(potentialSlowNode);
         }
       }
@@ -162,18 +162,16 @@ class SlowNodeDetector implements SolrMetricProducer {
         if (!recoveredSlowNodeCandidates.contains(latency.node)) {
           continue;
         }
-        iteratedResponseCountByNode.compute(latency.node, (k, v) -> v == null ? 1 : v + 1);
+        iteratedResponseCountByNode.putOrAdd(latency.node, 1, 1);
       }
 
       // if the all responses of such node are considered normal, then consider the node as
       // recovered
-      for (Map.Entry<String, Integer> nodeWithNormalResponseCount :
-          iteratedResponseCountByNode.entrySet()) {
-        String potentialRecoveredNode = nodeWithNormalResponseCount.getKey();
+      for (ObjectIntCursor<String> nodeWithNormalResponseCount : iteratedResponseCountByNode) {
+        String potentialRecoveredNode = nodeWithNormalResponseCount.key;
 
-        if (nodeWithNormalResponseCount
-            .getValue()
-            .equals(stats.responseCountByNode.get(potentialRecoveredNode))) {
+        if (nodeWithNormalResponseCount.value
+            == stats.responseCountByNode.getOrDefault(potentialRecoveredNode, 0)) {
           recoveredNodes.add(potentialRecoveredNode);
         }
       }

--- a/solr/core/src/java/org/apache/solr/handler/component/SlowNodeDetector.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SlowNodeDetector.java
@@ -33,8 +33,8 @@ class SlowNodeDetector implements SolrMetricProducer {
   /**
    * @param latencyDropRatioThreshold identify as a latency drop point when current latency is < 0.5
    *     of previous
-   * @param maxSlowResponsePercentage Only up to this percentage of responses can be considered "slow".
-   *                                  The rest of the responses are considered "normal"
+   * @param maxSlowResponsePercentage Only up to this percentage of responses can be considered
+   *     "slow". The rest of the responses are considered "normal"
    * @param minShardCountPerRequest minimum number of shards per Shard Request to be considered for
    *     slow node detection
    * @param slowLatencyThreshold minimum latency in millisec to be considered as slow node
@@ -72,7 +72,8 @@ class SlowNodeDetector implements SolrMetricProducer {
   }
 
   void notifyRequestStats(RequestStats stats) {
-    ComputeResult computeResult = computeSlowNodes(stats);;
+    ComputeResult computeResult = computeSlowNodes(stats);
+    ;
 
     if (computeResult != null) {
       for (String slowNode : computeResult.newSlowNodes) {
@@ -83,7 +84,6 @@ class SlowNodeDetector implements SolrMetricProducer {
       }
     }
   }
-
 
   private ComputeResult computeSlowNodes(RequestStats stats) {
     if (stats.responseLatencies.size() < minShardCountPerRequest) {
@@ -104,8 +104,7 @@ class SlowNodeDetector implements SolrMetricProducer {
     boolean foundLatencyDrop = false;
     Map<String, Integer> iteratedResponseCountByNode = new HashMap<>();
 
-
-    //iterate response to find slow nodes
+    // iterate response to find slow nodes
     int index = 0;
     for (RequestStats.NodeLatency current : stats.responseLatencies) {
       if (index++ > maxSlowResponseCount) {
@@ -155,7 +154,7 @@ class SlowNodeDetector implements SolrMetricProducer {
     recoveredSlowNodeCandidates.removeAll(slowNodes);
 
     if (!recoveredSlowNodeCandidates.isEmpty()) {
-      //the threshold for sorted response to be considered as normal latency
+      // the threshold for sorted response to be considered as normal latency
       int normalNodeResponseCount = stats.responseLatencies.size() - maxSlowResponseCount;
       iteratedResponseCountByNode.clear();
       for (int i = stats.responseLatencies.size() - 1; i >= normalNodeResponseCount; i--) {
@@ -166,18 +165,18 @@ class SlowNodeDetector implements SolrMetricProducer {
         iteratedResponseCountByNode.compute(latency.node, (k, v) -> v == null ? 1 : v + 1);
       }
 
-      // if the all responses of such node are considered normal, then consider the node as recovered
+      // if the all responses of such node are considered normal, then consider the node as
+      // recovered
       for (Map.Entry<String, Integer> nodeWithNormalResponseCount :
-              iteratedResponseCountByNode.entrySet()) {
+          iteratedResponseCountByNode.entrySet()) {
         String potentialRecoveredNode = nodeWithNormalResponseCount.getKey();
 
         if (nodeWithNormalResponseCount
-                .getValue()
-                .equals(stats.responseCountByNode.get(potentialRecoveredNode))) {
+            .getValue()
+            .equals(stats.responseCountByNode.get(potentialRecoveredNode))) {
           recoveredNodes.add(potentialRecoveredNode);
         }
       }
-
     }
 
     ComputeResult result = null;
@@ -194,7 +193,7 @@ class SlowNodeDetector implements SolrMetricProducer {
 
   private static class ComputeResult {
     Set<String> newSlowNodes;
-    Set<String> recoveredSlowNodes; //previously slow nodes that are no longer slow
+    Set<String> recoveredSlowNodes; // previously slow nodes that are no longer slow
 
     ComputeResult(Set<String> newSlowNodes, Set<String> recoveredSlowNodes) {
       this.newSlowNodes = newSlowNodes;
@@ -203,10 +202,12 @@ class SlowNodeDetector implements SolrMetricProducer {
 
     @Override
     public String toString() {
-      return "ComputeResult{" +
-              "newSlowNodes=" + newSlowNodes +
-              ", recoveredSlowNodes=" + recoveredSlowNodes +
-              '}';
+      return "ComputeResult{"
+          + "newSlowNodes="
+          + newSlowNodes
+          + ", recoveredSlowNodes="
+          + recoveredSlowNodes
+          + '}';
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/handler/component/SlowNodeDetector.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SlowNodeDetector.java
@@ -33,8 +33,8 @@ class SlowNodeDetector implements SolrMetricProducer {
   /**
    * @param latencyDropRatioThreshold identify as a latency drop point when current latency is < 0.5
    *     of previous
-   * @param maxSlowResponsePercentage If more than this percentage of potential slow nodes detected,
-   *     do not return any slow node at all
+   * @param maxSlowResponsePercentage Only up to this percentage of responses can be considered "slow".
+   *                                  The rest of the responses are considered "normal"
    * @param minShardCountPerRequest minimum number of shards per Shard Request to be considered for
    *     slow node detection
    * @param slowLatencyThreshold minimum latency in millisec to be considered as slow node

--- a/solr/core/src/java/org/apache/solr/handler/component/SlowNodeDetector.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SlowNodeDetector.java
@@ -72,16 +72,20 @@ class SlowNodeDetector implements SolrMetricProducer {
   }
 
   void notifyRequestStats(RequestStats stats) {
-    Set<String> newSlowNodes = computeSlowNodes(stats);
+    ComputeResult computeResult = computeSlowNodes(stats);;
 
-    if (newSlowNodes != null) {
-      for (String slowNode : newSlowNodes) {
+    if (computeResult != null) {
+      for (String slowNode : computeResult.newSlowNodes) {
         slowNodes.put(slowNode, Boolean.TRUE);
+      }
+      for (String purgingSlowNode : computeResult.recoveredSlowNodes) {
+        slowNodes.remove(purgingSlowNode);
       }
     }
   }
 
-  private Set<String> computeSlowNodes(RequestStats stats) {
+
+  private ComputeResult computeSlowNodes(RequestStats stats) {
     if (stats.responseLatencies.size() < minShardCountPerRequest) {
       return null; // not enough responses to make a decision
     }
@@ -100,11 +104,12 @@ class SlowNodeDetector implements SolrMetricProducer {
     boolean foundLatencyDrop = false;
     Map<String, Integer> iteratedResponseCountByNode = new HashMap<>();
 
+
+    //iterate response to find slow nodes
     int index = 0;
     for (RequestStats.NodeLatency current : stats.responseLatencies) {
-      if (index++
-          > maxSlowResponseCount) { // too many potential slow responses, not a good data as we
-        // assume they are minority
+      if (index++ > maxSlowResponseCount) {
+        // too many potential slow responses, not a good data as we assume they are minority
         break;
       }
       if (previousLatency != null
@@ -144,11 +149,65 @@ class SlowNodeDetector implements SolrMetricProducer {
       }
     }
 
-    if (log.isInfoEnabled() && !slowNodes.isEmpty()) {
-      log.info("Slow nodes detected: {}", slowNodes);
+    // find previous slow nodes that might have recovered
+    Set<String> recoveredNodes = new HashSet<>();
+    Set<String> recoveredSlowNodeCandidates = new HashSet<>(this.slowNodes.keySet());
+    recoveredSlowNodeCandidates.removeAll(slowNodes);
+
+    if (!recoveredSlowNodeCandidates.isEmpty()) {
+      //the threshold for sorted response to be considered as normal latency
+      int normalNodeResponseCount = stats.responseLatencies.size() - maxSlowResponseCount;
+      iteratedResponseCountByNode.clear();
+      for (int i = stats.responseLatencies.size() - 1; i >= normalNodeResponseCount; i--) {
+        RequestStats.NodeLatency latency = stats.responseLatencies.get(i);
+        if (!recoveredSlowNodeCandidates.contains(latency.node)) {
+          continue;
+        }
+        iteratedResponseCountByNode.compute(latency.node, (k, v) -> v == null ? 1 : v + 1);
+      }
+
+      // if the all responses of such node are considered normal, then consider the node as recovered
+      for (Map.Entry<String, Integer> nodeWithNormalResponseCount :
+              iteratedResponseCountByNode.entrySet()) {
+        String potentialRecoveredNode = nodeWithNormalResponseCount.getKey();
+
+        if (nodeWithNormalResponseCount
+                .getValue()
+                .equals(stats.responseCountByNode.get(potentialRecoveredNode))) {
+          recoveredNodes.add(potentialRecoveredNode);
+        }
+      }
+
     }
 
-    return slowNodes;
+    ComputeResult result = null;
+    if (!slowNodes.isEmpty() || !recoveredNodes.isEmpty()) {
+      result = new ComputeResult(slowNodes, recoveredNodes);
+    }
+
+    if (log.isInfoEnabled() && result != null) {
+      log.info("Slow nodes compute result: {}", result);
+    }
+
+    return result;
+  }
+
+  private static class ComputeResult {
+    Set<String> newSlowNodes;
+    Set<String> recoveredSlowNodes; //previously slow nodes that are no longer slow
+
+    ComputeResult(Set<String> newSlowNodes, Set<String> recoveredSlowNodes) {
+      this.newSlowNodes = newSlowNodes;
+      this.recoveredSlowNodes = recoveredSlowNodes;
+    }
+
+    @Override
+    public String toString() {
+      return "ComputeResult{" +
+              "newSlowNodes=" + newSlowNodes +
+              ", recoveredSlowNodes=" + recoveredSlowNodes +
+              '}';
+    }
   }
 
   @Override

--- a/solr/core/src/test/org/apache/solr/handler/component/TestSlowNodeDetector.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TestSlowNodeDetector.java
@@ -208,7 +208,6 @@ public class TestSlowNodeDetector extends SolrTestCaseJ4 {
     assertEquals(Collections.emptySet(), detector.getSlowNodes());
   }
 
-
   @Test
   public void testDetection1SlowNode1RecoveredNode() {
     RequestStats stats = new RequestStats();
@@ -220,7 +219,7 @@ public class TestSlowNodeDetector extends SolrTestCaseJ4 {
 
       if (serverIndex == 1) { // 1 slow nodes
         stats.recordLatency(node, 10000);
-      } else if (serverIndex == 2) { //recovered nodes
+      } else if (serverIndex == 2) { // recovered nodes
         stats.recordLatency(node, 1999);
       } else {
         stats.recordLatency(node, 2000);
@@ -230,7 +229,7 @@ public class TestSlowNodeDetector extends SolrTestCaseJ4 {
     SlowNodeDetector detector = new SlowNodeDetector.Builder().build();
     detector.setSlowNodes(Set.of("solr-2:8983"));
     detector.notifyRequestStats(stats);
-    assertEquals(Set.of("solr-1:8983"), detector.getSlowNodes()); //solr-2:8983 is recovered
+    assertEquals(Set.of("solr-1:8983"), detector.getSlowNodes()); // solr-2:8983 is recovered
   }
 
   @Test
@@ -245,7 +244,8 @@ public class TestSlowNodeDetector extends SolrTestCaseJ4 {
       if (serverIndex == 1) { // 1 slow nodes
         stats.recordLatency(node, 10000);
       } else if (serverIndex == 2 && i % 2 == 0) {
-        // this node is not considered slow (only some shards are slow), however it has not recovered either
+        // this node is not considered slow (only some shards are slow), however it has not
+        // recovered either
         stats.recordLatency(node, 10000);
       } else {
         stats.recordLatency(node, 2000);

--- a/solr/core/src/test/org/apache/solr/handler/component/TestSlowNodeDetector.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TestSlowNodeDetector.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Tests specifying a custom ShardHandlerFactory */
 public class TestSlowNodeDetector extends SolrTestCaseJ4 {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/solr/core/src/test/org/apache/solr/handler/component/TestSlowNodeDetector.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TestSlowNodeDetector.java
@@ -207,4 +207,54 @@ public class TestSlowNodeDetector extends SolrTestCaseJ4 {
     detector.notifyRequestStats(stats);
     assertEquals(Collections.emptySet(), detector.getSlowNodes());
   }
+
+
+  @Test
+  public void testDetection1SlowNode1RecoveredNode() {
+    RequestStats stats = new RequestStats();
+    final int SHARD_COUNT = 512;
+
+    for (int i = 0; i < SHARD_COUNT; i++) {
+      int serverIndex = (i / 8 + 1);
+      String node = "solr-" + serverIndex + ":8983";
+
+      if (serverIndex == 1) { // 1 slow nodes
+        stats.recordLatency(node, 10000);
+      } else if (serverIndex == 2) { //recovered nodes
+        stats.recordLatency(node, 1999);
+      } else {
+        stats.recordLatency(node, 2000);
+      }
+    }
+
+    SlowNodeDetector detector = new SlowNodeDetector.Builder().build();
+    detector.setSlowNodes(Set.of("solr-2:8983"));
+    detector.notifyRequestStats(stats);
+    assertEquals(Set.of("solr-1:8983"), detector.getSlowNodes()); //solr-2:8983 is recovered
+  }
+
+  @Test
+  public void testDetection1SlowNode0RecoveredNode() {
+    RequestStats stats = new RequestStats();
+    final int SHARD_COUNT = 512;
+
+    for (int i = 0; i < SHARD_COUNT; i++) {
+      int serverIndex = (i / 8 + 1);
+      String node = "solr-" + serverIndex + ":8983";
+
+      if (serverIndex == 1) { // 1 slow nodes
+        stats.recordLatency(node, 10000);
+      } else if (serverIndex == 2 && i % 2 == 0) {
+        // this node is not considered slow (only some shards are slow), however it has not recovered either
+        stats.recordLatency(node, 10000);
+      } else {
+        stats.recordLatency(node, 2000);
+      }
+    }
+
+    SlowNodeDetector detector = new SlowNodeDetector.Builder().build();
+    detector.setSlowNodes(Set.of("solr-2:8983"));
+    detector.notifyRequestStats(stats);
+    assertEquals(Set.of("solr-1:8983", "solr-2:8983"), detector.getSlowNodes());
+  }
 }

--- a/solr/core/src/test/org/apache/solr/handler/component/TestTimeLimitingShardHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TestTimeLimitingShardHandler.java
@@ -220,8 +220,10 @@ public class TestTimeLimitingShardHandler extends SolrTestCaseJ4 {
     }
   }
 
-
-  /** This ensures previous detected slow nodes, if recovered, should not be timeout nor stay in the slow node list */
+  /**
+   * This ensures previous detected slow nodes, if recovered, should not be timeout nor stay in the
+   * slow node list
+   */
   @Test
   public void testExecutionRecoveredNodes() throws IOException {
     List<String> shards = new ArrayList<>();
@@ -230,19 +232,19 @@ public class TestTimeLimitingShardHandler extends SolrTestCaseJ4 {
     for (int i = 0; i < SHARD_COUNT; i++) {
       int serverIndex = (i / 8 + 1);
       String shard =
-              "http://solr-" + serverIndex + ":8983/solr/coll_shard" + (i + 1) + "_replica_n" + (i + 1);
+          "http://solr-" + serverIndex + ":8983/solr/coll_shard" + (i + 1) + "_replica_n" + (i + 1);
       if (serverIndex == 10 || serverIndex == 11) { // 2 recovered nodes
         latenciesByShard.put(shard, 1800L);
       }
       shards.add(shard);
     }
     try (TestFixture fixture =
-                 buildTestFixture("solr-shardhandler-timelimited.xml", latenciesByShard, 2000)) {
+        buildTestFixture("solr-shardhandler-timelimited.xml", latenciesByShard, 2000)) {
       org.apache.solr.handler.component.ShardHandler handler = fixture.factory.getShardHandler();
       org.apache.solr.handler.component.ShardRequest sreq =
-              new org.apache.solr.handler.component.ShardRequest();
+          new org.apache.solr.handler.component.ShardRequest();
       fixture.slowNodeDetector.setSlowNodes(
-              Set.of("solr-10:8983", "solr-11:8983")); // simulate slow nodes in previous run
+          Set.of("solr-10:8983", "solr-11:8983")); // simulate slow nodes in previous run
       sreq.params = new ModifiableSolrParams();
       sreq.params.set(ShardParams.SHARDS_TOLERANT, true);
       sreq.actualShards = shards.toArray(new String[0]);
@@ -251,7 +253,7 @@ public class TestTimeLimitingShardHandler extends SolrTestCaseJ4 {
       }
 
       org.apache.solr.handler.component.ShardResponse response =
-              handler.takeCompletedIncludingErrors();
+          handler.takeCompletedIncludingErrors();
       assertEquals(SHARD_COUNT, response.getShardRequest().responses.size());
 
       assertNull(response.getException());

--- a/solr/core/src/test/org/apache/solr/handler/component/TestTimeLimitingShardHandler.java
+++ b/solr/core/src/test/org/apache/solr/handler/component/TestTimeLimitingShardHandler.java
@@ -220,6 +220,46 @@ public class TestTimeLimitingShardHandler extends SolrTestCaseJ4 {
     }
   }
 
+
+  /** This ensures previous detected slow nodes, if recovered, should not be timeout nor stay in the slow node list */
+  @Test
+  public void testExecutionRecoveredNodes() throws IOException {
+    List<String> shards = new ArrayList<>();
+    final int SHARD_COUNT = 512;
+    Map<String, Long> latenciesByShard = new HashMap<>();
+    for (int i = 0; i < SHARD_COUNT; i++) {
+      int serverIndex = (i / 8 + 1);
+      String shard =
+              "http://solr-" + serverIndex + ":8983/solr/coll_shard" + (i + 1) + "_replica_n" + (i + 1);
+      if (serverIndex == 10 || serverIndex == 11) { // 2 recovered nodes
+        latenciesByShard.put(shard, 1800L);
+      }
+      shards.add(shard);
+    }
+    try (TestFixture fixture =
+                 buildTestFixture("solr-shardhandler-timelimited.xml", latenciesByShard, 2000)) {
+      org.apache.solr.handler.component.ShardHandler handler = fixture.factory.getShardHandler();
+      org.apache.solr.handler.component.ShardRequest sreq =
+              new org.apache.solr.handler.component.ShardRequest();
+      fixture.slowNodeDetector.setSlowNodes(
+              Set.of("solr-10:8983", "solr-11:8983")); // simulate slow nodes in previous run
+      sreq.params = new ModifiableSolrParams();
+      sreq.params.set(ShardParams.SHARDS_TOLERANT, true);
+      sreq.actualShards = shards.toArray(new String[0]);
+      for (String shard : shards) {
+        handler.submit(sreq, shard, new ModifiableSolrParams());
+      }
+
+      org.apache.solr.handler.component.ShardResponse response =
+              handler.takeCompletedIncludingErrors();
+      assertEquals(SHARD_COUNT, response.getShardRequest().responses.size());
+
+      assertNull(response.getException());
+      assertTrue(fixture.slowNodeDetector.getSlowNodes().isEmpty());
+      assertEquals(0, fixture.factory.cancelledSlowNodeRequests.getCount());
+    }
+  }
+
   /** This ensures slow node execution would NOT be affected if shards.tolerant is not true */
   @Test
   public void testExecutionSlowNodesNotShardsTolerant() throws IOException {


### PR DESCRIPTION
## Description
As documented in this jira ticket https://fullstory.atlassian.net/browse/SAI-5505 and this slack conversation https://fullstory.slack.com/archives/C03T72C60F3/p1745503380209569?thread_ts=1745457059.396989&cid=C03T72C60F3 we have found the existing algorithm detecting rebooted nodes as slow node. 

This is not ideal as high number of false positive in the detection logic will reduce the effectiveness of the timeout logic later on

## Solution
Introduce a logic to detect if a slow node has "recovered". The logic goes like this:
1. To be eligible to flag as recovered nodes, it still share the existing checks as slow node detection (to avoid "noise" that somehow label a node as recovered) :
    1. Number of responses > minShardCountPerRequest (we only compute if for query to big collections)
    2. fastest shard response > slowLatencyThreshold (we only compute if the query itself is expensive enough)
2. Make use of the existing `maxSlowResponsePercentage`, which determines the max number of responses to be considered as slow. Now we added an addition definition that "The rest of the responses are considered "normal"
3. If a previously slow node has all response latencies considered as "normal", then it will be counted as "recovered"
4. Recovered nodes will be removed from the "slow node" list tracked by the `SlowNodeDetector`

Added test case to verify the new logic
