### PR TITLE
SAI-5572: Register the slow node gauges under solr.node instead of the default core scope

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/SlowNodeDetector.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SlowNodeDetector.java
@@ -13,6 +13,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import org.apache.solr.core.SolrInfoBean;
+import org.apache.solr.metrics.SolrMetricManager;
 import org.apache.solr.metrics.SolrMetricProducer;
 import org.apache.solr.metrics.SolrMetricsContext;
 import org.slf4j.Logger;
@@ -211,8 +213,10 @@ class SlowNodeDetector implements SolrMetricProducer {
 
   @Override
   public void initializeMetrics(SolrMetricsContext parentContext, String scope) {
-    parentContext.gauge(slowNodes::keySet, true, "slowNodes", scope);
-    parentContext.gauge(slowNodes::size, true, "slowNodeCount", scope);
+    String nodeRegistry = SolrMetricManager.getRegistryName(SolrInfoBean.Group.node);
+    SolrMetricManager manager = parentContext.getMetricManager();
+    manager.registerGauge(parentContext, nodeRegistry, slowNodes::keySet, parentContext.getTag(), SolrMetricManager.ResolutionStrategy.REPLACE, "slowNodes", scope);
+    manager.registerGauge(parentContext, nodeRegistry, slowNodes::size, parentContext.getTag(), SolrMetricManager.ResolutionStrategy.REPLACE, "slowNodeCount", scope);
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/handler/component/SlowNodeDetector.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SlowNodeDetector.java
@@ -215,8 +215,22 @@ class SlowNodeDetector implements SolrMetricProducer {
   public void initializeMetrics(SolrMetricsContext parentContext, String scope) {
     String nodeRegistry = SolrMetricManager.getRegistryName(SolrInfoBean.Group.node);
     SolrMetricManager manager = parentContext.getMetricManager();
-    manager.registerGauge(parentContext, nodeRegistry, slowNodes::keySet, parentContext.getTag(), SolrMetricManager.ResolutionStrategy.REPLACE, "slowNodes", scope);
-    manager.registerGauge(parentContext, nodeRegistry, slowNodes::size, parentContext.getTag(), SolrMetricManager.ResolutionStrategy.REPLACE, "slowNodeCount", scope);
+    manager.registerGauge(
+        parentContext,
+        nodeRegistry,
+        slowNodes::keySet,
+        parentContext.getTag(),
+        SolrMetricManager.ResolutionStrategy.REPLACE,
+        "slowNodes",
+        scope);
+    manager.registerGauge(
+        parentContext,
+        nodeRegistry,
+        slowNodes::size,
+        parentContext.getTag(),
+        SolrMetricManager.ResolutionStrategy.REPLACE,
+        "slowNodeCount",
+        scope);
   }
 
   @Override


### PR DESCRIPTION
## Description
The gauges `QUERY.httpShardHandler.slowNodeCount` and `QUERY.httpShardHandler.slowNodes` introduced for slow node detection by nature cannot be aggregated under the `solr.node` metrics. Therefore the Prometheus servlet failed to extract such metrics even though it's declared in `PrometheusMetricsServlet`.

Take note that this does NOT cause the slowness of metrics (the original SAI-5572 was for). This is just an additional issue discovered during the investigation of the slowness. 

The slowness will be addressed in another PR

## Solution
Explicitly declare the registry as "solr.node" for those 2 gauges, so the values will start showing under "solr.node" as expected

## Test
Deployed locally. Then query with 
http://localhost:8984/solr/admin/metrics?wt=json&indent=false&compact=true&group=solr.node&prefix=QUERY.httpShardHandler.cancelledSlowNodeRequests,QUERY.httpShardHandler.cancelledDryRunSlowNodeRequests,QUERY.httpShardHandler.slowNodeCount

The response now contains the slowNodeCount value (which was missing before)
```
{"responseHeader":{"status":0,"QTime":5},"metrics":{"solr.node":{"QUERY.httpShardHandler.cancelledDryRunSlowNodeRequests":0,"QUERY.httpShardHandler.cancelledSlowNodeRequests":0,"QUERY.httpShardHandler.slowNodeCount":0}}}
```