### PR TITLE
SAI-5668 : Add Prometheus metics for local evictions for cache

### DIFF
--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -857,7 +857,25 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
         "background_requests_delay_p99",
         "background request p99 duration",
         "p99_ms",
-        PrometheusMetricType.GAUGE);
+        PrometheusMetricType.GAUGE),
+    CUMULATIVE_DOCUMENT_CACHE_LOCAL_EVICTION(
+            "CACHE.searcher.documentCache",
+            "document_cache_store_local_eviction",
+            "Cumulative evictions from the per core local document cache store (vs backing shared cache store)",
+            "cumulative_evictions",
+            PrometheusMetricType.GAUGE),
+    CUMULATIVE_FILTER_CACHE_LOCAL_EVICTION(
+            "CACHE.searcher.filterCache",
+            "filter_cache_store_local_eviction",
+            "Cumulative evictions from the per core local filter cache store (vs backing shared cache store)",
+            "cumulative_evictions",
+            PrometheusMetricType.GAUGE),
+    CUMULATIVE_QUERY_RESULT_CACHE_LOCAL_EVICTION(
+            "CACHE.searcher.queryResultCache",
+            "query_result_cache_store_local_eviction",
+            "Cumulative evictions from the per core local query result cache store (vs backing shared cache store)",
+            "cumulative_evictions",
+            PrometheusMetricType.GAUGE);
     final String key, metricName, desc, property;
     private final PrometheusMetricType metricType;
     private static final Map<String, CoreMetric> lookup = new HashMap<>();
@@ -997,11 +1015,12 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
       }
 
       String propertyClause =
-          String.join(
-              "&property=",
               properties.stream()
-                  .map(p -> URLEncoder.encode(p, StandardCharsets.UTF_8))
-                  .collect(Collectors.toSet()));
+                      .distinct()
+                      .map(p -> "&property=" + URLEncoder.encode(p, StandardCharsets.UTF_8))
+                      .collect(Collectors.joining());
+
+
       return String.format(
           Locale.ROOT,
           "wt=json&indent=false&compact=true&group=%s&prefix=%s%s",

--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -863,19 +863,19 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
             "document_cache_store_local_eviction",
             "Cumulative evictions from the per core local document cache store (vs backing shared cache store)",
             "cumulative_evictions",
-            PrometheusMetricType.GAUGE),
+            PrometheusMetricType.COUNTER),
     CUMULATIVE_FILTER_CACHE_LOCAL_EVICTION(
             "CACHE.searcher.filterCache",
             "filter_cache_store_local_eviction",
             "Cumulative evictions from the per core local filter cache store (vs backing shared cache store)",
             "cumulative_evictions",
-            PrometheusMetricType.GAUGE),
+            PrometheusMetricType.COUNTER),
     CUMULATIVE_QUERY_RESULT_CACHE_LOCAL_EVICTION(
             "CACHE.searcher.queryResultCache",
             "query_result_cache_store_local_eviction",
             "Cumulative evictions from the per core local query result cache store (vs backing shared cache store)",
             "cumulative_evictions",
-            PrometheusMetricType.GAUGE);
+            PrometheusMetricType.COUNTER);
     final String key, metricName, desc, property;
     private final PrometheusMetricType metricType;
     private static final Map<String, CoreMetric> lookup = new HashMap<>();

--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -859,23 +859,23 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
         "p99_ms",
         PrometheusMetricType.GAUGE),
     CUMULATIVE_DOCUMENT_CACHE_LOCAL_EVICTION(
-            "CACHE.searcher.documentCache",
-            "document_cache_store_local_eviction",
-            "Cumulative evictions from the per core local document cache store (vs backing shared cache store)",
-            "cumulative_evictions",
-            PrometheusMetricType.COUNTER),
+        "CACHE.searcher.documentCache",
+        "document_cache_store_local_eviction",
+        "Cumulative evictions from the per core local document cache store (vs backing shared cache store)",
+        "cumulative_evictions",
+        PrometheusMetricType.COUNTER),
     CUMULATIVE_FILTER_CACHE_LOCAL_EVICTION(
-            "CACHE.searcher.filterCache",
-            "filter_cache_store_local_eviction",
-            "Cumulative evictions from the per core local filter cache store (vs backing shared cache store)",
-            "cumulative_evictions",
-            PrometheusMetricType.COUNTER),
+        "CACHE.searcher.filterCache",
+        "filter_cache_store_local_eviction",
+        "Cumulative evictions from the per core local filter cache store (vs backing shared cache store)",
+        "cumulative_evictions",
+        PrometheusMetricType.COUNTER),
     CUMULATIVE_QUERY_RESULT_CACHE_LOCAL_EVICTION(
-            "CACHE.searcher.queryResultCache",
-            "query_result_cache_store_local_eviction",
-            "Cumulative evictions from the per core local query result cache store (vs backing shared cache store)",
-            "cumulative_evictions",
-            PrometheusMetricType.COUNTER);
+        "CACHE.searcher.queryResultCache",
+        "query_result_cache_store_local_eviction",
+        "Cumulative evictions from the per core local query result cache store (vs backing shared cache store)",
+        "cumulative_evictions",
+        PrometheusMetricType.COUNTER);
     final String key, metricName, desc, property;
     private final PrometheusMetricType metricType;
     private static final Map<String, CoreMetric> lookup = new HashMap<>();
@@ -1015,11 +1015,10 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
       }
 
       String propertyClause =
-              properties.stream()
-                      .distinct()
-                      .map(p -> "&property=" + URLEncoder.encode(p, StandardCharsets.UTF_8))
-                      .collect(Collectors.joining());
-
+          properties.stream()
+              .distinct()
+              .map(p -> "&property=" + URLEncoder.encode(p, StandardCharsets.UTF_8))
+              .collect(Collectors.joining());
 
       return String.format(
           Locale.ROOT,


### PR DESCRIPTION
## Description
Currently our `PrometheusServlet` does not expose eviction on local cache key (vs the global shared cache, why does have existing metrics)

In particular, we are interested in the eviction triggered by local cache key size (per core entries)

## Solution
1. Added in `PrometheusServlet` eviction metrics on `filterCache`, `documentCache` and `queryResultCache`. Take note that we are extracting it from the core metrics's `cumulative_evictions`. This is the cumulative eviction done on such core for the local key. Which is precisely what we want.
2. Fixed property clause string construction for core metrics

## Test
Test done locally to ensure the per core `cumulative_evictions` is the value we want. By setting

```
<filterCache class="mn.fs.solr.sharedcache.CaffeineCache"
            size="1024"
            initialSize="1024"
            partitionSize="1"
            autowarmCount="0"
            enabled="${solr.fs.enableCaches:true}"/>
```

which the filter cache local key is size of 1. Then issuing query such as
http://localhost:8983/solr/local/select?fq=IndvSample%3A%5B0%20TO%2096%5D&fq=Kind%3Aindv&fq=UserAppKey%3A1*&indent=true&q.op=OR&q=*%3A*&useParams=

with 3 filters, so such query should cause 2 local key eviction

By forcing several hard commits, we found in http://localhost:8983/solr/admin/metrics?compact=true&indent=false&prefix=CACHE.searcher.filterCache&wt=json&group=core

that 

```
"solr.core.local.shard1.replica_n3":{"CACHE.searcher.filterCache":{"lookups":3,"hits":0,"hitratio":0.0,"inserts":3,"evictions":2,"size":1,"bytesUsed":4176,"warmupTime":0,"cumulative_lookups":15,"cumulative_hits":0,"cumulative_hitratio":0.0,"cumulative_inserts":15,"cumulative_evictions":10,"cumulative_bytesUsed":4176}},"
```

`evictions` is the current cache's local eviction count while `cumulative_evictions` is the cumulative eviction on the local key cache (should not be shared, as that one has 1024 size)
