### PR TITLE
SAI-5783 : Simple query regenerator

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/SimpleQueryRegenerator.java
+++ b/solr/core/src/java/org/apache/solr/search/SimpleQueryRegenerator.java
@@ -39,9 +39,12 @@ public class SimpleQueryRegenerator implements CacheRegenerator {
           V oldVal)
           throws IOException {
     if (oldKey instanceof Query && oldVal instanceof DocSet) {
-      ExtendedQuery noCache = new WrappedQuery((Query) oldKey);
-      noCache.setCache(false);
-      newCache.computeIfAbsent((K) noCache, (k) -> (V) newSearcher.getDocSet((Query) k));
+      newCache.computeIfAbsent(oldKey, (k) -> {
+        ExtendedQuery noCache = new WrappedQuery((Query) oldKey);
+        noCache.setCache(false);
+
+        return (V) newSearcher.getDocSet((Query) noCache);
+      });
       return true;
     } else {
       log.info("Not regenerating item as key should be a Query and val a DocSet, but found key of class {} and val of class {}", oldKey != null ? oldKey.getClass().getName() : "null", oldVal != null ? oldVal.getClass().getName() : "null");

--- a/solr/core/src/java/org/apache/solr/search/SimpleQueryRegenerator.java
+++ b/solr/core/src/java/org/apache/solr/search/SimpleQueryRegenerator.java
@@ -16,15 +16,15 @@
  */
 package org.apache.solr.search;
 
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import org.apache.lucene.search.Query;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.lang.invoke.MethodHandles;
-
 /**
- * A simple cache regenerator that computes the new value by executing the Query keys from old cache on the new Searcher
+ * A simple cache regenerator that computes the new value by executing the Query keys from old cache
+ * on the new Searcher
  */
 public class SimpleQueryRegenerator implements CacheRegenerator {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -32,22 +32,29 @@ public class SimpleQueryRegenerator implements CacheRegenerator {
   @SuppressWarnings("unchecked")
   @Override
   public <K, V> boolean regenerateItem(
-          SolrIndexSearcher newSearcher,
-          SolrCache<K, V> newCache,
-          SolrCache<K, V> oldCache,
-          K oldKey,
-          V oldVal)
-          throws IOException {
+      SolrIndexSearcher newSearcher,
+      SolrCache<K, V> newCache,
+      SolrCache<K, V> oldCache,
+      K oldKey,
+      V oldVal)
+      throws IOException {
     if (oldKey instanceof Query && oldVal instanceof DocSet) {
-      newCache.computeIfAbsent(oldKey, (k) -> {
-        ExtendedQuery noCache = new WrappedQuery((Query) oldKey);
-        noCache.setCache(false);
+      newCache.computeIfAbsent(
+          oldKey,
+          (k) -> {
+            ExtendedQuery noCache = new WrappedQuery((Query) oldKey);
+            noCache.setCache(false);
 
-        return (V) newSearcher.getDocSet((Query) noCache);
-      });
+            return (V) newSearcher.getDocSet((Query) noCache);
+          });
       return true;
     } else {
-      log.info("Not regenerating item as key should be a Query and val a DocSet, but found key of class {} and val of class {}", oldKey != null ? oldKey.getClass().getName() : "null", oldVal != null ? oldVal.getClass().getName() : "null");
+      if (log.isWarnEnabled()) {
+        log.warn(
+            "Not regenerating item as key should be a Query and val a DocSet, but found key of class {} and val of class {}",
+            oldKey != null ? oldKey.getClass().getName() : "null",
+            oldVal != null ? oldVal.getClass().getName() : "null");
+      }
       return false;
     }
   }

--- a/solr/core/src/java/org/apache/solr/search/SimpleQueryRegenerator.java
+++ b/solr/core/src/java/org/apache/solr/search/SimpleQueryRegenerator.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search;
+
+import org.apache.lucene.search.Query;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+
+/**
+ * A simple cache regenerator that computes the new value by executing the Query keys from old cache on the new Searcher
+ */
+public class SimpleQueryRegenerator implements CacheRegenerator {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <K, V> boolean regenerateItem(
+          SolrIndexSearcher newSearcher,
+          SolrCache<K, V> newCache,
+          SolrCache<K, V> oldCache,
+          K oldKey,
+          V oldVal)
+          throws IOException {
+    if (oldKey instanceof Query && oldVal instanceof DocSet) {
+      ExtendedQuery noCache = new WrappedQuery((Query) oldKey);
+      noCache.setCache(false);
+      newCache.computeIfAbsent((K) noCache, (k) -> (V) newSearcher.getDocSet((Query) k));
+      return true;
+    } else {
+      log.info("Not regenerating item as key should be a Query and val a DocSet, but found key of class {} and val of class {}", oldKey != null ? oldKey.getClass().getName() : "null", oldVal != null ? oldVal.getClass().getName() : "null");
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
## Description
It’s found that our user cache `fcache-docs-hot` even with autowarmCount="100%"does not autowarm as expected.

This is due to no default regenerator for user cache

## Solution
Introduce a new `SimpleQueryRegenerator` that computes the new value by executing the Query keys from old cache on the new Searcher

Then `fcache-docs-hot` should be configured to use such regenerator

## Test
Deployed on playpen (from this [branch](https://github.com/cowpaths/fullstory-solr/tree/patsonluk/SAI-5781-set-default-regenerator-user-cache) with debug logging). 

Then issue hot cache queue along with background indexing. Observed the log only shows hot cache miss on first query of each core and no longer shows misses on commits (every min)