### PR TITLE
Changed zk node for role to persistent

### DIFF
--- a/solr/core/src/java/org/apache/solr/cloud/ZkController.java
+++ b/solr/core/src/java/org/apache/solr/cloud/ZkController.java
@@ -1206,7 +1206,7 @@ public class ZkController implements Closeable {
         zkClient.create(
             NodeRoles.getZNodeForRoleMode(e.getKey(), e.getValue()) + "/" + nodeName,
             null,
-            CreateMode.EPHEMERAL,
+            CreateMode.PERSISTENT, // creating persistent as once node is live then it won't change.
             true);
       } catch (KeeperException.NodeExistsException ex) {
         // ignore , it already exists


### PR DESCRIPTION
We have observed in prod that sometime nodes are not updating their role in ZK. It can happen if nodes lives the cluster and joins again. **We need to make that operation solid joining live nodes and adding roles.** 

But, As a quick fix making that role as ZK-persistent, that will help this scenario (living the cluster and joining back)