### PR TITLE
SAI-5752: port SOLR-17131 as of 3f9be2201d9fcd92d801a151b5a086af87fc9911

### DIFF
--- a/solr/benchmark/src/java/org/apache/solr/bench/MiniClusterState.java
+++ b/solr/benchmark/src/java/org/apache/solr/bench/MiniClusterState.java
@@ -159,6 +159,9 @@ public class MiniClusterState {
 
       IOUtils.closeQuietly(client);
       cluster.shutdown();
+      if (useHttp1) {
+        System.clearProperty("solr.http1");
+      }
       logClusterDirectorySize();
     }
 
@@ -265,6 +268,9 @@ public class MiniClusterState {
       }
 
       try {
+        if (useHttp1) {
+          System.setProperty("solr.http1", "true");
+        }
         cluster =
             new MiniSolrCloudCluster.Builder(nodeCount, miniClusterBaseDir)
                 .formatZkServer(false)

--- a/solr/benchmark/src/java/org/apache/solr/bench/search/SearchOptimizations.java
+++ b/solr/benchmark/src/java/org/apache/solr/bench/search/SearchOptimizations.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.bench.search;
+
+import static org.apache.solr.bench.Docs.docs;
+import static org.apache.solr.bench.generators.SourceDSL.integers;
+import static org.apache.solr.bench.generators.SourceDSL.strings;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.solr.bench.BaseBenchState;
+import org.apache.solr.bench.Docs;
+import org.apache.solr.bench.MiniClusterState;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.request.CollectionAdminRequest;
+import org.apache.solr.client.solrj.request.QueryRequest;
+import org.apache.solr.common.params.CommonParams;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@Fork(value = 1)
+@Warmup(time = 5, iterations = 9)
+@Measurement(time = 5, iterations = 9)
+@Threads(value = 16)
+public class SearchOptimizations {
+
+  static final String COLLECTION = "c1";
+
+  @State(Scope.Benchmark)
+  public static class BenchState {
+    @Param({"false", "true"})
+    boolean singleShard;
+
+    @Param({"false", "true"})
+    boolean matchAllDocs;
+
+    @Param({"false", "true"})
+    boolean noRowsQuery;
+
+    @Param({"false", "true"})
+    boolean flScore;
+
+    @Param({"false", "true"})
+    boolean sortScore;
+
+    int numDocs = 10000;
+
+    AtomicLong total = new AtomicLong();
+    AtomicLong err = new AtomicLong();
+
+    QueryRequest q;
+
+    @Setup(Level.Trial)
+    public void setupTrial(MiniClusterState.MiniClusterBenchState miniClusterState)
+        throws Exception {
+      miniClusterState.setUseHttp1(true);
+      miniClusterState.startMiniCluster(1);
+      miniClusterState.createCollection(COLLECTION, singleShard ? 1 : 2, 1);
+      Docs docGen =
+          docs()
+              .field("id", integers().incrementing())
+              .field("text2_ts", strings().alpha().multi(10).ofLengthBetween(5, 10));
+      miniClusterState.index(COLLECTION, docGen, numDocs);
+      miniClusterState.forceMerge(COLLECTION, 1);
+      String base = miniClusterState.nodes.get(0);
+
+      q = new QueryRequest(getSolrQuery());
+      q.setBasePath(base);
+    }
+
+    private SolrQuery getSolrQuery() {
+      final String qstr;
+      if (matchAllDocs) {
+        qstr = "*:*";
+      } else {
+        qstr =
+            "id:10 OR id:20 OR id:30 OR id:40 OR id:50 OR id:60 OR id:70 OR id:80 OR id:90 OR id:100";
+      }
+      SolrQuery solrQuery = new SolrQuery("q", qstr);
+      if (noRowsQuery) {
+        solrQuery.set(CommonParams.ROWS, 0);
+      } else {
+        solrQuery.set(CommonParams.ROWS, CommonParams.ROWS_DEFAULT);
+      }
+      if (flScore) {
+        solrQuery.set(CommonParams.FL, "id,score");
+      } else {
+        solrQuery.set(CommonParams.FL, "id");
+      }
+      if (sortScore) {
+        solrQuery.set(CommonParams.SORT, "score desc,id asc");
+      } else {
+        solrQuery.set(CommonParams.SORT, "id asc");
+      }
+      return solrQuery;
+    }
+
+    @Setup(Level.Iteration)
+    public void setupIteration(MiniClusterState.MiniClusterBenchState miniClusterState)
+        throws SolrServerException, IOException {
+      // Reload the collection/core to drop existing caches
+      CollectionAdminRequest.Reload reload = CollectionAdminRequest.reloadCollection(COLLECTION);
+      reload.setBasePath(miniClusterState.nodes.get(0));
+      miniClusterState.client.request(reload);
+
+      total = new AtomicLong();
+      err = new AtomicLong();
+    }
+
+    @TearDown(Level.Iteration)
+    public void teardownIt() {
+      if (err.get() > 0) {
+        BaseBenchState.log(
+            "Completed Iteration with " + total.get() + " queries and " + err.get() + " errors");
+      }
+    }
+  }
+
+  @Benchmark
+  public Object query(
+      BenchState benchState, MiniClusterState.MiniClusterBenchState miniClusterState, Blackhole bh)
+      throws IOException {
+    try {
+      return miniClusterState.client.request(benchState.q, COLLECTION);
+    } catch (SolrServerException e) {
+      bh.consume(e);
+      benchState.err.getAndIncrement();
+      return null;
+    } finally {
+      benchState.total.getAndIncrement();
+    }
+  }
+}

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -161,7 +161,6 @@ public class QueryComponent extends SearchComponent {
       rb.setDistribStatsDisabled(!params.getBool(CommonParams.DISTRIB_STATS_CACHE, true));
     }
 
-    // Set field flags
     ReturnFields returnFields = new SolrReturnFields(req);
     rsp.setReturnFields(returnFields);
     int flags = 0;

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1670,7 +1670,9 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
 
       if ((flags & NO_SET_QCACHE) == 0) {
         // handle 0 special case as well as avoid idiv in the common case.
-        if (maxDocRequested < queryResultWindowSize) {
+        if (cmd.getLen() == 0) {
+          supersetMaxDoc = 0;
+        } else if (maxDocRequested < queryResultWindowSize) {
           supersetMaxDoc = queryResultWindowSize;
         } else {
           supersetMaxDoc =
@@ -1690,12 +1692,12 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     // - the sort doesn't contain score
     // - we don't want score returned.
 
-    // check if we should try and use the filter cache
+    // check if we should try and use the filter cache for the query itself
     final boolean needSort;
-    final boolean useFilterCache;
+    final boolean useFilterCacheForQuery;
     if ((flags & (GET_SCORES | NO_CHECK_FILTERCACHE)) != 0 || filterCache == null) {
-      needSort = true; // this value should be irrelevant when `useFilterCache=false`
-      useFilterCache = false;
+      needSort = true; // this value should be irrelevant when `useFilterCacheForQuery=false`
+      useFilterCacheForQuery = false;
     } else if (q instanceof MatchAllDocsQuery
         || (useFilterForSortedQuery && QueryUtils.isConstantScoreQuery(q))) {
       // special-case MatchAllDocsQuery: implicit default useFilterForSortedQuery=true;
@@ -1707,7 +1709,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       final Sort sort = cmd.getSort();
       needSort = cmd.getLen() > 0 && sortIncludesOtherThanScore(sort);
       if (!needSort) {
-        useFilterCache = true;
+        useFilterCacheForQuery = true;
       } else {
         /*
         NOTE: if `sort:score` is specified, it will have no effect, so we really _could_ in
@@ -1716,16 +1718,16 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
         expects `score` to be present ... so just make the optimization contingent on the absence
         of `score` in the requested sort.
          */
-        useFilterCache =
+        useFilterCacheForQuery =
             Arrays.stream(sort.getSort()).noneMatch((sf) -> sf.getType() == SortField.Type.SCORE);
       }
     } else {
       // for non-constant-score queries, must sort unless no docs requested
       needSort = cmd.getLen() > 0;
-      useFilterCache = useFilterCacheForDynamicScoreQuery(needSort, cmd);
+      useFilterCacheForQuery = useFilterCacheForDynamicScoreQuery(needSort, cmd);
     }
 
-    if (useFilterCache) {
+    if (useFilterCacheForQuery) {
       // now actually use the filter cache.
       // for large filters that match few documents, this may be
       // slower than simply re-executing the query.
@@ -1740,7 +1742,6 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       // the filters instead of anding them first...
       // perhaps there should be a multi-docset-iterator
       if (needSort) {
-        fullSortCount.increment();
         sortDocSet(qr, cmd);
       } else {
         skipSortCount.increment();
@@ -1758,7 +1759,6 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
         }
       }
     } else {
-      fullSortCount.increment();
       // do it the normal way...
       if ((flags & GET_DOCSET) != 0) {
         // this currently conflates returning the docset for the base query vs
@@ -1864,6 +1864,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
    */
   TopDocsCollector<? extends ScoreDoc> buildTopDocsCollector(int len, QueryCommand cmd)
       throws IOException {
+    fullSortCount.increment();
     int minNumFound = cmd.getMinExactCount();
     Query q = cmd.getQuery();
     if (q instanceof RankQuery) {

--- a/solr/core/src/java/org/apache/solr/search/SolrReturnFields.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrReturnFields.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
 import org.apache.lucene.queries.function.FunctionQuery;
@@ -68,6 +69,7 @@ public class SolrReturnFields extends ReturnFields {
   protected DocTransformer transformer;
   protected boolean _wantsScore = false;
   protected boolean _wantsAllFields = false;
+  private boolean _noRows = false;
   protected Map<String, String> renameFields = Collections.emptyMap();
 
   // Only set currently with the SolrDocumentFetcher.solrDoc method. Primarily used
@@ -166,6 +168,12 @@ public class SolrReturnFields extends ReturnFields {
   private void parseFieldList(String[] fl, SolrQueryRequest req) {
     _wantsScore = false;
     _wantsAllFields = false;
+
+    // Optimize the case of rows=0
+    if (req != null && Objects.equals("0", req.getParams().get(CommonParams.ROWS))) {
+      _noRows = true;
+    }
+
     if (fl == null || fl.length == 0 || (fl.length == 1 && fl[0].length() == 0)) {
       _wantsAllFields = true;
       return;
@@ -532,10 +540,18 @@ public class SolrReturnFields extends ReturnFields {
     okFieldNames.add(key);
     // a valid field name
     if (SCORE.equals(field)) {
-      _wantsScore = true;
+      if (_noRows) {
+        reqFieldNames.remove(field);
+        reqFieldNames.remove(key);
+        fields.remove(field);
+        okFieldNames.remove(field);
+        okFieldNames.remove(key);
+      } else {
+        _wantsScore = true;
 
-      String disp = (key == null) ? field : key;
-      augmenters.addTransformer(new ScoreAugmenter(disp));
+        String disp = (key == null) ? field : key;
+        augmenters.addTransformer(new ScoreAugmenter(disp));
+      }
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/search/SortSpec.java
+++ b/solr/core/src/java/org/apache/solr/search/SortSpec.java
@@ -62,16 +62,13 @@ public class SortSpec {
     this.fields = Collections.unmodifiableList(fields);
   }
 
-  public static boolean includesScore(Sort sort) {
+  public boolean includesScore() {
+    if (num == 0) return false;
     if (sort == null) return true;
     for (SortField sf : sort.getSort()) {
       if (sf.getType() == SortField.Type.SCORE) return true;
     }
     return false;
-  }
-
-  public boolean includesScore() {
-    return includesScore(sort);
   }
 
   /**

--- a/solr/core/src/test/org/apache/solr/ConvertedLegacyTest.java
+++ b/solr/core/src/test/org/apache/solr/ConvertedLegacyTest.java
@@ -866,7 +866,7 @@ public class ConvertedLegacyTest extends SolrTestCaseJ4 {
     args.put("fl", "*,score");
     args.put("sort", "id desc");
     req = new LocalSolrQueryRequest(h.getCore(), "id:44", "/select", 0, 0, args);
-    assertQ(req, "//result[@maxScore>0]");
+    assertQ(req, "//result[count(@maxScore)=0]");
 
     //  test schema field attribute inheritance and overriding
 

--- a/solr/core/src/test/org/apache/solr/TestDistributedGrouping.java
+++ b/solr/core/src/test/org/apache/solr/TestDistributedGrouping.java
@@ -1636,6 +1636,27 @@ public class TestDistributedGrouping extends BaseDistributedSearchTestCase {
         CommonParams.TIME_ALLOWED,
         1);
 
+    // Check rows=0 ngroups still work
+    rsp =
+        query(
+            "q",
+            "*:*",
+            "fq",
+            s1 + ":a",
+            "rows",
+            0,
+            "group",
+            "true",
+            "group.field",
+            i1,
+            "group.ngroups",
+            "true");
+    nl = (NamedList<?>) rsp.getResponse().get("grouped");
+    nl = (NamedList<?>) nl.get(i1);
+    assertEquals(rsp.toString(), 200, nl.get("matches"));
+    assertEquals(rsp.toString(), 2, nl.get("ngroups"));
+    assertEquals(rsp.toString(), 0, ((List<NamedList<?>>) nl.get("groups")).size());
+
     // Debug
     simpleQuery(
         "q",

--- a/solr/core/src/test/org/apache/solr/TestGroupingSearch.java
+++ b/solr/core/src/test/org/apache/solr/TestGroupingSearch.java
@@ -1566,6 +1566,33 @@ public class TestGroupingSearch extends SolrTestCaseJ4 {
   }
 
   @Test
+  public void testGroupingNoRows() throws Exception {
+    assertU(add(doc("id", "1", "date_dt", "2012-11-20T00:00:00Z")));
+    assertU(add(doc("id", "2", "date_dt", "2012-11-21T00:00:00Z")));
+    assertU(commit());
+
+    assertU(add(doc("id", "3", "date_dt", "2012-11-20T00:00:00Z")));
+    assertU(add(doc("id", "4", "date_dt", "2013-01-15T00:00:00Z")));
+    assertU(add(doc("id", "5")));
+    assertU(commit());
+
+    assertJQ(
+        req(
+            params(
+                "q",
+                "*:*",
+                "rows",
+                "0",
+                "group",
+                "true",
+                "group.ngroups",
+                "true",
+                "group.field",
+                "date_dt")),
+        "/grouped=={'date_dt':{'matches':5,'ngroups':4, 'groups':[ ]}}");
+  }
+
+  @Test
   public void testGroupingOnDateField() throws Exception {
     assertU(add(doc("id", "1", "date_dt", "2012-11-20T00:00:00Z")));
     assertU(add(doc("id", "2", "date_dt", "2012-11-21T00:00:00Z")));

--- a/solr/core/src/test/org/apache/solr/search/ReturnFieldsTest.java
+++ b/solr/core/src/test/org/apache/solr/search/ReturnFieldsTest.java
@@ -395,6 +395,16 @@ public class ReturnFieldsTest extends SolrTestCaseJ4 {
         "//arr[@name='#foo_s']/str[.='how now brown cow']");
   }
 
+  @Test
+  public void testRowsZeroNoScore() {
+    ReturnFields rf = new SolrReturnFields(req("fl", "id,score", "rows", "0"));
+    assertFalse(rf.wantsScore());
+    assertFalse(rf.wantsField("score"));
+    assertTrue(rf.wantsField("id"));
+    assertFalse(rf.wantsField("xxx"));
+    assertFalse(rf.wantsAllFields());
+  }
+
   /**
    * Whitebox verification that the conversion from lucene {@link Document} to {@link SolrDocument}
    * respects the {@link ReturnFields} and doesn't unnecessarily convert Fields that aren't needed.

--- a/solr/core/src/test/org/apache/solr/search/SolrIndexSearcherTest.java
+++ b/solr/core/src/test/org/apache/solr/search/SolrIndexSearcherTest.java
@@ -256,6 +256,7 @@ public class SolrIndexSearcherTest extends SolrTestCaseJ4 {
         .withSearcher(
             searcher -> {
               final QueryCommand cmd = new QueryCommand();
+              cmd.setLen(1); // make sure we get at least one doc to check later
               cmd.setFlags(SolrIndexSearcher.GET_SCORES | getDocSetFlag);
 
               if (doSort) {

--- a/solr/core/src/test/org/apache/solr/search/TestMainQueryCaching.java
+++ b/solr/core/src/test/org/apache/solr/search/TestMainQueryCaching.java
@@ -146,7 +146,8 @@ public class TestMainQueryCaching extends SolrTestCaseJ4 {
 
   @Test
   public void testConstantScoreFlScore() throws Exception {
-    // explicitly requesting scores should unconditionally disable caching and sorting optimizations
+    // explicitly requesting rows=0 means that scores should not unconditionally disable caching and
+    // sorting optimizations
     String response =
         JQ(
             req(
@@ -160,7 +161,12 @@ public class TestMainQueryCaching extends SolrTestCaseJ4 {
                 "id,score",
                 "sort",
                 (random().nextBoolean() ? "id asc" : "score desc")));
-    assertMetricCounts(response, false, 0, 1, 0);
+    assertMetricCounts(
+        response,
+        false,
+        USE_FILTER_FOR_SORTED_QUERY ? 1 : 0,
+        0,
+        USE_FILTER_FOR_SORTED_QUERY ? 1 : 0);
   }
 
   @Test
@@ -185,12 +191,7 @@ public class TestMainQueryCaching extends SolrTestCaseJ4 {
                 "sort",
                 (random().nextBoolean() ? "id asc" : "score desc")));
     final int insertAndSkipCount = USE_FILTER_FOR_SORTED_QUERY ? 1 : 0;
-    assertMetricCounts(
-        response,
-        false,
-        insertAndSkipCount,
-        USE_FILTER_FOR_SORTED_QUERY ? 0 : 1,
-        insertAndSkipCount);
+    assertMetricCounts(response, false, insertAndSkipCount, 0, insertAndSkipCount);
   }
 
   @Test
@@ -275,8 +276,8 @@ public class TestMainQueryCaching extends SolrTestCaseJ4 {
 
   @Test
   public void testMatchAllDocsFlScore() throws Exception {
-    // explicitly requesting scores should unconditionally disable all cache consultation and sort
-    // optimization
+    // explicitly requesting rows=0 means that scores should not unconditionally disable caching and
+    // sorting optimizations
     String response =
         JQ(
             req(
@@ -290,14 +291,7 @@ public class TestMainQueryCaching extends SolrTestCaseJ4 {
                 "id,score",
                 "sort",
                 (random().nextBoolean() ? "id asc" : "score desc")));
-    /*
-    NOTE: pretend we're not MatchAllDocs, from the perspective of `assertMetricsCounts(...)`
-    We're specifically choosing `*:*` here because we want a query that would _definitely_ hit
-    our various optimizations, _but_ for the fact that we explicitly requested `score` to be
-    returned. This would be a bit of an anti-pattern in "real life", but it's useful (e.g., in
-    tests) to have this case just disable the optimizations.
-     */
-    assertMetricCounts(response, false, 0, 1, 0, ALL_DOCS);
+    assertMetricCounts(response, true, 0, 0, 1, ALL_DOCS);
   }
 
   @Test
@@ -333,6 +327,7 @@ public class TestMainQueryCaching extends SolrTestCaseJ4 {
     final int expectNumFound = MATCH_ALL_DOCS_QUERY.equals(q) ? ALL_DOCS : MOST_DOCS;
     final boolean consultMatchAllDocs;
     final boolean insertFilterCache;
+    final boolean fullSort;
     if (includeScoreInSort) {
       consultMatchAllDocs = false;
       insertFilterCache = false;
@@ -350,6 +345,7 @@ public class TestMainQueryCaching extends SolrTestCaseJ4 {
   @Test
   public void testCursorMarkZeroRows() throws Exception {
     String q = pickRandom(ALL_QUERIES);
+    boolean sortByScore = random().nextBoolean();
     String response =
         JQ(
             req(
@@ -362,25 +358,14 @@ public class TestMainQueryCaching extends SolrTestCaseJ4 {
                 "rows",
                 "0",
                 "sort",
-                random().nextBoolean() ? "id asc" : "score desc,id asc"));
-    final boolean consultMatchAllDocs;
-    final boolean insertFilterCache;
-    final boolean skipSort;
-    if (MATCH_ALL_DOCS_QUERY.equals(q)) {
-      consultMatchAllDocs = true;
-      insertFilterCache = false;
-      skipSort = true;
-    } else {
-      consultMatchAllDocs = false;
-      insertFilterCache = USE_FILTER_FOR_SORTED_QUERY;
-      skipSort = USE_FILTER_FOR_SORTED_QUERY;
-    }
+                sortByScore ? "score desc,id asc" : "id asc"));
+    boolean filterCacheInsertCount = !MATCH_ALL_DOCS_QUERY.equals(q) && USE_FILTER_FOR_SORTED_QUERY;
     assertMetricCounts(
         response,
-        consultMatchAllDocs,
-        insertFilterCache ? 1 : 0,
-        skipSort ? 0 : 1,
-        skipSort ? 1 : 0);
+        MATCH_ALL_DOCS_QUERY.equals(q),
+        filterCacheInsertCount ? 1 : 0,
+        0,
+        MATCH_ALL_DOCS_QUERY.equals(q) || filterCacheInsertCount ? 1 : 0);
   }
 
   private static void assertMetricCounts(


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/SOLR-17131

this optimizes the rows==0 case to avoid sort/score

This is relevant to evaluating the impact of caching changes because it optimizes a case that can obscure the true impact of caching improvements

This commit should probably be reverted and merged in from upstream once this lands on upstream branch