### PR TITLE
SAI-5755: hacky but harmless; expose `solr.CaffeineCache.syncStats()` publicly

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
+++ b/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
@@ -511,7 +511,7 @@ public class CaffeineCache<K, V> extends SolrCacheBase
    * CacheStats}. This method returns a {@link CacheStats} instance that represents synchronous ops
    * since this cache was marked as {@link SolrCache.State#LIVE} via {@link #setState(State)}.
    */
-  private CacheStats syncStats() {
+  public CacheStats syncStats() {
     return cache.stats().minus(offsetSyncStats.get());
   }
 


### PR DESCRIPTION
ideally we should not expose backing cache or its stats directly, but rather get everything through existing solr metrics framework. Until we do that though, the stats exposed here are read-only, so there's no harm in it.