### PR TITLE
SAI-5572 : Fix slow metrics caused by new slow node metrics

### DIFF
--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -577,8 +577,9 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
   static class NodeMetricsApiCaller extends MetricsByPrefixApiCaller {
 
     NodeMetricsApiCaller() {
-      // use 3 prefixes as using just prefix "QUERY.httpShardHandler" matches too many metrics, even
-      // with explicit "property" filter, it does not count down compute time
+      // use 3 prefixes instead of 1 generic prefix "QUERY.httpShardHandler" matches too many
+      // metrics,
+      // as even with explicit "property" filter, it does not cut down compute time
       super(
           "solr.node",
           "QUERY.httpShardHandler.cancelledSlowNodeRequests,QUERY.httpShardHandler.cancelledDryRunSlowNodeRequests,QUERY.httpShardHandler.slowNodeCount");

--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -1180,8 +1180,8 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
       String prefixClause =
           Arrays.stream(prefixes)
               .distinct()
-              .map(p -> "," + URLEncoder.encode(p, StandardCharsets.UTF_8))
-              .collect(Collectors.joining());
+              .map(p -> URLEncoder.encode(p, StandardCharsets.UTF_8))
+              .collect(Collectors.joining(","));
       return String.format(
           Locale.ROOT,
           "wt=json&indent=false&compact=true&group=%s&prefix=%s%s",

--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -578,8 +578,7 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
 
     NodeMetricsApiCaller() {
       // use 3 prefixes instead of 1 generic prefix "QUERY.httpShardHandler" matches too many
-      // metrics,
-      // as even with explicit "property" filter, it does not cut down compute time
+      // metrics as even with explicit "property" filter, it does not cut down compute time
       super(
           "solr.node",
           "QUERY.httpShardHandler.cancelledSlowNodeRequests,QUERY.httpShardHandler.cancelledDryRunSlowNodeRequests,QUERY.httpShardHandler.slowNodeCount");

--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -581,11 +581,7 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
       // with explicit "property" filter, it does not count down compute time
       super(
           "solr.node",
-          new String[] {
-            "QUERY.httpShardHandler.cancelledSlowNodeRequests",
-            "QUERY.httpShardHandler.cancelledDryRunSlowNodeRequests",
-            "QUERY.httpShardHandler.slowNodeCount"
-          });
+          "QUERY.httpShardHandler.cancelledSlowNodeRequests,QUERY.httpShardHandler.cancelledDryRunSlowNodeRequests,QUERY.httpShardHandler.slowNodeCount");
     }
 
     /*
@@ -1154,17 +1150,13 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
 
   private abstract static class MetricsByPrefixApiCaller extends MetricsApiCaller {
     protected final String group;
-    protected final String[] prefixes;
+    protected final String prefix;
     protected final String[] properties;
     protected final String property; // for backward compatibility
 
     MetricsByPrefixApiCaller(String group, String prefix, String... properties) {
-      this(group, new String[] {prefix}, properties);
-    }
-
-    MetricsByPrefixApiCaller(String group, String[] prefixes, String... properties) {
       this.group = group;
-      this.prefixes = prefixes;
+      this.prefix = prefix;
       this.properties = properties;
       this.property = properties.length > 0 ? properties[0] : null;
     }
@@ -1176,17 +1168,11 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
               .distinct()
               .map(p -> "&property=" + URLEncoder.encode(p, StandardCharsets.UTF_8))
               .collect(Collectors.joining());
-
-      String prefixClause =
-          Arrays.stream(prefixes)
-              .distinct()
-              .map(p -> URLEncoder.encode(p, StandardCharsets.UTF_8))
-              .collect(Collectors.joining(","));
       return String.format(
           Locale.ROOT,
           "wt=json&indent=false&compact=true&group=%s&prefix=%s%s",
           URLEncoder.encode(group, StandardCharsets.UTF_8),
-          prefixClause,
+          URLEncoder.encode(prefix, StandardCharsets.UTF_8),
           propertyClause);
     }
   }

--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -577,12 +577,15 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
   static class NodeMetricsApiCaller extends MetricsByPrefixApiCaller {
 
     NodeMetricsApiCaller() {
+      // use 3 prefixes as using just prefix "QUERY.httpShardHandler" matches too many metrics, even
+      // with explicit "property" filter, it does not count down compute time
       super(
           "solr.node",
-          "QUERY.httpShardHandler",
-          "cancelledSlowNodeRequests",
-          "cancelledDryRunSlowNodeRequests",
-          "slowNodeCount");
+          new String[] {
+            "QUERY.httpShardHandler.cancelledSlowNodeRequests",
+            "QUERY.httpShardHandler.cancelledDryRunSlowNodeRequests",
+            "QUERY.httpShardHandler.slowNodeCount"
+          });
     }
 
     /*
@@ -1151,13 +1154,17 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
 
   private abstract static class MetricsByPrefixApiCaller extends MetricsApiCaller {
     protected final String group;
-    protected final String prefix;
+    protected final String[] prefixes;
     protected final String[] properties;
     protected final String property; // for backward compatibility
 
     MetricsByPrefixApiCaller(String group, String prefix, String... properties) {
+      this(group, new String[] {prefix}, properties);
+    }
+
+    MetricsByPrefixApiCaller(String group, String[] prefixes, String... properties) {
       this.group = group;
-      this.prefix = prefix;
+      this.prefixes = prefixes;
       this.properties = properties;
       this.property = properties.length > 0 ? properties[0] : null;
     }
@@ -1169,11 +1176,17 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
               .distinct()
               .map(p -> "&property=" + URLEncoder.encode(p, StandardCharsets.UTF_8))
               .collect(Collectors.joining());
+
+      String prefixClause =
+          Arrays.stream(prefixes)
+              .distinct()
+              .map(p -> "," + URLEncoder.encode(p, StandardCharsets.UTF_8))
+              .collect(Collectors.joining());
       return String.format(
           Locale.ROOT,
           "wt=json&indent=false&compact=true&group=%s&prefix=%s%s",
           URLEncoder.encode(group, StandardCharsets.UTF_8),
-          URLEncoder.encode(prefix, StandardCharsets.UTF_8),
+          prefixClause,
           propertyClause);
     }
   }


### PR DESCRIPTION
## Description
It is observed that since introducing slow node detection, the QA node's QTime for getting metrics (/solr/metrics endpoint) has increased significantly (from 500-700ms to up to 10 sec)

## Cause
The new metrics from slow node are obtained in `PrometheusMetricsServlet` via group `solr.node`, prefix `QUERY.httpShardHandler` and properties `cancelledSlowNodeRequests`, `cancelledDryRunSlowNodeRequests` and `slowNodeCount`

Such translate to URL param `?wt=json&indent=false&compact=true&group=solr.node&prefix=QUERY.httpShardHandler&property=cancelledSlowNodeRequests&property=cancelledDryRunSlowNodeRequests&property=slowNodeCount`

However, if we issue such URL to prod such as https://solrqueryaggregator-c91-1.internal.fullstory.com/solr/admin/metrics?wt=json&indent=false&compact=true&group=solr.node&prefix=QUERY.httpShardHandler&property=cancelledSlowNodeRequests&property=cancelledDryRunSlowNodeRequests&property=slowNodeCount . We can see that QTime is around 5sec (slow)

This is because even tho we have narrowed down the scope by using `property` url param, such param only cut down the response size, the actually process is as slow as if the `property` is not defined. This is probably some Solr issue not related to the new metrics

## Solution
Instead of using a generic query prefix `prefix=QUERY.httpShardHandler` which is slow, we will use 3 different prefixes each matching the target metrics directly. 

Ie we will use url param:
`?wt=json&indent=false&compact=true&group=solr.node&prefix=QUERY.httpShardHandler.cancelledSlowNodeRequests%2CQUERY.httpShardHandler.cancelledDryRunSlowNodeRequests%2CQUERY.httpShardHandler.slowNodeCount`


## Test
1. Compared the old request on solrqueryaggregator-c91-1 prod https://solrqueryaggregator-c91-1.internal.fullstory.com/solr/admin/metrics?wt=json&indent=false&compact=true&group=solr.node&prefix=QUERY.httpShardHandler&property=cancelledSlowNodeRequests&property=cancelledDryRunSlowNodeRequests&property=slowNodeCount with the new format https://solrqueryaggregator-c91-1.internal.fullstory.com/solr/admin/metrics?wt=json&indent=false&compact=true&group=solr.node&prefix=QUERY.httpShardHandler.cancelledSlowNodeRequests%2CQUERY.httpShardHandler.cancelledDryRunSlowNodeRequests%2CQUERY.httpShardHandler.slowNodeCount . Latency change 5s -> less than 300 millisec
2. Debug the code to ensure `NodeMetricsApiCaller` generates the correct URL param 

## Remark
During this investigation, we have also found 2 other issues:
1. `QUERY.httpShardHandler.slowNodeCount` is missing under `solr.node` from endpoint `/solr/admin/metrics`. This is addressed in #261 
2. `property` filter only works to certain degree, for example `property=cancelledSlowNodeRequests&property=cancelledDryRunSlowNodeRequests&property=slowNodeCount` does not ONLY return 3 properties, it retuned around 15 properties, for sure it is much less than NOT defining property at all, but there's certain bug on solr end that `property` does not work as expected. This does not matter to us right now, since we are switching away from `property` for `NodeMetricsApiCaller` in this PR