### PR TITLE
SAI-5736: Use `ext.cacheOverrides` instead of `cacheOverrides` as key in clusterprops.json

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
 import org.apache.solr.common.cloud.ClusterProperties;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.core.SolrCore;
@@ -67,7 +66,8 @@ import org.slf4j.LoggerFactory;
  */
 @SuppressWarnings("unchecked")
 public class CacheOverridesManager {
-  public static final String CACHE_OVERRIDE_KEY = ClusterProperties.EXT_PROPRTTY_PREFIX + "cacheOverrides";
+  public static final String CACHE_OVERRIDE_KEY =
+      ClusterProperties.EXT_PROPRTTY_PREFIX + "cacheOverrides";
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private volatile Map<String, List<CacheOverrides>> overridesByCacheName = Map.of();
 

--- a/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
@@ -7,13 +7,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import org.apache.solr.common.cloud.ClusterProperties;
 import org.apache.solr.common.cloud.ZkStateReader;
 import org.apache.solr.core.SolrCore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A manager that gets and subscribes to ZK clusterprops.json on field "cacheOverrides" <br>
+ * A manager that gets and subscribes to ZK clusterprops.json on field "ext.cacheOverrides" <br>
  * <br>
  * The value of the field defines a list of cache overrides, each override is a map with cache name
  * as key and a map of properties as value. An extra "collections" key can be used to apply the
@@ -37,7 +39,7 @@ import org.slf4j.LoggerFactory;
  * <pre>
  *   {
  * ...
- *  "cacheOverrides" : [
+ *  "ext.cacheOverrides" : [
  *    {
  *      "filterCache" :  {
  *        "size": 9999
@@ -65,6 +67,7 @@ import org.slf4j.LoggerFactory;
  */
 @SuppressWarnings("unchecked")
 public class CacheOverridesManager {
+  public static final String CACHE_OVERRIDE_KEY = ClusterProperties.EXT_PROPRTTY_PREFIX + "cacheOverrides";
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private volatile Map<String, List<CacheOverrides>> overridesByCacheName = Map.of();
 
@@ -96,7 +99,7 @@ public class CacheOverridesManager {
   public CacheOverridesManager(ZkStateReader zkStateReader) {
     zkStateReader.registerClusterPropertiesListener(
         (Map<String, Object> properties) -> {
-          processCacheOverrides(properties.get("cacheOverrides"));
+          processCacheOverrides(properties.get(CACHE_OVERRIDE_KEY));
           return false;
         });
   }

--- a/solr/core/src/test/org/apache/solr/search/CacheOverridesManagerTest.java
+++ b/solr/core/src/test/org/apache/solr/search/CacheOverridesManagerTest.java
@@ -39,7 +39,7 @@ public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
     String jsonString =
         "{\n"
             + " \"legacyCloud\": \"false\",\n"
-            + " \"cacheOverrides\" :\n"
+            + " \"ext.cacheOverrides\" :\n"
             + "   {\n"
             + "     \"filterCache\" :  {\n"
             + "       \"size\": 9999\n"
@@ -67,7 +67,7 @@ public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
     jsonString =
         "{\n"
             + " \"legacyCloud\": \"false\",\n"
-            + " \"cacheOverrides\" : [ \n"
+            + " \"ext.cacheOverrides\" : [ \n"
             + "   {\n"
             + "     \"filterCache\" :  {\n"
             + "       \"size\": 9999\n"
@@ -96,7 +96,7 @@ public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
     String jsonString =
         "{\n"
             + " \"legacyCloud\": \"false\",\n"
-            + " \"cacheOverrides\" : [ \n"
+            + " \"ext.cacheOverrides\" : [ \n"
             + "   {\n"
             + "     \"filterCache\" :  {\n"
             + "       \"size\": 9999\n"
@@ -186,7 +186,7 @@ public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
     String jsonString =
         "{\n"
             + " \"legacyCloud\": \"false\",\n"
-            + " \"cacheOverrides\" : [ \n"
+            + " \"ext.cacheOverrides\" : [ \n"
             + "   {\n"
             + "     \"filterCache\" :  {\n"
             + "       \"size\": 9999\n"
@@ -231,7 +231,7 @@ public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
     jsonString =
         "{\n"
             + " \"legacyCloud\": \"false\",\n"
-            + " \"cacheOverrides\" : [ \n"
+            + " \"ext.cacheOverrides\" : [ \n"
             + "   {\n"
             + "     \"filterCache\" :  {\n"
             + "       \"size\": 1111\n"
@@ -296,7 +296,7 @@ public class CacheOverridesManagerTest extends SolrTestCaseJ4 {
     String jsonString =
         "{\n"
             + " \"legacyCloud\": \"false\",\n"
-            + " \"cacheOverrides\" : [ \n"
+            + " \"ext.cacheOverrides\" : [ \n"
             + "   {\n"
             + "     \"filterCache\" :  {\n"
             + "       \"size\": 9999\n"


### PR DESCRIPTION
## Description
According to https://solr.apache.org/guide/solr/9_7/deployment-guide/cluster-node-management.html#clusterprop-parameters, all non standard clusterprops.json properties should have key prefix `ext.` in order function properly for CLUSTERPROP api call

