### PR TITLE
SAI-5661 - Cache config override driven by clusterprops.json in ZK (Cherry pick to 9_7)

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -142,6 +142,7 @@ import org.apache.solr.pkg.SolrPackageLoader;
 import org.apache.solr.request.SolrRequestHandler;
 import org.apache.solr.request.SolrRequestInfo;
 import org.apache.solr.search.CacheConfig;
+import org.apache.solr.search.CacheOverridesManager;
 import org.apache.solr.search.SolrCache;
 import org.apache.solr.search.SolrFieldCacheBean;
 import org.apache.solr.security.AllowListUrlChecker;
@@ -310,6 +311,8 @@ public class CoreContainer {
   private final Set<Path> allowPaths;
 
   private final AllowListUrlChecker allowListUrlChecker;
+
+  private volatile CacheOverridesManager cacheOverridesManager;
 
   // Bits for the state variable.
   public static final long LOAD_COMPLETE = 0x1L;
@@ -1040,6 +1043,10 @@ public class CoreContainer {
       metricManager.loadClusterReporters(metricReporters, this);
     }
 
+    if (getZkController() != null) {
+      cacheOverridesManager = new CacheOverridesManager(zkClientSupplier.get());
+    }
+
     // setup executor to load cores in parallel
     ExecutorService coreLoadExecutor =
         MetricUtils.instrumentedExecutorService(
@@ -1704,6 +1711,10 @@ public class CoreContainer {
   /** Gets the URLs checker based on the {@code allowUrls} configuration of solr.xml. */
   public AllowListUrlChecker getAllowListUrlChecker() {
     return allowListUrlChecker;
+  }
+
+  public CacheOverridesManager getCacheOverridesManager() {
+    return cacheOverridesManager;
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/search/CacheConfig.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheConfig.java
@@ -199,6 +199,25 @@ public class CacheConfig implements MapSerializable {
     return new HashMap<>(args);
   }
 
+  /**
+   * Returns a CacheConfig with the given arguments merged into the existing ones. <br>
+   * The existing config should not be modified
+   *
+   * @param newArgs new arguments to merge into the existing config, overrides existing values
+   */
+  public CacheConfig withArgs(Map<String, String> newArgs) {
+    if (newArgs == null || newArgs.isEmpty()) {
+      return this;
+    }
+    if (this.args == null) {
+      return new CacheConfig(this.clazz.get(), new HashMap<>(newArgs), this.regenerator);
+    } else {
+      Map<String, String> finalArgs = new HashMap<>(this.args);
+      finalArgs.putAll(newArgs);
+      return new CacheConfig(this.clazz.get(), finalArgs, this.regenerator);
+    }
+  }
+
   public String getNodeName() {
     return nodeName;
   }

--- a/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
@@ -1,0 +1,222 @@
+package org.apache.solr.search;
+
+import java.lang.invoke.MethodHandles;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.solr.common.cloud.SolrZkClient;
+import org.apache.solr.common.cloud.ZkStateReader;
+import org.apache.solr.common.util.Utils;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A manager that gets and subscribes to ZK clusterprops.json on field "cacheOverrides" <br>
+ * <br>
+ * The value of the field defines a list of cache overrides, each override is a map with cache name
+ * as key and a map of properties as value. An extra "collections" key can be used to apply the
+ * overrides only to specific collections. <br>
+ * <br>
+ * The override will only be effective if the cache is re-instantiated. Therefore, some backing
+ * shared caches that only instantiate on startup might only see the overrides after process
+ * restart, while some transient caches such as local core cache will see the new values on searcher
+ * reopening without restart. <br>
+ * <br>
+ * Take note that overrides do NOT work on below properties: <br>
+ *
+ * <ol>
+ *   <li>class
+ *   <li>regenerator
+ * </ol>
+ *
+ * <br>
+ * Example of the override config in clusterprops.json: <br>
+ *
+ * <pre>
+ *   {
+ * ...
+ *  cacheOverrides : [
+ *    {
+ *      filterCache :  {
+ *        size: 9999
+ *      }
+ *      documentCache : {
+ *        size: 9999
+ *      }
+ *      fs-cache : {
+ *        maxRamMB: 9999
+ *      }
+ *    },
+ *    {
+ *      filterCache :  {
+ *        size: 12345
+ *      }
+ *      collections: [ "104H4B" ]
+ *    }
+ *  ]
+ *
+ * }
+ * </pre>
+ *
+ * Entries will be applied as overrides according to the order declared in the array. Hence, later
+ * entry overrides earlier for overlaps
+ */
+@SuppressWarnings("unchecked")
+public class CacheOverridesManager {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private volatile Map<String, List<CacheOverrides>> overridesByCacheName = Map.of();
+
+  public CacheOverridesManager(SolrZkClient zkClient) {
+    byte[] clusterPropsBytes = null;
+
+    final Watcher watcher =
+        new Watcher() {
+          @Override
+          public void process(WatchedEvent event) {
+            try {
+              if (event.getType() == Event.EventType.NodeDataChanged
+                  || event.getType() == Event.EventType.NodeCreated) {
+                // Fetch the updated cluster properties
+                byte[] data = zkClient.getData(event.getPath(), this, null, true);
+                if (data != null) {
+                  Map<String, Object> clusterPropsJson = (Map<String, Object>) Utils.fromJSON(data);
+                  // Process the cache overrides from cluster properties
+                  processCacheOverrides(clusterPropsJson.get("cacheOverrides"));
+                } else {
+                  processCacheOverrides(null);
+                }
+              } else if (event.getType() == Event.EventType.NodeDeleted) {
+                zkClient.exists(event.getPath(), this, true);
+                processCacheOverrides(null);
+              } else {
+                // just re-install watcher
+                zkClient.exists(event.getPath(), this, true);
+              }
+            } catch (Exception e) {
+              log.warn("Error processing cache overrides from ZooKeeper", e);
+            }
+          }
+        };
+
+    try {
+      clusterPropsBytes = zkClient.getData(ZkStateReader.CLUSTER_PROPS, watcher, null, true);
+    } catch (KeeperException.NoNodeException e) {
+      try {
+        zkClient.exists(ZkStateReader.CLUSTER_PROPS, watcher, true); // still install a watcher
+      } catch (Exception ex) {
+        log.warn("Error installing exist watcher on cluster properties from ZooKeeper", e);
+      }
+    } catch (Exception e) {
+      log.warn("Error fetching cluster properties from ZooKeeper", e);
+    }
+
+    if (clusterPropsBytes != null) {
+      Map<String, String> clusterPropsJson =
+          (Map<String, String>) Utils.fromJSON(clusterPropsBytes);
+      processCacheOverrides(clusterPropsJson.get("cacheOverrides"));
+    }
+  }
+
+  private void processCacheOverrides(Object cacheOverridesContents) {
+    if (cacheOverridesContents instanceof List) {
+      @SuppressWarnings("unchecked")
+      List<Map<String, Object>> entries = (List<Map<String, Object>>) cacheOverridesContents;
+      Map<String, List<CacheOverrides>> newOverridesByCacheName = new HashMap<>();
+      for (Map<String, Object> overridesMap : entries) {
+        List<String> collectionsFilter = (List<String>) overridesMap.get("collections");
+
+        for (Map.Entry<String, Object> entry : overridesMap.entrySet()) {
+          if ("collections".equals(entry.getKey())) { // a special case for collection filter
+            continue;
+          }
+          String cacheName = entry.getKey();
+          Map<String, String> overrides = new HashMap<>();
+          for (Map.Entry<String, Object> propertyKv :
+              ((Map<String, Object>) entry.getValue()).entrySet()) {
+            overrides.put(propertyKv.getKey(), String.valueOf(propertyKv.getValue()));
+          }
+          CacheOverrides cacheOverrides =
+              new CacheOverrides(
+                  overrides, collectionsFilter == null ? null : Set.copyOf(collectionsFilter));
+          newOverridesByCacheName
+              .computeIfAbsent(cacheName, k -> new java.util.ArrayList<>())
+              .add(cacheOverrides);
+        }
+      }
+
+      overridesByCacheName = Map.copyOf(newOverridesByCacheName);
+      log.info("Cache overrides updated to {}", overridesByCacheName);
+
+    } else if (cacheOverridesContents == null) { // overrides removal
+      overridesByCacheName = Map.of();
+      log.info("Cleared cache overrides");
+    } else {
+      log.warn(
+          "Unexpected format for cacheOverrides in cluster properties: {}", cacheOverridesContents);
+    }
+  }
+
+  /**
+   * Applies the overrides to the given cache configuration.
+   *
+   * @param cacheConfig the existing cache config
+   * @param cacheName the name of the cache to apply overrides for (filterCache, documentCache etc)
+   * @param collection the collection name of this cache
+   * @return existing config if no overrides otherwise a new config with overrides applied
+   */
+  public CacheConfig applyOverrides(CacheConfig cacheConfig, String cacheName, String collection) {
+    List<Map<String, String>> overridesEntries = getOverrides(cacheName, collection);
+    if (overridesEntries != null) {
+      for (Map<String, String> overrides : overridesEntries) {
+        cacheConfig = cacheConfig.withArgs(overrides);
+      }
+    }
+    return cacheConfig;
+  }
+
+  List<Map<String, String>> getOverrides(String cacheName, String collection) {
+    List<CacheOverrides> overrides = overridesByCacheName.get(cacheName);
+    if (overrides == null) {
+      return null;
+    }
+    List<Map<String, String>> result =
+        overrides.stream()
+            .map(override -> override.getOverrides(collection))
+            .filter(overridesMap -> overridesMap != null && !overridesMap.isEmpty())
+            .collect(Collectors.toList());
+    return result.isEmpty() ? null : result;
+  }
+
+  static class CacheOverrides {
+    private final Map<String, String> overrides;
+    private final Set<String> matchCollections;
+
+    public CacheOverrides(Map<String, String> overrides, Set<String> matchCollections) {
+      this.overrides = new HashMap<>(overrides);
+      this.matchCollections = matchCollections;
+    }
+
+    public Map<String, String> getOverrides(String collection) {
+      if (matchCollections == null || matchCollections.contains(collection)) {
+        return overrides;
+      } else {
+        return null;
+      }
+    }
+
+    @Override
+    public String toString() {
+      return "CacheOverrides{"
+          + "overrides="
+          + overrides
+          + ", matchCollections="
+          + matchCollections
+          + '}';
+    }
+  }
+}

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -388,21 +388,15 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       final ArrayList<SolrCache> clist = new ArrayList<>();
       clist.add(ordMapCache.toInternal());
       fieldValueCache =
-          solrConfig.fieldValueCacheConfig == null
-              ? null
-              : solrConfig.fieldValueCacheConfig.newInstance(core);
+          buildCache(solrConfig, "fieldValueCache", core);
       if (fieldValueCache != null) {
         clist.add(fieldValueCache.toInternal());
       }
-      filterCache =
-          solrConfig.filterCacheConfig == null
-              ? null
-              : solrConfig.filterCacheConfig.newInstance(core);
+
+      filterCache = buildCache(solrConfig, "filterCache", core);
       if (filterCache != null) clist.add(filterCache.toInternal());
-      queryResultCache =
-          solrConfig.queryResultCacheConfig == null
-              ? null
-              : solrConfig.queryResultCacheConfig.newInstance(core);
+
+      queryResultCache = buildCache(solrConfig, "queryResultCache", core);
       if (queryResultCache != null) {
         clist.add(queryResultCache.toInternal());
       }
@@ -413,9 +407,8 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
         cacheMap = NO_GENERIC_CACHES;
       } else {
         cacheMap = CollectionUtil.newHashMap(solrConfig.userCacheConfigs.size());
-        for (Map.Entry<String, CacheConfig> e : solrConfig.userCacheConfigs.entrySet()) {
-          CacheConfig config = e.getValue();
-          SolrCache<?, ?> cache = config.newInstance(core);
+        for (String cacheName : solrConfig.userCacheConfigs.keySet()) {
+          SolrCache cache = buildCache(solrConfig, cacheName, core);
           if (cache != null) {
             cacheMap.put(cache.name(), cache);
             clist.add(cache.toInternal());
@@ -438,6 +431,40 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     // do this at the end since an exception in the constructor means we won't close
     numOpens.incrementAndGet();
     assert ObjectReleaseTracker.track(this);
+  }
+
+  @SuppressWarnings("unchecked")
+  private <K, V> SolrCache<K, V> buildCache(
+      SolrConfig solrConfig, String cacheName, SolrCore core) {
+    CacheConfig cacheConfig;
+    switch (cacheName) {
+      case "fieldValueCache":
+        cacheConfig = solrConfig.fieldValueCacheConfig;
+        break;
+      case "filterCache":
+        cacheConfig = solrConfig.filterCacheConfig;
+        break;
+      case "queryResultCache":
+        cacheConfig = solrConfig.queryResultCacheConfig;
+        break;
+      default: // generic caches
+        cacheConfig = solrConfig.userCacheConfigs.get(cacheName);
+    }
+
+    if (cacheConfig == null) {
+      return null;
+    }
+
+    // check overrides
+    CacheOverridesManager cacheOverridesManager =
+        core.getCoreContainer().getCacheOverridesManager();
+    if (cacheOverridesManager != null) {
+      cacheConfig =
+          cacheOverridesManager.applyOverrides(
+              cacheConfig, cacheName, core.getCoreDescriptor().getCollectionName());
+    }
+
+    return (SolrCache<K, V>) cacheConfig.newInstance(core);
   }
 
   public SolrDocumentFetcher getDocFetcher() {

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -387,8 +387,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     if (cachingEnabled) {
       final ArrayList<SolrCache> clist = new ArrayList<>();
       clist.add(ordMapCache.toInternal());
-      fieldValueCache =
-          buildCache(solrConfig, "fieldValueCache", core);
+      fieldValueCache = buildCache(solrConfig, "fieldValueCache", core);
       if (fieldValueCache != null) {
         clist.add(fieldValueCache.toInternal());
       }

--- a/solr/core/src/test/org/apache/solr/search/CacheOverridesManagerTest.java
+++ b/solr/core/src/test/org/apache/solr/search/CacheOverridesManagerTest.java
@@ -1,0 +1,280 @@
+package org.apache.solr.search;
+
+import static org.apache.solr.common.params.CommonParams.NAME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.common.cloud.SolrZkClient;
+import org.apache.solr.common.cloud.ZkStateReader;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
+  private SolrZkClient mockZkClient;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    assumeWorkingMockito();
+  }
+
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    mockZkClient = Mockito.mock(SolrZkClient.class);
+  }
+
+  @Test
+  public void testGetOverrides() throws InterruptedException, KeeperException {
+    String jsonString =
+        "{\n"
+            + " legacyCloud: \"false\",\n"
+            + " cacheOverrides : [ \n"
+            + "   {\n"
+            + "     filterCache :  {\n"
+            + "       size: 9999\n"
+            + "     }\n"
+            + "     documentCache : {\n"
+            + "       size: 8888    \n"
+            + "     }\n"
+            + "     fs-cache : {\n"
+            + "       maxRamMB: 7777\n"
+            + "     }\n"
+            + "   },\n"
+            + "   {\n"
+            + "     filterCache :  {\n"
+            + "       size: 12345\n"
+            + "     }\n"
+            + "     collections: [ \"104H4B\" ]\n"
+            + "   }\n"
+            + " ]\n"
+            + " \n"
+            + "}";
+
+    // Stub a method to return a specific value
+    when(mockZkClient.getData(eq(ZkStateReader.CLUSTER_PROPS), any(), any(), anyBoolean()))
+        .thenReturn(jsonString.getBytes(Charset.defaultCharset()));
+
+    CacheOverridesManager cacheOverridesManager = new CacheOverridesManager(mockZkClient);
+
+    List<Map<String, String>> overrides;
+    overrides = cacheOverridesManager.getOverrides("filterCache", "dummyCollection");
+    assertEquals(1, overrides.size());
+    assertEquals("9999", overrides.get(0).get("size"));
+
+    overrides = cacheOverridesManager.getOverrides("documentCache", "dummyCollection");
+    assertEquals(1, overrides.size());
+    assertEquals("8888", overrides.get(0).get("size"));
+
+    overrides = cacheOverridesManager.getOverrides("fs-cache", "dummyCollection");
+    assertEquals(1, overrides.size());
+    assertEquals("7777", overrides.get(0).get("maxRamMB"));
+
+    overrides = cacheOverridesManager.getOverrides("unknown-cache", "dummyCollection");
+    assertNull(overrides);
+
+    overrides = cacheOverridesManager.getOverrides("filterCache", "104H4B");
+    assertEquals(2, overrides.size());
+    assertEquals("9999", overrides.get(0).get("size"));
+    assertEquals("12345", overrides.get(1).get("size"));
+
+    overrides = cacheOverridesManager.getOverrides("documentCache", "104H4B");
+    assertEquals(1, overrides.size());
+    assertEquals("8888", overrides.get(0).get("size"));
+
+    overrides = cacheOverridesManager.getOverrides("fs-cache", "104H4B");
+    assertEquals(1, overrides.size());
+    assertEquals("7777", overrides.get(0).get("maxRamMB"));
+
+    overrides = cacheOverridesManager.getOverrides("unknown-cache", "dummyCollection");
+    assertNull(overrides);
+  }
+
+  @Test
+  public void testOverridesZkChanges() throws InterruptedException, KeeperException {
+    // start with no clusterprops.json in ZK
+    AtomicReference<Watcher> watcherRef = new AtomicReference<>();
+    Mockito.doAnswer(
+            invocation -> {
+              watcherRef.set(invocation.getArgument(1));
+              throw new KeeperException.NoNodeException();
+            })
+        .when(mockZkClient)
+        .getData(eq(ZkStateReader.CLUSTER_PROPS), any(), any(), Mockito.anyBoolean());
+
+    CacheOverridesManager cacheOverridesManager = new CacheOverridesManager(mockZkClient);
+
+    List<Map<String, String>> overrides;
+    overrides = cacheOverridesManager.getOverrides("filterCache", "dummy");
+    assertNull(overrides);
+
+    // emulate new clusterprops.json in ZK
+    String jsonString =
+        "{\n"
+            + " legacyCloud: \"false\",\n"
+            + " cacheOverrides : [ \n"
+            + "   {\n"
+            + "     filterCache :  {\n"
+            + "       size: 9999\n"
+            + "     }\n"
+            + "   },\n"
+            + "   {\n"
+            + "     filterCache :  {\n"
+            + "       size: 12345\n"
+            + "     }\n"
+            + "     collections: [ \"104H4B\" ]\n"
+            + "   }\n"
+            + " ]\n"
+            + " \n"
+            + "}";
+
+    when(mockZkClient.getData(eq(ZkStateReader.CLUSTER_PROPS), any(), any(), anyBoolean()))
+        .thenReturn(jsonString.getBytes(Charset.defaultCharset()));
+    watcherRef
+        .get()
+        .process(
+            new WatchedEvent(
+                Watcher.Event.EventType.NodeCreated,
+                Watcher.Event.KeeperState.SyncConnected,
+                ZkStateReader.CLUSTER_PROPS));
+
+    overrides = cacheOverridesManager.getOverrides("filterCache", "104H4B");
+    assertEquals(2, overrides.size());
+    assertEquals("9999", overrides.get(0).get("size"));
+    assertEquals("12345", overrides.get(1).get("size"));
+
+    // emulate changes in ZK
+    jsonString =
+        "{\n"
+            + " legacyCloud: \"false\",\n"
+            + " cacheOverrides : [ \n"
+            + "   {\n"
+            + "     filterCache :  {\n"
+            + "       size: 1111\n"
+            + "     }\n"
+            + "     collections: [ \"104H4B\" ]\n"
+            + "   },\n"
+            + "   {\n"
+            + "     filterCache :  {\n"
+            + "       size: 2222\n"
+            + "     }\n"
+            + "     collections: [ \"local\" ]\n"
+            + "   }\n"
+            + " ]\n"
+            + " \n"
+            + "}";
+
+    when(mockZkClient.getData(eq(ZkStateReader.CLUSTER_PROPS), any(), any(), anyBoolean()))
+        .thenReturn(jsonString.getBytes(Charset.defaultCharset()));
+    watcherRef
+        .get()
+        .process(
+            new WatchedEvent(
+                Watcher.Event.EventType.NodeDataChanged,
+                Watcher.Event.KeeperState.SyncConnected,
+                ZkStateReader.CLUSTER_PROPS));
+
+    overrides = cacheOverridesManager.getOverrides("filterCache", "dummy");
+    assertNull(overrides);
+
+    overrides = cacheOverridesManager.getOverrides("filterCache", "104H4B");
+    assertEquals(1, overrides.size());
+    assertEquals("1111", overrides.get(0).get("size"));
+
+    overrides = cacheOverridesManager.getOverrides("filterCache", "local");
+    assertEquals(1, overrides.size());
+    assertEquals("2222", overrides.get(0).get("size"));
+
+    // emulate overrides removed from clusterprops.json
+    jsonString = "{ legacyCloud : \"false\" }";
+    when(mockZkClient.getData(eq(ZkStateReader.CLUSTER_PROPS), any(), any(), anyBoolean()))
+        .thenReturn(jsonString.getBytes(Charset.defaultCharset()));
+    watcherRef
+        .get()
+        .process(
+            new WatchedEvent(
+                Watcher.Event.EventType.NodeDataChanged,
+                Watcher.Event.KeeperState.SyncConnected,
+                ZkStateReader.CLUSTER_PROPS));
+    overrides = cacheOverridesManager.getOverrides("filterCache", "104H4B");
+    assertNull(overrides);
+
+    // emulate clusterprops.json deleted
+    watcherRef
+        .get()
+        .process(
+            new WatchedEvent(
+                Watcher.Event.EventType.NodeDeleted,
+                Watcher.Event.KeeperState.SyncConnected,
+                ZkStateReader.CLUSTER_PROPS));
+    overrides = cacheOverridesManager.getOverrides("filterCache", "104H4B");
+    assertNull(overrides);
+  }
+
+  @Test
+  public void testApplyZkOverrides() throws InterruptedException, KeeperException {
+    // test when there's no clusterprops.json in ZK
+    when(mockZkClient.getData(eq(ZkStateReader.CLUSTER_PROPS), any(), any(), anyBoolean()))
+        .thenThrow(new KeeperException.NoNodeException());
+
+    CacheOverridesManager cacheOverridesManager = new CacheOverridesManager(mockZkClient);
+
+    Map<String, String> args = Map.of(NAME, "filterCache", "size", "10000", "initialSize", "10");
+
+    CacheConfig config = new CacheConfig(CaffeineCache.class, args, null);
+    CacheConfig afterConfig =
+        cacheOverridesManager.applyOverrides(config, "filterCache", "dummyCollection");
+
+    assertEquals(config, afterConfig);
+
+    String jsonString =
+        "{\n"
+            + " legacyCloud: \"false\",\n"
+            + " cacheOverrides : [ \n"
+            + "   {\n"
+            + "     filterCache :  {\n"
+            + "       size: 9999\n"
+            + "     }\n"
+            + "     documentCache : {\n"
+            + "       size: 8888    \n"
+            + "     }\n"
+            + "     fs-cache : {\n"
+            + "       maxRamMB: 7777\n"
+            + "     }\n"
+            + "   },\n"
+            + "   {\n"
+            + "     filterCache :  {\n"
+            + "       size: 12345\n"
+            + "     }\n"
+            + "     collections: [ \"104H4B\" ]\n"
+            + "   }\n"
+            + " ]\n"
+            + " \n"
+            + "}";
+    when(mockZkClient.getData(eq(ZkStateReader.CLUSTER_PROPS), any(), any(), anyBoolean()))
+        .thenReturn(jsonString.getBytes(Charset.defaultCharset()));
+
+    cacheOverridesManager = new CacheOverridesManager(mockZkClient);
+
+    afterConfig = cacheOverridesManager.applyOverrides(config, "filterCache", "dummyCollection");
+    assertEquals("9999", afterConfig.toMap(new HashMap<>()).get("size"));
+    assertEquals("10", afterConfig.toMap(new HashMap<>()).get("initialSize")); // not overridden
+
+    afterConfig = cacheOverridesManager.applyOverrides(config, "filterCache", "104H4B");
+    assertEquals("12345", afterConfig.toMap(new HashMap<>()).get("size"));
+    assertEquals("10", afterConfig.toMap(new HashMap<>()).get("initialSize")); // not overridden
+  }
+}


### PR DESCRIPTION
The 9x PR is #265

Cherry picking this back to 9_7