### PR TITLE
SAI-5800: Add hot cache local eviction metrics

### DIFF
--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -875,7 +875,13 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
         "query_result_cache_store_local_eviction",
         "Cumulative evictions from the per core local query result cache store (vs backing shared cache store)",
         "cumulative_evictions",
-        PrometheusMetricType.COUNTER);
+        PrometheusMetricType.COUNTER),
+    CUMULATIVE_FCACHE_DOCS_HOT_LOCAL_EVICTION(
+            "CACHE.searcher.fcache-docs-hot",
+            "fcache_docs_hot_local_eviction",
+            "Cumulative evictions from the per core local fcache-docs-hot cache store (vs backing shared cache store)",
+            "cumulative_evictions",
+            PrometheusMetricType.COUNTER);
     final String key, metricName, desc, property;
     private final PrometheusMetricType metricType;
     private static final Map<String, CoreMetric> lookup = new HashMap<>();

--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -877,11 +877,11 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
         "cumulative_evictions",
         PrometheusMetricType.COUNTER),
     CUMULATIVE_FCACHE_DOCS_HOT_LOCAL_EVICTION(
-            "CACHE.searcher.fcache-docs-hot",
-            "fcache_docs_hot_local_eviction",
-            "Cumulative evictions from the per core local fcache-docs-hot cache store (vs backing shared cache store)",
-            "cumulative_evictions",
-            PrometheusMetricType.COUNTER);
+        "CACHE.searcher.fcache-docs-hot",
+        "fcache_docs_hot_local_eviction",
+        "Cumulative evictions from the per core local fcache-docs-hot cache store (vs backing shared cache store)",
+        "cumulative_evictions",
+        PrometheusMetricType.COUNTER);
     final String key, metricName, desc, property;
     private final PrometheusMetricType metricType;
     private static final Map<String, CoreMetric> lookup = new HashMap<>();


### PR DESCRIPTION
## Description
Adding local eviction metrics for `fcache-docs-hot`


## Test
Debug locally by hitting http://localhost:8983/solr/metrics to ensure the source cache metric key/property exists and gives
```
# HELP fcache_docs_hot_local_eviction Cumulative evictions from the per core local fcache-docs-hot cache store (vs backing shared cache store)
# TYPE fcache_docs_hot_local_eviction counter
fcache_docs_hot_local_eviction 0
```