### PR TITLE
SAI-5661 - Cache config override driven by clusterprops.json in ZK

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -1043,7 +1043,7 @@ public class CoreContainer {
       metricManager.loadClusterReporters(metricReporters, this);
     }
 
-    cacheOverridesManager = new CacheOverridesManager(zkClientSupplier.get());
+    cacheOverridesManager = new CacheOverridesManager(zkClientSupplier.get(), this);
 
     // setup executor to load cores in parallel
     ExecutorService coreLoadExecutor =

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -142,6 +142,7 @@ import org.apache.solr.pkg.SolrPackageLoader;
 import org.apache.solr.request.SolrRequestHandler;
 import org.apache.solr.request.SolrRequestInfo;
 import org.apache.solr.search.CacheConfig;
+import org.apache.solr.search.CacheOverridesManager;
 import org.apache.solr.search.SolrCache;
 import org.apache.solr.search.SolrFieldCacheBean;
 import org.apache.solr.security.AllowListUrlChecker;
@@ -310,6 +311,8 @@ public class CoreContainer {
   private final Set<Path> allowPaths;
 
   private final AllowListUrlChecker allowListUrlChecker;
+
+  private volatile CacheOverridesManager cacheOverridesManager;
 
   // Bits for the state variable.
   public static final long LOAD_COMPLETE = 0x1L;
@@ -1040,6 +1043,8 @@ public class CoreContainer {
       metricManager.loadClusterReporters(metricReporters, this);
     }
 
+    cacheOverridesManager = new CacheOverridesManager(zkClientSupplier.get());
+
     // setup executor to load cores in parallel
     ExecutorService coreLoadExecutor =
         MetricUtils.instrumentedExecutorService(
@@ -1704,6 +1709,10 @@ public class CoreContainer {
   /** Gets the URLs checker based on the {@code allowUrls} configuration of solr.xml. */
   public AllowListUrlChecker getAllowListUrlChecker() {
     return allowListUrlChecker;
+  }
+
+  public CacheOverridesManager getCacheOverridesManager() {
+    return cacheOverridesManager;
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -1043,7 +1043,7 @@ public class CoreContainer {
       metricManager.loadClusterReporters(metricReporters, this);
     }
 
-    cacheOverridesManager = new CacheOverridesManager(zkClientSupplier.get(), this);
+    cacheOverridesManager = new CacheOverridesManager(zkClientSupplier.get());
 
     // setup executor to load cores in parallel
     ExecutorService coreLoadExecutor =

--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -1043,7 +1043,9 @@ public class CoreContainer {
       metricManager.loadClusterReporters(metricReporters, this);
     }
 
-    cacheOverridesManager = new CacheOverridesManager(zkClientSupplier.get());
+    if (getZkController() != null) {
+      cacheOverridesManager = new CacheOverridesManager(zkClientSupplier.get());
+    }
 
     // setup executor to load cores in parallel
     ExecutorService coreLoadExecutor =

--- a/solr/core/src/java/org/apache/solr/core/SolrConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrConfig.java
@@ -330,7 +330,7 @@ public class SolrConfig implements MapSerializable {
         args.put(NAME, "fieldValueCache");
         args.put("size", "10000");
         args.put("initialSize", "10");
-        conf = new CacheConfig(loader, CaffeineCache.class.getName(), args, null);
+        conf = new CacheConfig(CaffeineCache.class, args, null);
       }
       fieldValueCacheConfig = conf;
       useColdSearcher = get("query").get("useColdSearcher").boolVal(false);

--- a/solr/core/src/java/org/apache/solr/core/SolrConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrConfig.java
@@ -330,7 +330,7 @@ public class SolrConfig implements MapSerializable {
         args.put(NAME, "fieldValueCache");
         args.put("size", "10000");
         args.put("initialSize", "10");
-        conf = new CacheConfig(CaffeineCache.class, args, null);
+        conf = new CacheConfig(loader, CaffeineCache.class.getName(), args, null);
       }
       fieldValueCacheConfig = conf;
       useColdSearcher = get("query").get("useColdSearcher").boolVal(false);

--- a/solr/core/src/java/org/apache/solr/search/CacheConfig.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheConfig.java
@@ -199,6 +199,19 @@ public class CacheConfig implements MapSerializable {
     return new HashMap<>(args);
   }
 
+  public CacheConfig withArgs(Map<String, String> newArgs) {
+    if (newArgs == null || newArgs.isEmpty()) {
+      return this;
+    }
+    if (this.args == null) {
+      this.args = newArgs;
+    } else {
+      this.args = new HashMap<>(this.args);
+      this.args.putAll(newArgs);
+    }
+    return this;
+  }
+
   public String getNodeName() {
     return nodeName;
   }

--- a/solr/core/src/java/org/apache/solr/search/CacheConfig.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheConfig.java
@@ -25,7 +25,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
+import java.util.function.Supplier;
 import org.apache.solr.common.ConfigNode;
 import org.apache.solr.common.MapSerializable;
 import org.apache.solr.common.util.CollectionUtil;
@@ -47,12 +47,10 @@ public class CacheConfig implements MapSerializable {
 
   /**
    * When this object is created, the core is not yet available . So, if the class is to be loaded
-   * from a package we should have a corresponding core <br>
-   * This loader could be passed to another CacheConfig constructor to load different cache impl
-   * class
+   * from a package we should have a corresponding core
    */
   @SuppressWarnings({"rawtypes"})
-  private Function<String, Class<? extends SolrCache>> classProvider;
+  private Supplier<Class<? extends SolrCache>> clazz;
 
   private Map<String, String> args;
   private CacheRegenerator regenerator;
@@ -67,21 +65,9 @@ public class CacheConfig implements MapSerializable {
 
   @SuppressWarnings({"rawtypes"})
   public CacheConfig(
-      SolrResourceLoader loader,
-      String cacheImpl,
-      Map<String, String> args,
-      CacheRegenerator regenerator) {
-    this(buildClassProvider(loader), cacheImpl, args, regenerator);
-  }
-
-  @SuppressWarnings({"rawtypes"})
-  private CacheConfig(
-      Function<String, Class<? extends SolrCache>> classProvider,
-      String cacheImpl,
-      Map<String, String> args,
-      CacheRegenerator regenerator) {
-    this.classProvider = classProvider;
-    this.cacheImpl = cacheImpl;
+      Class<? extends SolrCache> clazz, Map<String, String> args, CacheRegenerator regenerator) {
+    this.clazz = () -> clazz;
+    this.cacheImpl = clazz.getName();
     this.args = args;
     this.regenerator = regenerator;
     this.nodeName = args.get(NAME);
@@ -154,7 +140,22 @@ public class CacheConfig implements MapSerializable {
 
     config.cacheImpl = config.args.get("class");
     if (config.cacheImpl == null) config.cacheImpl = "solr.CaffeineCache";
-    config.classProvider = buildClassProvider(loader);
+    config.clazz =
+        new Supplier<>() {
+          @SuppressWarnings("rawtypes")
+          Class<? extends SolrCache> loadedClass;
+
+          @Override
+          @SuppressWarnings("rawtypes")
+          public Class<? extends SolrCache> get() {
+            if (loadedClass != null) return loadedClass;
+            return loadedClass =
+                loader.findClass(
+                    new PluginInfo("cache", Collections.singletonMap("class", config.cacheImpl)),
+                    SolrCache.class,
+                    true);
+          }
+        };
     config.regenImpl = config.args.get("regenerator");
     if (config.regenImpl != null) {
       config.regenerator = loader.newInstance(config.regenImpl, CacheRegenerator.class);
@@ -163,37 +164,11 @@ public class CacheConfig implements MapSerializable {
     return config;
   }
 
-  @SuppressWarnings({"rawtypes"})
-  private static Function<String, Class<? extends SolrCache>> buildClassProvider(
-      SolrResourceLoader loader) {
-    return new Function<>() {
-      @SuppressWarnings("rawtypes")
-      Class<? extends SolrCache> loadedClass;
-
-      @Override
-      @SuppressWarnings("rawtypes")
-      public Class<? extends SolrCache> apply(String cacheClassName) {
-        if (loadedClass != null
-            && loadedClass
-                .getName()
-                .equals(cacheClassName)) { // the class is either not loaded or stale
-          return loadedClass;
-        }
-        return loadedClass =
-            loader.findClass(
-                new PluginInfo("cache", Collections.singletonMap("class", cacheClassName)),
-                SolrCache.class,
-                true);
-      }
-    };
-  }
-
   @SuppressWarnings("rawtypes")
   public SolrCache newInstance(SolrCore core) {
     try {
       @SuppressWarnings("unchecked")
-      SolrCache<?, ?> cache =
-          newInstance(core, (Class<? extends SolrCache<?, ?>>) classProvider.apply(cacheImpl));
+      SolrCache<?, ?> cache = newInstance(core, (Class<? extends SolrCache<?, ?>>) clazz.get());
       persistence[0] = cache.init(args, persistence[0], regenerator);
       return cache;
     } catch (Exception e) {
@@ -234,22 +209,16 @@ public class CacheConfig implements MapSerializable {
     if (newArgs == null || newArgs.isEmpty()) {
       return this;
     }
-
-    Map<String, String> finalArgs = new HashMap<>(this.args);
-    finalArgs.putAll(newArgs);
-
-    String cacheImpl = finalArgs.getOrDefault("class", this.cacheImpl);
-
-    return new CacheConfig(this.classProvider, cacheImpl, finalArgs, this.regenerator);
+    if (this.args == null) {
+      return new CacheConfig(this.clazz.get(), new HashMap<>(newArgs), this.regenerator);
+    } else {
+      Map<String, String> finalArgs = new HashMap<>(this.args);
+      finalArgs.putAll(newArgs);
+      return new CacheConfig(this.clazz.get(), finalArgs, this.regenerator);
+    }
   }
 
   public String getNodeName() {
     return nodeName;
-  }
-
-  /** For test */
-  @SuppressWarnings("rawtypes")
-  Class<? extends SolrCache> getCacheImplClass() {
-    return classProvider.apply(cacheImpl);
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/CacheConfig.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheConfig.java
@@ -25,7 +25,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
+import java.util.function.Function;
 import org.apache.solr.common.ConfigNode;
 import org.apache.solr.common.MapSerializable;
 import org.apache.solr.common.util.CollectionUtil;
@@ -47,10 +47,12 @@ public class CacheConfig implements MapSerializable {
 
   /**
    * When this object is created, the core is not yet available . So, if the class is to be loaded
-   * from a package we should have a corresponding core
+   * from a package we should have a corresponding core <br>
+   * This loader could be passed to another CacheConfig constructor to load different cache impl
+   * class
    */
   @SuppressWarnings({"rawtypes"})
-  private Supplier<Class<? extends SolrCache>> clazz;
+  private Function<String, Class<? extends SolrCache>> classProvider;
 
   private Map<String, String> args;
   private CacheRegenerator regenerator;
@@ -65,9 +67,21 @@ public class CacheConfig implements MapSerializable {
 
   @SuppressWarnings({"rawtypes"})
   public CacheConfig(
-      Class<? extends SolrCache> clazz, Map<String, String> args, CacheRegenerator regenerator) {
-    this.clazz = () -> clazz;
-    this.cacheImpl = clazz.getName();
+      SolrResourceLoader loader,
+      String cacheImpl,
+      Map<String, String> args,
+      CacheRegenerator regenerator) {
+    this(buildClassProvider(loader), cacheImpl, args, regenerator);
+  }
+
+  @SuppressWarnings({"rawtypes"})
+  private CacheConfig(
+      Function<String, Class<? extends SolrCache>> classProvider,
+      String cacheImpl,
+      Map<String, String> args,
+      CacheRegenerator regenerator) {
+    this.classProvider = classProvider;
+    this.cacheImpl = cacheImpl;
     this.args = args;
     this.regenerator = regenerator;
     this.nodeName = args.get(NAME);
@@ -140,22 +154,7 @@ public class CacheConfig implements MapSerializable {
 
     config.cacheImpl = config.args.get("class");
     if (config.cacheImpl == null) config.cacheImpl = "solr.CaffeineCache";
-    config.clazz =
-        new Supplier<>() {
-          @SuppressWarnings("rawtypes")
-          Class<? extends SolrCache> loadedClass;
-
-          @Override
-          @SuppressWarnings("rawtypes")
-          public Class<? extends SolrCache> get() {
-            if (loadedClass != null) return loadedClass;
-            return loadedClass =
-                loader.findClass(
-                    new PluginInfo("cache", Collections.singletonMap("class", config.cacheImpl)),
-                    SolrCache.class,
-                    true);
-          }
-        };
+    config.classProvider = buildClassProvider(loader);
     config.regenImpl = config.args.get("regenerator");
     if (config.regenImpl != null) {
       config.regenerator = loader.newInstance(config.regenImpl, CacheRegenerator.class);
@@ -164,11 +163,37 @@ public class CacheConfig implements MapSerializable {
     return config;
   }
 
+  @SuppressWarnings({"rawtypes"})
+  private static Function<String, Class<? extends SolrCache>> buildClassProvider(
+      SolrResourceLoader loader) {
+    return new Function<>() {
+      @SuppressWarnings("rawtypes")
+      Class<? extends SolrCache> loadedClass;
+
+      @Override
+      @SuppressWarnings("rawtypes")
+      public Class<? extends SolrCache> apply(String cacheClassName) {
+        if (loadedClass != null
+            && loadedClass
+                .getName()
+                .equals(cacheClassName)) { // the class is either not loaded or stale
+          return loadedClass;
+        }
+        return loadedClass =
+            loader.findClass(
+                new PluginInfo("cache", Collections.singletonMap("class", cacheClassName)),
+                SolrCache.class,
+                true);
+      }
+    };
+  }
+
   @SuppressWarnings("rawtypes")
   public SolrCache newInstance(SolrCore core) {
     try {
       @SuppressWarnings("unchecked")
-      SolrCache<?, ?> cache = newInstance(core, (Class<? extends SolrCache<?, ?>>) clazz.get());
+      SolrCache<?, ?> cache =
+          newInstance(core, (Class<? extends SolrCache<?, ?>>) classProvider.apply(cacheImpl));
       persistence[0] = cache.init(args, persistence[0], regenerator);
       return cache;
     } catch (Exception e) {
@@ -209,16 +234,22 @@ public class CacheConfig implements MapSerializable {
     if (newArgs == null || newArgs.isEmpty()) {
       return this;
     }
-    if (this.args == null) {
-      return new CacheConfig(this.clazz.get(), new HashMap<>(newArgs), this.regenerator);
-    } else {
-      Map<String, String> finalArgs = new HashMap<>(this.args);
-      finalArgs.putAll(newArgs);
-      return new CacheConfig(this.clazz.get(), finalArgs, this.regenerator);
-    }
+
+    Map<String, String> finalArgs = new HashMap<>(this.args);
+    finalArgs.putAll(newArgs);
+
+    String cacheImpl = finalArgs.getOrDefault("class", this.cacheImpl);
+
+    return new CacheConfig(this.classProvider, cacheImpl, finalArgs, this.regenerator);
   }
 
   public String getNodeName() {
     return nodeName;
+  }
+
+  /** For test */
+  @SuppressWarnings("rawtypes")
+  Class<? extends SolrCache> getCacheImplClass() {
+    return classProvider.apply(cacheImpl);
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/CacheConfig.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheConfig.java
@@ -200,9 +200,9 @@ public class CacheConfig implements MapSerializable {
   }
 
   /**
-   * Returns a CacheConfig with the given arguments merged into the existing ones.
-   * <br>
+   * Returns a CacheConfig with the given arguments merged into the existing ones. <br>
    * The existing config should not be modified
+   *
    * @param newArgs new arguments to merge into the existing config, overrides existing values
    */
   public CacheConfig withArgs(Map<String, String> newArgs) {

--- a/solr/core/src/java/org/apache/solr/search/CacheConfig.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheConfig.java
@@ -199,17 +199,23 @@ public class CacheConfig implements MapSerializable {
     return new HashMap<>(args);
   }
 
+  /**
+   * Returns a CacheConfig with the given arguments merged into the existing ones.
+   * <br>
+   * The existing config should not be modified
+   * @param newArgs new arguments to merge into the existing config, overrides existing values
+   */
   public CacheConfig withArgs(Map<String, String> newArgs) {
     if (newArgs == null || newArgs.isEmpty()) {
       return this;
     }
     if (this.args == null) {
-      this.args = newArgs;
+      return new CacheConfig(this.clazz.get(), new HashMap<>(newArgs), this.regenerator);
     } else {
-      this.args = new HashMap<>(this.args);
-      this.args.putAll(newArgs);
+      Map<String, String> finalArgs = new HashMap<>(this.args);
+      finalArgs.putAll(newArgs);
+      return new CacheConfig(this.clazz.get(), finalArgs, this.regenerator);
     }
-    return this;
   }
 
   public String getNodeName() {

--- a/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
@@ -3,18 +3,13 @@ package org.apache.solr.search;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.util.Utils;
-import org.apache.solr.core.CoreContainer;
-import org.apache.solr.core.SolrCore;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -26,11 +21,10 @@ import java.util.stream.Collectors;
 public class CacheOverridesManager {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private final ConcurrentMap<String, List<CacheOverrides>> overridesByCacheName = new ConcurrentHashMap<>();
-  private final CoreContainer coreContainer;
 
-  public CacheOverridesManager(SolrZkClient zkClient, CoreContainer coreContainer) {
+
+  public CacheOverridesManager(SolrZkClient zkClient) {
     byte[] clusterPropsBytes = null;
-    this.coreContainer = coreContainer;
 
     final Watcher watcher = new Watcher() {
       @Override
@@ -68,7 +62,6 @@ public class CacheOverridesManager {
   }
 
   private void processCacheOverrides(Object cacheOverridesContents) {
-    Set<String> affectedCacheNames = new HashSet<>(overridesByCacheName.keySet());
     if (cacheOverridesContents instanceof List) {
       @SuppressWarnings("unchecked")
       List<Map<String, Object>> entries = (List<Map<String, Object>>) cacheOverridesContents;
@@ -87,7 +80,6 @@ public class CacheOverridesManager {
           }
           CacheOverrides cacheOverrides = new CacheOverrides(overrides, collectionsFilter == null ? null : Set.copyOf(collectionsFilter));
           newOverridesByCacheName.computeIfAbsent(cacheName, k -> new java.util.ArrayList<>()).add(cacheOverrides);
-          affectedCacheNames.add(cacheName);
         }
       }
       synchronized(overridesByCacheName) {
@@ -100,41 +92,7 @@ public class CacheOverridesManager {
       log.info("Cleared cache overrides");
     } else {
       log.warn("Unexpected format for cacheOverrides in cluster properties: {}", cacheOverridesContents);
-      return;
     }
-
-    Class<?> sharedCacheClass = findAbstractSharedCacheClass();
-
-    if (sharedCacheClass != null) { //then there's some shared cache loaded
-      try {
-        Method evictMethod = sharedCacheClass.getDeclaredMethod("evictSharedStore", String.class);
-        for (String affectedCacheName : affectedCacheNames) {
-          try {
-            evictMethod.setAccessible(true);
-            evictMethod.invoke(null, affectedCacheName);
-          } catch (IllegalAccessException e) {
-            log.error("Error while trying to evict shared cache store for cache: " + affectedCacheName, e);
-          } catch (InvocationTargetException e) {
-            log.error("Error while trying to evict shared cache store for cache: " + affectedCacheName, e);
-          }
-        }
-      } catch (NoSuchMethodException e) {
-        log.error("Error while trying to evict shared cache store", e);
-      }
-    }
-  }
-
-  private Class<?> findAbstractSharedCacheClass() {
-    for (String loadedCoreName : coreContainer.getLoadedCoreNames()) {
-      SolrCore core = coreContainer.getCore(loadedCoreName);
-      if (core != null) {
-        try {
-          return core.getSolrConfig().getResourceLoader().findClass("mn.fs.solr.sharedcache.AbstractSharedCache", SolrCache.class);
-        } catch (Exception e) {
-        }
-      }
-    }
-    return null;
   }
 
   public List<Map<String, String>> getOverrides(String cacheName, String collection) {

--- a/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
@@ -1,7 +1,6 @@
 package org.apache.solr.search;
 
 import java.lang.invoke.MethodHandles;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
@@ -3,13 +3,18 @@ package org.apache.solr.search;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.common.util.Utils;
+import org.apache.solr.core.CoreContainer;
+import org.apache.solr.core.SolrCore;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -21,10 +26,11 @@ import java.util.stream.Collectors;
 public class CacheOverridesManager {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private final ConcurrentMap<String, List<CacheOverrides>> overridesByCacheName = new ConcurrentHashMap<>();
+  private final CoreContainer coreContainer;
 
-
-  public CacheOverridesManager(SolrZkClient zkClient) {
+  public CacheOverridesManager(SolrZkClient zkClient, CoreContainer coreContainer) {
     byte[] clusterPropsBytes = null;
+    this.coreContainer = coreContainer;
 
     final Watcher watcher = new Watcher() {
       @Override
@@ -62,6 +68,7 @@ public class CacheOverridesManager {
   }
 
   private void processCacheOverrides(Object cacheOverridesContents) {
+    Set<String> affectedCacheNames = new HashSet<>(overridesByCacheName.keySet());
     if (cacheOverridesContents instanceof List) {
       @SuppressWarnings("unchecked")
       List<Map<String, Object>> entries = (List<Map<String, Object>>) cacheOverridesContents;
@@ -80,6 +87,7 @@ public class CacheOverridesManager {
           }
           CacheOverrides cacheOverrides = new CacheOverrides(overrides, collectionsFilter == null ? null : Set.copyOf(collectionsFilter));
           newOverridesByCacheName.computeIfAbsent(cacheName, k -> new java.util.ArrayList<>()).add(cacheOverrides);
+          affectedCacheNames.add(cacheName);
         }
       }
       synchronized(overridesByCacheName) {
@@ -92,7 +100,41 @@ public class CacheOverridesManager {
       log.info("Cleared cache overrides");
     } else {
       log.warn("Unexpected format for cacheOverrides in cluster properties: {}", cacheOverridesContents);
+      return;
     }
+
+    Class<?> sharedCacheClass = findAbstractSharedCacheClass();
+
+    if (sharedCacheClass != null) { //then there's some shared cache loaded
+      try {
+        Method evictMethod = sharedCacheClass.getDeclaredMethod("evictSharedStore", String.class);
+        for (String affectedCacheName : affectedCacheNames) {
+          try {
+            evictMethod.setAccessible(true);
+            evictMethod.invoke(null, affectedCacheName);
+          } catch (IllegalAccessException e) {
+            log.error("Error while trying to evict shared cache store for cache: " + affectedCacheName, e);
+          } catch (InvocationTargetException e) {
+            log.error("Error while trying to evict shared cache store for cache: " + affectedCacheName, e);
+          }
+        }
+      } catch (NoSuchMethodException e) {
+        log.error("Error while trying to evict shared cache store", e);
+      }
+    }
+  }
+
+  private Class<?> findAbstractSharedCacheClass() {
+    for (String loadedCoreName : coreContainer.getLoadedCoreNames()) {
+      SolrCore core = coreContainer.getCore(loadedCoreName);
+      if (core != null) {
+        try {
+          return core.getSolrConfig().getResourceLoader().findClass("mn.fs.solr.sharedcache.AbstractSharedCache", SolrCache.class);
+        } catch (Exception e) {
+        }
+      }
+    }
+    return null;
   }
 
   public List<Map<String, String>> getOverrides(String cacheName, String collection) {

--- a/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
@@ -1,12 +1,11 @@
 package org.apache.solr.search;
 
 import java.lang.invoke.MethodHandles;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.cloud.ZkStateReader;
@@ -71,8 +70,7 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("unchecked")
 public class CacheOverridesManager {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-  private volatile ConcurrentMap<String, List<CacheOverrides>> overridesByCacheName =
-      new ConcurrentHashMap<>();
+  private volatile Map<String, List<CacheOverrides>> overridesByCacheName = Collections.EMPTY_MAP;
 
   public CacheOverridesManager(SolrZkClient zkClient) {
     byte[] clusterPropsBytes = null;
@@ -129,8 +127,7 @@ public class CacheOverridesManager {
     if (cacheOverridesContents instanceof List) {
       @SuppressWarnings("unchecked")
       List<Map<String, Object>> entries = (List<Map<String, Object>>) cacheOverridesContents;
-      ConcurrentMap<String, List<CacheOverrides>> newOverridesByCacheName =
-          new ConcurrentHashMap<>();
+      Map<String, List<CacheOverrides>> newOverridesByCacheName = new HashMap<>();
       for (Map<String, Object> overridesMap : entries) {
         List<String> collectionsFilter = (List<String>) overridesMap.get("collections");
 
@@ -153,11 +150,11 @@ public class CacheOverridesManager {
         }
       }
 
-      overridesByCacheName = newOverridesByCacheName;
+      overridesByCacheName = Map.copyOf(newOverridesByCacheName);
       log.info("Cache overrides updated to {}", overridesByCacheName);
 
     } else if (cacheOverridesContents == null) { // overrides removal
-      overridesByCacheName.clear();
+      overridesByCacheName = Collections.EMPTY_MAP;
       log.info("Cleared cache overrides");
     } else {
       log.warn(
@@ -184,10 +181,7 @@ public class CacheOverridesManager {
   }
 
   List<Map<String, String>> getOverrides(String cacheName, String collection) {
-    List<CacheOverrides> overrides;
-    synchronized (overridesByCacheName) {
-      overrides = overridesByCacheName.get(cacheName);
-    }
+    List<CacheOverrides> overrides = overridesByCacheName.get(cacheName);
     if (overrides == null) {
       return null;
     }

--- a/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
@@ -1,13 +1,5 @@
 package org.apache.solr.search;
 
-import org.apache.solr.common.cloud.SolrZkClient;
-import org.apache.solr.common.cloud.ZkStateReader;
-import org.apache.solr.common.util.Utils;
-import org.apache.zookeeper.WatchedEvent;
-import org.apache.zookeeper.Watcher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.List;
@@ -16,40 +8,101 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
+import org.apache.solr.common.cloud.SolrZkClient;
+import org.apache.solr.common.cloud.ZkStateReader;
+import org.apache.solr.common.util.Utils;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * A manager that gets and subscribes to ZK clusterprops.json on field "cacheOverrides" <br>
+ * The value of the field defines a list of cache overrides, each override is a map with cache name
+ * as key and a map of properties as value. An extra "collections" key can be used to filter apply
+ * the overrides only to specific collections. <br>
+ * The override will only be effective if the cache is re-instantiated. Therefore, some backing
+ * shared cache that only instantiate on startup might only see the overrides after process restart,
+ * while more transient cache such as local core cache will see the new values on searching
+ * reopening without restart. <br>
+ * Example of the override config in clusterprops.json:
+ *
+ * <pre>
+ *   {
+ * ...
+ *  cacheOverrides : [
+ *    {
+ *      filterCache :  {
+ *        size: 9999
+ *      }
+ *      documentCache : {
+ *        size: 9999
+ *      }
+ *      fs-cache : {
+ *        maxRamMB: 9999
+ *      }
+ *    },
+ *    {
+ *      filterCache :  {
+ *        size: 12345
+ *      }
+ *      collections: [ "104H4B" ]
+ *    }
+ *  ]
+ *
+ * }
+ * </pre>
+ *
+ * Entries will be applied as overrides according to the order declared in the array. Hence, later
+ * entry overrides earlier for value overlaps
+ */
 @SuppressWarnings("unchecked")
 public class CacheOverridesManager {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-  private final ConcurrentMap<String, List<CacheOverrides>> overridesByCacheName = new ConcurrentHashMap<>();
-
+  private final ConcurrentMap<String, List<CacheOverrides>> overridesByCacheName =
+      new ConcurrentHashMap<>();
 
   public CacheOverridesManager(SolrZkClient zkClient) {
     byte[] clusterPropsBytes = null;
 
-    final Watcher watcher = new Watcher() {
-      @Override
-      public void process(WatchedEvent event) {
-        if (event.getType() == Event.EventType.NodeDataChanged) {
-          try {
-            // Fetch the updated cluster properties
-            byte[] data = zkClient.getData(event.getPath(), this, null, true);
-            if (data != null) {
-              Map<String, Object> clusterPropsJson =
-                      (Map<String, Object>) Utils.fromJSON(data);
-              // Process the cache overrides from cluster properties
-              processCacheOverrides(clusterPropsJson.get("cacheOverrides"));
-            } else {
-              processCacheOverrides(null);
+    final Watcher watcher =
+        new Watcher() {
+          @Override
+          public void process(WatchedEvent event) {
+            try {
+              if (event.getType() == Event.EventType.NodeDataChanged
+                  || event.getType() == Event.EventType.NodeCreated) {
+                // Fetch the updated cluster properties
+                byte[] data = zkClient.getData(event.getPath(), this, null, true);
+                if (data != null) {
+                  Map<String, Object> clusterPropsJson = (Map<String, Object>) Utils.fromJSON(data);
+                  // Process the cache overrides from cluster properties
+                  processCacheOverrides(clusterPropsJson.get("cacheOverrides"));
+                } else {
+                  processCacheOverrides(null);
+                }
+              } else if (event.getType() == Event.EventType.NodeDeleted) {
+                zkClient.exists(event.getPath(), this, true);
+                processCacheOverrides(null);
+              } else {
+                // just re-install watcher
+                zkClient.exists(event.getPath(), this, true);
+              }
+            } catch (Exception e) {
+              log.warn("Error processing cache overrides from ZooKeeper", e);
             }
-          } catch (Exception e) {
-            log.warn("Error processing cache overrides from ZooKeeper", e);
           }
-        }
-      }
-    };
+        };
 
     try {
       clusterPropsBytes = zkClient.getData(ZkStateReader.CLUSTER_PROPS, watcher, null, true);
+    } catch (KeeperException.NoNodeException e) {
+      try {
+        zkClient.exists(ZkStateReader.CLUSTER_PROPS, watcher, true); // still install a watcher
+      } catch (Exception ex) {
+        log.warn("Error installing exist watcher on cluster properties from ZooKeeper", e);
+      }
     } catch (Exception e) {
       log.warn("Error fetching cluster properties from ZooKeeper", e);
     }
@@ -70,43 +123,69 @@ public class CacheOverridesManager {
         List<String> collectionsFilter = (List<String>) overridesMap.get("collections");
 
         for (Map.Entry<String, Object> entry : overridesMap.entrySet()) {
-          if ("collections".equals(entry.getKey())) { //a special case for collection filter
+          if ("collections".equals(entry.getKey())) { // a special case for collection filter
             continue;
           }
           String cacheName = entry.getKey();
           Map<String, String> overrides = new HashMap<>();
-          for (Map.Entry<String, Object> propertyKv : ((Map<String, Object>) entry.getValue()).entrySet()) {
+          for (Map.Entry<String, Object> propertyKv :
+              ((Map<String, Object>) entry.getValue()).entrySet()) {
             overrides.put(propertyKv.getKey(), String.valueOf(propertyKv.getValue()));
           }
-          CacheOverrides cacheOverrides = new CacheOverrides(overrides, collectionsFilter == null ? null : Set.copyOf(collectionsFilter));
-          newOverridesByCacheName.computeIfAbsent(cacheName, k -> new java.util.ArrayList<>()).add(cacheOverrides);
+          CacheOverrides cacheOverrides =
+              new CacheOverrides(
+                  overrides, collectionsFilter == null ? null : Set.copyOf(collectionsFilter));
+          newOverridesByCacheName
+              .computeIfAbsent(cacheName, k -> new java.util.ArrayList<>())
+              .add(cacheOverrides);
         }
       }
-      synchronized(overridesByCacheName) {
+      synchronized (overridesByCacheName) {
         overridesByCacheName.clear();
         overridesByCacheName.putAll(newOverridesByCacheName);
         log.info("Cache overrides updated to {}", overridesByCacheName);
       }
-    } else if (cacheOverridesContents == null) { //overrides removal
+    } else if (cacheOverridesContents == null) { // overrides removal
       overridesByCacheName.clear();
       log.info("Cleared cache overrides");
     } else {
-      log.warn("Unexpected format for cacheOverrides in cluster properties: {}", cacheOverridesContents);
+      log.warn(
+          "Unexpected format for cacheOverrides in cluster properties: {}", cacheOverridesContents);
     }
   }
 
-  public List<Map<String, String>> getOverrides(String cacheName, String collection) {
+  /**
+   * Applies the overrides to the given cache configuration.
+   *
+   * @param cacheConfig the existing cache config
+   * @param cacheName the name of the cache to apply overrides for (filterCache, documentCache etc)
+   * @param collection the collection name of this cache
+   * @return existing config if no overrides otherwise a new config with overrides applied
+   */
+  public CacheConfig applyOverrides(CacheConfig cacheConfig, String cacheName, String collection) {
+    List<Map<String, String>> overridesEntries = getOverrides(cacheName, collection);
+    if (overridesEntries != null) {
+      for (Map<String, String> overrides : overridesEntries) {
+        cacheConfig = cacheConfig.withArgs(overrides);
+      }
+    }
+    return cacheConfig;
+  }
+
+  List<Map<String, String>> getOverrides(String cacheName, String collection) {
     List<CacheOverrides> overrides;
     synchronized (overridesByCacheName) {
-       overrides = overridesByCacheName.get(cacheName);
+      overrides = overridesByCacheName.get(cacheName);
     }
     if (overrides == null) {
       return null;
     }
-    return overrides.stream()
-        .map(override -> override.getOverrides(collection))
-        .filter(overridesMap -> overridesMap != null && !overridesMap.isEmpty())
-        .collect(Collectors.toList());
+    List<Map<String, String>> result =
+        overrides.stream()
+            .map(override -> override.getOverrides(collection))
+            .filter(overridesMap -> overridesMap != null && !overridesMap.isEmpty())
+            .collect(Collectors.toList());
+    return result.isEmpty() ? null : result;
   }
 
   static class CacheOverrides {
@@ -128,10 +207,12 @@ public class CacheOverridesManager {
 
     @Override
     public String toString() {
-      return "CacheOverrides{" +
-              "overrides=" + overrides +
-              ", matchCollections=" + matchCollections +
-              '}';
+      return "CacheOverrides{"
+          + "overrides="
+          + overrides
+          + ", matchCollections="
+          + matchCollections
+          + '}';
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
@@ -19,14 +19,25 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A manager that gets and subscribes to ZK clusterprops.json on field "cacheOverrides" <br>
+ * <br>
  * The value of the field defines a list of cache overrides, each override is a map with cache name
- * as key and a map of properties as value. An extra "collections" key can be used to filter apply
- * the overrides only to specific collections. <br>
+ * as key and a map of properties as value. An extra "collections" key can be used to apply the
+ * overrides only to specific collections. <br>
+ * <br>
  * The override will only be effective if the cache is re-instantiated. Therefore, some backing
- * shared cache that only instantiate on startup might only see the overrides after process restart,
- * while more transient cache such as local core cache will see the new values on searching
+ * shared caches that only instantiate on startup might only see the overrides after process
+ * restart, while some transient caches such as local core cache will see the new values on searcher
  * reopening without restart. <br>
- * Example of the override config in clusterprops.json:
+ * <br>
+ * Take note that overrides do NOT work on below properties: <br>
+ *
+ * <ol>
+ *   <li>class
+ *   <li>regenerator
+ * </ol>
+ *
+ * <br>
+ * Example of the override config in clusterprops.json: <br>
  *
  * <pre>
  *   {
@@ -55,12 +66,12 @@ import org.slf4j.LoggerFactory;
  * </pre>
  *
  * Entries will be applied as overrides according to the order declared in the array. Hence, later
- * entry overrides earlier for value overlaps
+ * entry overrides earlier for overlaps
  */
 @SuppressWarnings("unchecked")
 public class CacheOverridesManager {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-  private final ConcurrentMap<String, List<CacheOverrides>> overridesByCacheName =
+  private volatile ConcurrentMap<String, List<CacheOverrides>> overridesByCacheName =
       new ConcurrentHashMap<>();
 
   public CacheOverridesManager(SolrZkClient zkClient) {
@@ -118,7 +129,8 @@ public class CacheOverridesManager {
     if (cacheOverridesContents instanceof List) {
       @SuppressWarnings("unchecked")
       List<Map<String, Object>> entries = (List<Map<String, Object>>) cacheOverridesContents;
-      Map<String, List<CacheOverrides>> newOverridesByCacheName = new HashMap<>();
+      ConcurrentMap<String, List<CacheOverrides>> newOverridesByCacheName =
+          new ConcurrentHashMap<>();
       for (Map<String, Object> overridesMap : entries) {
         List<String> collectionsFilter = (List<String>) overridesMap.get("collections");
 
@@ -140,11 +152,10 @@ public class CacheOverridesManager {
               .add(cacheOverrides);
         }
       }
-      synchronized (overridesByCacheName) {
-        overridesByCacheName.clear();
-        overridesByCacheName.putAll(newOverridesByCacheName);
-        log.info("Cache overrides updated to {}", overridesByCacheName);
-      }
+
+      overridesByCacheName = newOverridesByCacheName;
+      log.info("Cache overrides updated to {}", overridesByCacheName);
+
     } else if (cacheOverridesContents == null) { // overrides removal
       overridesByCacheName.clear();
       log.info("Cleared cache overrides");

--- a/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
@@ -93,8 +93,6 @@ public class CacheOverridesManager {
     } else {
       log.warn("Unexpected format for cacheOverrides in cluster properties: {}", cacheOverridesContents);
     }
-
-    log.info("!!!!!processCacheOverrides {} values {}", System.identityHashCode(this), overridesByCacheName);
   }
 
   public List<Map<String, String>> getOverrides(String cacheName, String collection) {

--- a/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
@@ -70,7 +70,7 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("unchecked")
 public class CacheOverridesManager {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-  private volatile Map<String, List<CacheOverrides>> overridesByCacheName = Collections.EMPTY_MAP;
+  private volatile Map<String, List<CacheOverrides>> overridesByCacheName = Map.of();
 
   public CacheOverridesManager(SolrZkClient zkClient) {
     byte[] clusterPropsBytes = null;
@@ -154,7 +154,7 @@ public class CacheOverridesManager {
       log.info("Cache overrides updated to {}", overridesByCacheName);
 
     } else if (cacheOverridesContents == null) { // overrides removal
-      overridesByCacheName = Collections.EMPTY_MAP;
+      overridesByCacheName = Map.of();
       log.info("Cleared cache overrides");
     } else {
       log.warn(

--- a/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
@@ -17,6 +17,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 
+@SuppressWarnings("unchecked")
 public class CacheOverridesManager {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private final ConcurrentMap<String, List<CacheOverrides>> overridesByCacheName = new ConcurrentHashMap<>();
@@ -24,28 +25,33 @@ public class CacheOverridesManager {
 
   public CacheOverridesManager(SolrZkClient zkClient) {
     byte[] clusterPropsBytes = null;
-    try {
-      clusterPropsBytes = zkClient.getData(ZkStateReader.CLUSTER_PROPS, new Watcher() {
-        @Override
-        public void process(WatchedEvent event) {
-          if (event.getType() == Event.EventType.NodeDataChanged) {
-            try {
-              // Fetch the updated cluster properties
-              byte[] data = zkClient.getData(event.getPath(), null, null, true);
-              if (data != null) {
-                Map<String, Object> clusterPropsJson =
-                        (Map<String, Object>) Utils.fromJSON(data);
-                // Process the cache overrides from cluster properties
-                processCacheOverrides(clusterPropsJson.get("cacheOverrides"));
-              }
-            } catch (Exception e) {
-              //TODO
+
+    final Watcher watcher = new Watcher() {
+      @Override
+      public void process(WatchedEvent event) {
+        if (event.getType() == Event.EventType.NodeDataChanged) {
+          try {
+            // Fetch the updated cluster properties
+            byte[] data = zkClient.getData(event.getPath(), this, null, true);
+            if (data != null) {
+              Map<String, Object> clusterPropsJson =
+                      (Map<String, Object>) Utils.fromJSON(data);
+              // Process the cache overrides from cluster properties
+              processCacheOverrides(clusterPropsJson.get("cacheOverrides"));
+            } else {
+              processCacheOverrides(null);
             }
+          } catch (Exception e) {
+            log.warn("Error processing cache overrides from ZooKeeper", e);
           }
         }
-      }, null, true);
-    } catch (Exception e) {
+      }
+    };
 
+    try {
+      clusterPropsBytes = zkClient.getData(ZkStateReader.CLUSTER_PROPS, watcher, null, true);
+    } catch (Exception e) {
+      log.warn("Error fetching cluster properties from ZooKeeper", e);
     }
 
     if (clusterPropsBytes != null) {
@@ -56,12 +62,12 @@ public class CacheOverridesManager {
   }
 
   private void processCacheOverrides(Object cacheOverridesContents) {
-    if (cacheOverridesContents instanceof Map) {
+    if (cacheOverridesContents instanceof List) {
       @SuppressWarnings("unchecked")
       List<Map<String, Object>> entries = (List<Map<String, Object>>) cacheOverridesContents;
+      Map<String, List<CacheOverrides>> newOverridesByCacheName = new HashMap<>();
       for (Map<String, Object> overridesMap : entries) {
         List<String> collectionsFilter = (List<String>) overridesMap.get("collections");
-
 
         for (Map.Entry<String, Object> entry : overridesMap.entrySet()) {
           if ("collections".equals(entry.getKey())) { //a special case for collection filter
@@ -73,16 +79,29 @@ public class CacheOverridesManager {
             overrides.put(propertyKv.getKey(), String.valueOf(propertyKv.getValue()));
           }
           CacheOverrides cacheOverrides = new CacheOverrides(overrides, collectionsFilter == null ? null : Set.copyOf(collectionsFilter));
-          overridesByCacheName.computeIfAbsent(cacheName, k -> new java.util.ArrayList<>()).add(cacheOverrides);
+          newOverridesByCacheName.computeIfAbsent(cacheName, k -> new java.util.ArrayList<>()).add(cacheOverrides);
         }
       }
+      synchronized(overridesByCacheName) {
+        overridesByCacheName.clear();
+        overridesByCacheName.putAll(newOverridesByCacheName);
+        log.info("Cache overrides updated to {}", overridesByCacheName);
+      }
+    } else if (cacheOverridesContents == null) { //overrides removal
+      overridesByCacheName.clear();
+      log.info("Cleared cache overrides");
     } else {
       log.warn("Unexpected format for cacheOverrides in cluster properties: {}", cacheOverridesContents);
     }
+
+    log.info("!!!!!processCacheOverrides {} values {}", System.identityHashCode(this), overridesByCacheName);
   }
 
   public List<Map<String, String>> getOverrides(String cacheName, String collection) {
-    List<CacheOverrides> overrides = overridesByCacheName.get(cacheName);
+    List<CacheOverrides> overrides;
+    synchronized (overridesByCacheName) {
+       overrides = overridesByCacheName.get(cacheName);
+    }
     if (overrides == null) {
       return null;
     }
@@ -107,6 +126,14 @@ public class CacheOverridesManager {
       } else {
         return null;
       }
+    }
+
+    @Override
+    public String toString() {
+      return "CacheOverrides{" +
+              "overrides=" + overrides +
+              ", matchCollections=" + matchCollections +
+              '}';
     }
   }
 }

--- a/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
@@ -1,0 +1,112 @@
+package org.apache.solr.search;
+
+import org.apache.solr.common.cloud.SolrZkClient;
+import org.apache.solr.common.cloud.ZkStateReader;
+import org.apache.solr.common.util.Utils;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+public class CacheOverridesManager {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private final ConcurrentMap<String, List<CacheOverrides>> overridesByCacheName = new ConcurrentHashMap<>();
+
+
+  public CacheOverridesManager(SolrZkClient zkClient) {
+    byte[] clusterPropsBytes = null;
+    try {
+      clusterPropsBytes = zkClient.getData(ZkStateReader.CLUSTER_PROPS, new Watcher() {
+        @Override
+        public void process(WatchedEvent event) {
+          if (event.getType() == Event.EventType.NodeDataChanged) {
+            try {
+              // Fetch the updated cluster properties
+              byte[] data = zkClient.getData(event.getPath(), null, null, true);
+              if (data != null) {
+                Map<String, Object> clusterPropsJson =
+                        (Map<String, Object>) Utils.fromJSON(data);
+                // Process the cache overrides from cluster properties
+                processCacheOverrides(clusterPropsJson.get("cacheOverrides"));
+              }
+            } catch (Exception e) {
+              //TODO
+            }
+          }
+        }
+      }, null, true);
+    } catch (Exception e) {
+
+    }
+
+    if (clusterPropsBytes != null) {
+      Map<String, String> clusterPropsJson =
+          (Map<String, String>) Utils.fromJSON(clusterPropsBytes);
+      processCacheOverrides(clusterPropsJson.get("cacheOverrides"));
+    }
+  }
+
+  private void processCacheOverrides(Object cacheOverridesContents) {
+    if (cacheOverridesContents instanceof Map) {
+      @SuppressWarnings("unchecked")
+      List<Map<String, Object>> entries = (List<Map<String, Object>>) cacheOverridesContents;
+      for (Map<String, Object> overridesMap : entries) {
+        List<String> collectionsFilter = (List<String>) overridesMap.get("collections");
+
+
+        for (Map.Entry<String, Object> entry : overridesMap.entrySet()) {
+          if ("collections".equals(entry.getKey())) { //a special case for collection filter
+            continue;
+          }
+          String cacheName = entry.getKey();
+          Map<String, String> overrides = new HashMap<>();
+          for (Map.Entry<String, Object> propertyKv : ((Map<String, Object>) entry.getValue()).entrySet()) {
+            overrides.put(propertyKv.getKey(), String.valueOf(propertyKv.getValue()));
+          }
+          CacheOverrides cacheOverrides = new CacheOverrides(overrides, collectionsFilter == null ? null : Set.copyOf(collectionsFilter));
+          overridesByCacheName.computeIfAbsent(cacheName, k -> new java.util.ArrayList<>()).add(cacheOverrides);
+        }
+      }
+    } else {
+      log.warn("Unexpected format for cacheOverrides in cluster properties: {}", cacheOverridesContents);
+    }
+  }
+
+  public List<Map<String, String>> getOverrides(String cacheName, String collection) {
+    List<CacheOverrides> overrides = overridesByCacheName.get(cacheName);
+    if (overrides == null) {
+      return null;
+    }
+    return overrides.stream()
+        .map(override -> override.getOverrides(collection))
+        .filter(overridesMap -> overridesMap != null && !overridesMap.isEmpty())
+        .collect(Collectors.toList());
+  }
+
+  static class CacheOverrides {
+    private final Map<String, String> overrides;
+    private final Set<String> matchCollections;
+
+    public CacheOverrides(Map<String, String> overrides, Set<String> matchCollections) {
+      this.overrides = new HashMap<>(overrides);
+      this.matchCollections = matchCollections;
+    }
+
+    public Map<String, String> getOverrides(String collection) {
+      if (matchCollections == null || matchCollections.contains(collection)) {
+        return overrides;
+      } else {
+        return null;
+      }
+    }
+  }
+}

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -424,7 +424,8 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
   }
 
   @SuppressWarnings("unchecked")
-  private<K, V> SolrCache<K, V> buildCache(SolrConfig solrConfig, String cacheName, SolrCore core) {
+  private <K, V> SolrCache<K, V> buildCache(
+      SolrConfig solrConfig, String cacheName, SolrCore core) {
     CacheConfig cacheConfig;
     switch (cacheName) {
       case "fieldValueCache":
@@ -436,7 +437,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       case "queryResultCache":
         cacheConfig = solrConfig.queryResultCacheConfig;
         break;
-      default: //generic caches
+      default: // generic caches
         cacheConfig = solrConfig.userCacheConfigs.get(cacheName);
     }
 
@@ -444,13 +445,11 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       return null;
     }
 
-    //check overrides
-    List<Map<String, String>> overridesEntries = core.getCoreContainer().getCacheOverridesManager().getOverrides(cacheName, core.getCoreDescriptor().getCollectionName());
-    if (overridesEntries != null) {
-      for (Map<String, String> overrides : overridesEntries) {
-        cacheConfig = cacheConfig.withArgs(overrides);
-      }
-    }
+    // check overrides
+    cacheConfig =
+        core.getCoreContainer()
+            .getCacheOverridesManager()
+            .applyOverrides(cacheConfig, cacheName, core.getCoreDescriptor().getCollectionName());
 
     return (SolrCache<K, V>) cacheConfig.newInstance(core);
   }

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -423,6 +423,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     assert ObjectReleaseTracker.track(this);
   }
 
+  @SuppressWarnings("unchecked")
   private<K, V> SolrCache<K, V> buildCache(SolrConfig solrConfig, String cacheName, SolrCore core) {
     CacheConfig cacheConfig;
     switch (cacheName) {

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -446,10 +446,13 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     }
 
     // check overrides
-    cacheConfig =
-        core.getCoreContainer()
-            .getCacheOverridesManager()
-            .applyOverrides(cacheConfig, cacheName, core.getCoreDescriptor().getCollectionName());
+    CacheOverridesManager cacheOverridesManager =
+        core.getCoreContainer().getCacheOverridesManager();
+    if (cacheOverridesManager != null) {
+      cacheConfig =
+          cacheOverridesManager.applyOverrides(
+              cacheConfig, cacheName, core.getCoreDescriptor().getCollectionName());
+    }
 
     return (SolrCache<K, V>) cacheConfig.newInstance(core);
   }

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -381,21 +381,15 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     this.cachingEnabled = enableCache;
     if (cachingEnabled) {
       final ArrayList<SolrCache> clist = new ArrayList<>();
-      fieldValueCache =
-          solrConfig.fieldValueCacheConfig == null
-              ? null
-              : solrConfig.fieldValueCacheConfig.newInstance(core);
+      fieldValueCache = buildCache(solrConfig, "fieldValueCache", core);
       if (fieldValueCache != null) clist.add(fieldValueCache);
-      filterCache =
-          solrConfig.filterCacheConfig == null
-              ? null
-              : solrConfig.filterCacheConfig.newInstance(core);
+
+      filterCache = buildCache(solrConfig, "filterCache", core);
       if (filterCache != null) clist.add(filterCache);
-      queryResultCache =
-          solrConfig.queryResultCacheConfig == null
-              ? null
-              : solrConfig.queryResultCacheConfig.newInstance(core);
+
+      queryResultCache = buildCache(solrConfig, "queryResultCache", core);
       if (queryResultCache != null) clist.add(queryResultCache);
+
       SolrCache<Integer, Document> documentCache = docFetcher.getDocumentCache();
       if (documentCache != null) clist.add(documentCache);
 
@@ -403,8 +397,8 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
         cacheMap = NO_GENERIC_CACHES;
       } else {
         cacheMap = CollectionUtil.newHashMap(solrConfig.userCacheConfigs.size());
-        for (Map.Entry<String, CacheConfig> e : solrConfig.userCacheConfigs.entrySet()) {
-          SolrCache cache = e.getValue().newInstance(core);
+        for (String cacheName : solrConfig.userCacheConfigs.keySet()) {
+          SolrCache cache = buildCache(solrConfig, cacheName, core);
           if (cache != null) {
             cacheMap.put(cache.name(), cache);
             clist.add(cache);
@@ -427,6 +421,37 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     // do this at the end since an exception in the constructor means we won't close
     numOpens.incrementAndGet();
     assert ObjectReleaseTracker.track(this);
+  }
+
+  private<K, V> SolrCache<K, V> buildCache(SolrConfig solrConfig, String cacheName, SolrCore core) {
+    CacheConfig cacheConfig;
+    switch (cacheName) {
+      case "fieldValueCache":
+        cacheConfig = solrConfig.fieldValueCacheConfig;
+        break;
+      case "filterCache":
+        cacheConfig = solrConfig.filterCacheConfig;
+        break;
+      case "queryResultCache":
+        cacheConfig = solrConfig.queryResultCacheConfig;
+        break;
+      default: //generic caches
+        cacheConfig = solrConfig.userCacheConfigs.get(cacheName);
+    }
+
+    if (cacheConfig == null) {
+      return null;
+    }
+
+    //check overrides
+    List<Map<String, String>> overridesEntries = core.getCoreContainer().getCacheOverridesManager().getOverrides(cacheName, core.getCoreDescriptor().getCollectionName());
+    if (overridesEntries != null) {
+      for (Map<String, String> overrides : overridesEntries) {
+        cacheConfig = cacheConfig.withArgs(overrides);
+      }
+    }
+
+    return (SolrCache<K, V>) cacheConfig.newInstance(core);
   }
 
   public SolrDocumentFetcher getDocFetcher() {

--- a/solr/core/src/test/org/apache/solr/search/CacheOverridesManagerTest.java
+++ b/solr/core/src/test/org/apache/solr/search/CacheOverridesManagerTest.java
@@ -17,7 +17,6 @@ import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -29,14 +28,6 @@ public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
   @BeforeClass
   public static void beforeClass() throws Exception {
     assumeWorkingMockito();
-    initCore(
-        "solrconfig-tlog.xml",
-        "schema15.xml"); // to make Solr core available to get SolrResourceLoader
-  }
-
-  @AfterClass
-  public static void afterClass() {
-    deleteCore();
   }
 
   @Before
@@ -234,7 +225,7 @@ public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testApplyZkOverrides() throws Exception {
+  public void testApplyZkOverrides() throws InterruptedException, KeeperException {
     // test when there's no clusterprops.json in ZK
     when(mockZkClient.getData(eq(ZkStateReader.CLUSTER_PROPS), any(), any(), anyBoolean()))
         .thenThrow(new KeeperException.NoNodeException());
@@ -243,14 +234,11 @@ public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
 
     Map<String, String> args = Map.of(NAME, "filterCache", "size", "10000", "initialSize", "10");
 
-    CacheConfig config =
-        new CacheConfig(solrConfig.getResourceLoader(), CaffeineCache.class.getName(), args, null);
+    CacheConfig config = new CacheConfig(CaffeineCache.class, args, null);
     CacheConfig afterConfig =
         cacheOverridesManager.applyOverrides(config, "filterCache", "dummyCollection");
 
     assertEquals(config, afterConfig);
-    assertEquals(CaffeineCache.class, config.getCacheImplClass());
-    assertEquals(CaffeineCache.class, afterConfig.getCacheImplClass());
 
     String jsonString =
         "{\n"
@@ -269,7 +257,6 @@ public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
             + "   },\n"
             + "   {\n"
             + "     filterCache :  {\n"
-            + "       class: \"org.apache.solr.search.ThinCache\",\n"
             + "       size: 12345\n"
             + "     }\n"
             + "     collections: [ \"104H4B\" ]\n"
@@ -285,11 +272,9 @@ public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
     afterConfig = cacheOverridesManager.applyOverrides(config, "filterCache", "dummyCollection");
     assertEquals("9999", afterConfig.toMap(new HashMap<>()).get("size"));
     assertEquals("10", afterConfig.toMap(new HashMap<>()).get("initialSize")); // not overridden
-    assertEquals(CaffeineCache.class, afterConfig.getCacheImplClass());
 
     afterConfig = cacheOverridesManager.applyOverrides(config, "filterCache", "104H4B");
     assertEquals("12345", afterConfig.toMap(new HashMap<>()).get("size"));
     assertEquals("10", afterConfig.toMap(new HashMap<>()).get("initialSize")); // not overridden
-    assertEquals(ThinCache.class, afterConfig.getCacheImplClass());
   }
 }

--- a/solr/core/src/test/org/apache/solr/search/CacheOverridesManagerTest.java
+++ b/solr/core/src/test/org/apache/solr/search/CacheOverridesManagerTest.java
@@ -1,8 +1,6 @@
 package org.apache.solr.search;
 
 import static org.apache.solr.common.params.CommonParams.NAME;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
@@ -12,7 +10,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
-
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.cloud.ZkStateReader;
@@ -26,7 +23,6 @@ import org.mockito.Mockito;
 
 public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
   private SolrZkClient mockZkClient;
-
 
   @BeforeClass
   public static void beforeClass() throws Exception {

--- a/solr/core/src/test/org/apache/solr/search/CacheOverridesManagerTest.java
+++ b/solr/core/src/test/org/apache/solr/search/CacheOverridesManagerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,7 @@ public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
   }
 
   @Before
+  @Override
   public void setUp() throws Exception {
     super.setUp();
     mockZkClient = Mockito.mock(SolrZkClient.class);
@@ -64,7 +66,7 @@ public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
 
     // Stub a method to return a specific value
     when(mockZkClient.getData(eq(ZkStateReader.CLUSTER_PROPS), any(), any(), anyBoolean()))
-        .thenReturn(jsonString.getBytes());
+        .thenReturn(jsonString.getBytes(Charset.defaultCharset()));
 
     CacheOverridesManager cacheOverridesManager = new CacheOverridesManager(mockZkClient);
 
@@ -140,7 +142,7 @@ public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
             + "}";
 
     when(mockZkClient.getData(eq(ZkStateReader.CLUSTER_PROPS), any(), any(), anyBoolean()))
-        .thenReturn(jsonString.getBytes());
+        .thenReturn(jsonString.getBytes(Charset.defaultCharset()));
     watcherRef
         .get()
         .process(
@@ -176,7 +178,7 @@ public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
             + "}";
 
     when(mockZkClient.getData(eq(ZkStateReader.CLUSTER_PROPS), any(), any(), anyBoolean()))
-        .thenReturn(jsonString.getBytes());
+        .thenReturn(jsonString.getBytes(Charset.defaultCharset()));
     watcherRef
         .get()
         .process(
@@ -199,7 +201,7 @@ public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
     // emulate overrides removed from clusterprops.json
     jsonString = "{ legacyCloud : \"false\" }";
     when(mockZkClient.getData(eq(ZkStateReader.CLUSTER_PROPS), any(), any(), anyBoolean()))
-        .thenReturn(jsonString.getBytes());
+        .thenReturn(jsonString.getBytes(Charset.defaultCharset()));
     watcherRef
         .get()
         .process(
@@ -263,7 +265,7 @@ public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
             + " \n"
             + "}";
     when(mockZkClient.getData(eq(ZkStateReader.CLUSTER_PROPS), any(), any(), anyBoolean()))
-        .thenReturn(jsonString.getBytes());
+        .thenReturn(jsonString.getBytes(Charset.defaultCharset()));
 
     cacheOverridesManager = new CacheOverridesManager(mockZkClient);
 

--- a/solr/core/src/test/org/apache/solr/search/CacheOverridesManagerTest.java
+++ b/solr/core/src/test/org/apache/solr/search/CacheOverridesManagerTest.java
@@ -1,0 +1,272 @@
+package org.apache.solr.search;
+
+import static org.apache.solr.common.params.CommonParams.NAME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.solr.common.cloud.SolrZkClient;
+import org.apache.solr.common.cloud.ZkStateReader;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class CacheOverridesManagerTest {
+  private SolrZkClient mockZkClient;
+
+  @Before
+  public void setUp() {
+    mockZkClient = Mockito.mock(SolrZkClient.class);
+  }
+
+  @Test
+  public void testGetOverrides() throws InterruptedException, KeeperException {
+    String jsonString =
+        "{\n"
+            + " legacyCloud: \"false\",\n"
+            + " cacheOverrides : [ \n"
+            + "   {\n"
+            + "     filterCache :  {\n"
+            + "       size: 9999\n"
+            + "     }\n"
+            + "     documentCache : {\n"
+            + "       size: 8888    \n"
+            + "     }\n"
+            + "     fs-cache : {\n"
+            + "       maxRamMB: 7777\n"
+            + "     }\n"
+            + "   },\n"
+            + "   {\n"
+            + "     filterCache :  {\n"
+            + "       size: 12345\n"
+            + "     }\n"
+            + "     collections: [ \"104H4B\" ]\n"
+            + "   }\n"
+            + " ]\n"
+            + " \n"
+            + "}";
+
+    // Stub a method to return a specific value
+    when(mockZkClient.getData(eq(ZkStateReader.CLUSTER_PROPS), any(), any(), anyBoolean()))
+        .thenReturn(jsonString.getBytes());
+
+    CacheOverridesManager cacheOverridesManager = new CacheOverridesManager(mockZkClient);
+
+    List<Map<String, String>> overrides;
+    overrides = cacheOverridesManager.getOverrides("filterCache", "dummyCollection");
+    assertEquals(1, overrides.size());
+    assertEquals("9999", overrides.get(0).get("size"));
+
+    overrides = cacheOverridesManager.getOverrides("documentCache", "dummyCollection");
+    assertEquals(1, overrides.size());
+    assertEquals("8888", overrides.get(0).get("size"));
+
+    overrides = cacheOverridesManager.getOverrides("fs-cache", "dummyCollection");
+    assertEquals(1, overrides.size());
+    assertEquals("7777", overrides.get(0).get("maxRamMB"));
+
+    overrides = cacheOverridesManager.getOverrides("unknown-cache", "dummyCollection");
+    assertNull(overrides);
+
+    overrides = cacheOverridesManager.getOverrides("filterCache", "104H4B");
+    assertEquals(2, overrides.size());
+    assertEquals("9999", overrides.get(0).get("size"));
+    assertEquals("12345", overrides.get(1).get("size"));
+
+    overrides = cacheOverridesManager.getOverrides("documentCache", "104H4B");
+    assertEquals(1, overrides.size());
+    assertEquals("8888", overrides.get(0).get("size"));
+
+    overrides = cacheOverridesManager.getOverrides("fs-cache", "104H4B");
+    assertEquals(1, overrides.size());
+    assertEquals("7777", overrides.get(0).get("maxRamMB"));
+
+    overrides = cacheOverridesManager.getOverrides("unknown-cache", "dummyCollection");
+    assertNull(overrides);
+  }
+
+  @Test
+  public void testOverridesZkChanges() throws InterruptedException, KeeperException {
+    // start with no clusterprops.json in ZK
+    AtomicReference<Watcher> watcherRef = new AtomicReference<>();
+    Mockito.doAnswer(
+            invocation -> {
+              watcherRef.set(invocation.getArgument(1));
+              throw new KeeperException.NoNodeException();
+            })
+        .when(mockZkClient)
+        .getData(eq(ZkStateReader.CLUSTER_PROPS), any(), any(), Mockito.anyBoolean());
+
+    CacheOverridesManager cacheOverridesManager = new CacheOverridesManager(mockZkClient);
+
+    List<Map<String, String>> overrides;
+    overrides = cacheOverridesManager.getOverrides("filterCache", "dummy");
+    assertNull(overrides);
+
+    // emulate new clusterprops.json in ZK
+    String jsonString =
+        "{\n"
+            + " legacyCloud: \"false\",\n"
+            + " cacheOverrides : [ \n"
+            + "   {\n"
+            + "     filterCache :  {\n"
+            + "       size: 9999\n"
+            + "     }\n"
+            + "   },\n"
+            + "   {\n"
+            + "     filterCache :  {\n"
+            + "       size: 12345\n"
+            + "     }\n"
+            + "     collections: [ \"104H4B\" ]\n"
+            + "   }\n"
+            + " ]\n"
+            + " \n"
+            + "}";
+
+    when(mockZkClient.getData(eq(ZkStateReader.CLUSTER_PROPS), any(), any(), anyBoolean()))
+        .thenReturn(jsonString.getBytes());
+    watcherRef
+        .get()
+        .process(
+            new WatchedEvent(
+                Watcher.Event.EventType.NodeCreated,
+                Watcher.Event.KeeperState.SyncConnected,
+                ZkStateReader.CLUSTER_PROPS));
+
+    overrides = cacheOverridesManager.getOverrides("filterCache", "104H4B");
+    assertEquals(2, overrides.size());
+    assertEquals("9999", overrides.get(0).get("size"));
+    assertEquals("12345", overrides.get(1).get("size"));
+
+    // emulate changes in ZK
+    jsonString =
+        "{\n"
+            + " legacyCloud: \"false\",\n"
+            + " cacheOverrides : [ \n"
+            + "   {\n"
+            + "     filterCache :  {\n"
+            + "       size: 1111\n"
+            + "     }\n"
+            + "     collections: [ \"104H4B\" ]\n"
+            + "   },\n"
+            + "   {\n"
+            + "     filterCache :  {\n"
+            + "       size: 2222\n"
+            + "     }\n"
+            + "     collections: [ \"local\" ]\n"
+            + "   }\n"
+            + " ]\n"
+            + " \n"
+            + "}";
+
+    when(mockZkClient.getData(eq(ZkStateReader.CLUSTER_PROPS), any(), any(), anyBoolean()))
+        .thenReturn(jsonString.getBytes());
+    watcherRef
+        .get()
+        .process(
+            new WatchedEvent(
+                Watcher.Event.EventType.NodeDataChanged,
+                Watcher.Event.KeeperState.SyncConnected,
+                ZkStateReader.CLUSTER_PROPS));
+
+    overrides = cacheOverridesManager.getOverrides("filterCache", "dummy");
+    assertNull(overrides);
+
+    overrides = cacheOverridesManager.getOverrides("filterCache", "104H4B");
+    assertEquals(1, overrides.size());
+    assertEquals("1111", overrides.get(0).get("size"));
+
+    overrides = cacheOverridesManager.getOverrides("filterCache", "local");
+    assertEquals(1, overrides.size());
+    assertEquals("2222", overrides.get(0).get("size"));
+
+    // emulate overrides removed from clusterprops.json
+    jsonString = "{ legacyCloud : \"false\" }";
+    when(mockZkClient.getData(eq(ZkStateReader.CLUSTER_PROPS), any(), any(), anyBoolean()))
+        .thenReturn(jsonString.getBytes());
+    watcherRef
+        .get()
+        .process(
+            new WatchedEvent(
+                Watcher.Event.EventType.NodeDataChanged,
+                Watcher.Event.KeeperState.SyncConnected,
+                ZkStateReader.CLUSTER_PROPS));
+    overrides = cacheOverridesManager.getOverrides("filterCache", "104H4B");
+    assertNull(overrides);
+
+    // emulate clusterprops.json deleted
+    watcherRef
+        .get()
+        .process(
+            new WatchedEvent(
+                Watcher.Event.EventType.NodeDeleted,
+                Watcher.Event.KeeperState.SyncConnected,
+                ZkStateReader.CLUSTER_PROPS));
+    overrides = cacheOverridesManager.getOverrides("filterCache", "104H4B");
+    assertNull(overrides);
+  }
+
+  @Test
+  public void testApplyZkOverrides() throws InterruptedException, KeeperException {
+    // test when there's no clusterprops.json in ZK
+    when(mockZkClient.getData(eq(ZkStateReader.CLUSTER_PROPS), any(), any(), anyBoolean()))
+        .thenThrow(new KeeperException.NoNodeException());
+
+    CacheOverridesManager cacheOverridesManager = new CacheOverridesManager(mockZkClient);
+
+    Map<String, String> args = Map.of(NAME, "filterCache", "size", "10000", "initialSize", "10");
+
+    CacheConfig config = new CacheConfig(CaffeineCache.class, args, null);
+    CacheConfig afterConfig =
+        cacheOverridesManager.applyOverrides(config, "filterCache", "dummyCollection");
+
+    assertEquals(config, afterConfig);
+
+    String jsonString =
+        "{\n"
+            + " legacyCloud: \"false\",\n"
+            + " cacheOverrides : [ \n"
+            + "   {\n"
+            + "     filterCache :  {\n"
+            + "       size: 9999\n"
+            + "     }\n"
+            + "     documentCache : {\n"
+            + "       size: 8888    \n"
+            + "     }\n"
+            + "     fs-cache : {\n"
+            + "       maxRamMB: 7777\n"
+            + "     }\n"
+            + "   },\n"
+            + "   {\n"
+            + "     filterCache :  {\n"
+            + "       size: 12345\n"
+            + "     }\n"
+            + "     collections: [ \"104H4B\" ]\n"
+            + "   }\n"
+            + " ]\n"
+            + " \n"
+            + "}";
+    when(mockZkClient.getData(eq(ZkStateReader.CLUSTER_PROPS), any(), any(), anyBoolean()))
+        .thenReturn(jsonString.getBytes());
+
+    cacheOverridesManager = new CacheOverridesManager(mockZkClient);
+
+    afterConfig = cacheOverridesManager.applyOverrides(config, "filterCache", "dummyCollection");
+    assertEquals("9999", afterConfig.toMap(new HashMap<>()).get("size"));
+    assertEquals("10", afterConfig.toMap(new HashMap<>()).get("initialSize")); // not overridden
+
+    afterConfig = cacheOverridesManager.applyOverrides(config, "filterCache", "104H4B");
+    assertEquals("12345", afterConfig.toMap(new HashMap<>()).get("size"));
+    assertEquals("10", afterConfig.toMap(new HashMap<>()).get("initialSize")); // not overridden
+  }
+}

--- a/solr/core/src/test/org/apache/solr/search/CacheOverridesManagerTest.java
+++ b/solr/core/src/test/org/apache/solr/search/CacheOverridesManagerTest.java
@@ -34,7 +34,8 @@ public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
   }
 
   @Before
-  public void setUp() {
+  public void setUp() throws Exception {
+    super.setUp();
     mockZkClient = Mockito.mock(SolrZkClient.class);
   }
 

--- a/solr/core/src/test/org/apache/solr/search/CacheOverridesManagerTest.java
+++ b/solr/core/src/test/org/apache/solr/search/CacheOverridesManagerTest.java
@@ -17,6 +17,7 @@ import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -28,6 +29,14 @@ public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
   @BeforeClass
   public static void beforeClass() throws Exception {
     assumeWorkingMockito();
+    initCore(
+        "solrconfig-tlog.xml",
+        "schema15.xml"); // to make Solr core available to get SolrResourceLoader
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    deleteCore();
   }
 
   @Before
@@ -225,7 +234,7 @@ public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
   }
 
   @Test
-  public void testApplyZkOverrides() throws InterruptedException, KeeperException {
+  public void testApplyZkOverrides() throws Exception {
     // test when there's no clusterprops.json in ZK
     when(mockZkClient.getData(eq(ZkStateReader.CLUSTER_PROPS), any(), any(), anyBoolean()))
         .thenThrow(new KeeperException.NoNodeException());
@@ -234,11 +243,14 @@ public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
 
     Map<String, String> args = Map.of(NAME, "filterCache", "size", "10000", "initialSize", "10");
 
-    CacheConfig config = new CacheConfig(CaffeineCache.class, args, null);
+    CacheConfig config =
+        new CacheConfig(solrConfig.getResourceLoader(), CaffeineCache.class.getName(), args, null);
     CacheConfig afterConfig =
         cacheOverridesManager.applyOverrides(config, "filterCache", "dummyCollection");
 
     assertEquals(config, afterConfig);
+    assertEquals(CaffeineCache.class, config.getCacheImplClass());
+    assertEquals(CaffeineCache.class, afterConfig.getCacheImplClass());
 
     String jsonString =
         "{\n"
@@ -257,6 +269,7 @@ public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
             + "   },\n"
             + "   {\n"
             + "     filterCache :  {\n"
+            + "       class: \"org.apache.solr.search.ThinCache\",\n"
             + "       size: 12345\n"
             + "     }\n"
             + "     collections: [ \"104H4B\" ]\n"
@@ -272,9 +285,11 @@ public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
     afterConfig = cacheOverridesManager.applyOverrides(config, "filterCache", "dummyCollection");
     assertEquals("9999", afterConfig.toMap(new HashMap<>()).get("size"));
     assertEquals("10", afterConfig.toMap(new HashMap<>()).get("initialSize")); // not overridden
+    assertEquals(CaffeineCache.class, afterConfig.getCacheImplClass());
 
     afterConfig = cacheOverridesManager.applyOverrides(config, "filterCache", "104H4B");
     assertEquals("12345", afterConfig.toMap(new HashMap<>()).get("size"));
     assertEquals("10", afterConfig.toMap(new HashMap<>()).get("initialSize")); // not overridden
+    assertEquals(ThinCache.class, afterConfig.getCacheImplClass());
   }
 }

--- a/solr/core/src/test/org/apache/solr/search/CacheOverridesManagerTest.java
+++ b/solr/core/src/test/org/apache/solr/search/CacheOverridesManagerTest.java
@@ -12,17 +12,26 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.cloud.SolrZkClient;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-public class CacheOverridesManagerTest {
+public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
   private SolrZkClient mockZkClient;
+
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    assumeWorkingMockito();
+  }
 
   @Before
   public void setUp() {


### PR DESCRIPTION
## Description
Cache config is loaded on process startup, it cannot be changed unless the process is restarted.

We are proposing changes such that cache config can be overridden by `clusterprops.json` value in ZK, and example:
```
{
...
 cacheOverrides : [ 
   {
     filterCache :  {
       class: "mn.fs.solr.sharedcache.MemBoundedCache",
       size: 9999
     }
     documentCache : {
       size: 9999    
     }
     fs-cache : {
       maxRamMB: 9999
     }
   },
   {
     filterCache :  {
       size: 12345
     }
     collections: [ "104H4B" ]
   }
 ]
}
```

Take note that there's an optional `collections` kv in the entry to indicate a "collection filter", only cores with collection matching any value in the filter will get the corresponding entry.

If there are multiple entry matches, each override will be applied to the `CacheConfig` according to the ordering declared in the json array.

## Solution
1. Created a new `CacheOverridesManager`, which manages the overrides. It keeps the current map of overrides and listen to ZK for changes.
2. `CoreContainer` create an instance of `CacheOverridesManager` along with other existing managers
3. Refactored `CacheConfig -> Cache instantiation` logic to centralize the flow. Then call the `CacheOverridesManager` manager to apply overrides if applicable.
4. Changed CacheConfig instantiation to always keep a reference of loader in case later change requires reloading class resource

Take note that this means only Cache created after the ZK change will see the config changes. Therefore in our shared cache usage, the core local "key" cache will see the new `PerCore/partition` param on open searcher (after commits), but the backing shared cache will only see the change after process restart since such cache only get created once on first access `AbstractSharedCache` under each cache name (filterCache, documentCache etc)

## Tests
1. Debugged locally to ensure local cache instantiation use the new overrides
   i. Test partition size changes - should take effect w/o restart
   ii. Test class change - should take effect w/o restart
   iii. Test size change - only take affect after restart
2. Unit test cases
3. Deployed with branch (https://github.com/cowpaths/fullstory-solr/tree/patsonluk/SAI-5661-cache-override-9-7 based on fs/branch_9_7) to playpen:
   1. Added cache config override to `clusterprops.json`, and verified in log`2025-07-01 18:29:14.305 INFO  (zkCallback-15-thread-120) [c: s: r: x: rid:] o.a.s.s.CacheOverridesManager Cache overrides updated to {filterCache=[CacheOverrides{overrides={partitionSize=512}, matchCollections=null}, CacheOverrides{overrides={partitionSize=1024}, matchCollections=[local]}], fs-cache=[CacheOverrides{overrides={maxRamMB=2048}, matchCollections=null}]}`
   3. Issued query with filter to ensure no issues
   4. Removed the cache config override and verified in log again `2025-07-01 18:32:53.067 INFO  (zkCallback-15-thread-122) [c: s: r: x: rid:] o.a.s.s.CacheOverridesManager Cleared cache overrides`
  