### PR TITLE
SAI-5804: Synchronizes commits on all cores for a give collection

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/CoreContainer.java
+++ b/solr/core/src/java/org/apache/solr/core/CoreContainer.java
@@ -154,6 +154,7 @@ import org.apache.solr.security.PKIAuthenticationPlugin;
 import org.apache.solr.security.PublicKeyHandler;
 import org.apache.solr.security.SecurityPluginHolder;
 import org.apache.solr.security.SolrNodeKeyPair;
+import org.apache.solr.update.CommitTrackerManager;
 import org.apache.solr.update.SolrCoreState;
 import org.apache.solr.update.UpdateShardHandler;
 import org.apache.solr.util.OrderedExecutor;
@@ -1045,6 +1046,7 @@ public class CoreContainer {
 
     if (getZkController() != null) {
       cacheOverridesManager = new CacheOverridesManager(getZkController().getZkStateReader());
+      CommitTrackerManager.init(getZkController().getZkStateReader());
     }
 
     // setup executor to load cores in parallel

--- a/solr/core/src/java/org/apache/solr/core/SolrConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrConfig.java
@@ -831,6 +831,7 @@ public class SolrConfig implements MapSerializable {
     public final boolean openSearcher; // is opening a new searcher part of hard autocommit?
     public final boolean commitWithinSoftCommit;
     public final boolean aggregateNodeLevelMetricsEnabled;
+    public final boolean alignCommitTime;
 
     /**
      * @param autoCommmitMaxDocs set -1 as default
@@ -845,7 +846,8 @@ public class SolrConfig implements MapSerializable {
         boolean openSearcher,
         int autoSoftCommmitMaxDocs,
         int autoSoftCommmitMaxTime,
-        boolean commitWithinSoftCommit) {
+        boolean commitWithinSoftCommit,
+        boolean alignCommitTime) {
       this.className = className;
       this.autoCommmitMaxDocs = autoCommmitMaxDocs;
       this.autoCommmitMaxTime = autoCommmitMaxTime;
@@ -857,6 +859,7 @@ public class SolrConfig implements MapSerializable {
 
       this.commitWithinSoftCommit = commitWithinSoftCommit;
       this.aggregateNodeLevelMetricsEnabled = false;
+      this.alignCommitTime = alignCommitTime;
     }
 
     public UpdateHandlerInfo(ConfigNode updateHandler) {
@@ -873,6 +876,7 @@ public class SolrConfig implements MapSerializable {
           updateHandler.get("commitWithin").get("softCommit").boolVal(true);
       this.aggregateNodeLevelMetricsEnabled =
           updateHandler.boolAttr("aggregateNodeLevelMetricsEnabled", false);
+      this.alignCommitTime = updateHandler.get("alignCommitTime").boolVal(false);
     }
 
     @Override

--- a/solr/core/src/java/org/apache/solr/core/SolrConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrConfig.java
@@ -876,8 +876,7 @@ public class SolrConfig implements MapSerializable {
           updateHandler.get("commitWithin").get("softCommit").boolVal(true);
       this.aggregateNodeLevelMetricsEnabled =
           updateHandler.boolAttr("aggregateNodeLevelMetricsEnabled", false);
-      this.alignCommitTime =
-          updateHandler.get("alignCommitTime").boolVal(false);
+      this.alignCommitTime = updateHandler.get("alignCommitTime").boolVal(false);
     }
 
     @Override

--- a/solr/core/src/java/org/apache/solr/core/SolrConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrConfig.java
@@ -876,7 +876,7 @@ public class SolrConfig implements MapSerializable {
           updateHandler.get("commitWithin").get("softCommit").boolVal(true);
       this.aggregateNodeLevelMetricsEnabled =
           updateHandler.boolAttr("aggregateNodeLevelMetricsEnabled", false);
-      this.alignCommitTime = updateHandler.get("alignCommitTime").boolVal(false);
+      this.alignCommitTime = updateHandler.get("autoSoftCommit").get("alignCommitTime").boolVal(false);
     }
 
     @Override

--- a/solr/core/src/java/org/apache/solr/core/SolrConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrConfig.java
@@ -876,7 +876,8 @@ public class SolrConfig implements MapSerializable {
           updateHandler.get("commitWithin").get("softCommit").boolVal(true);
       this.aggregateNodeLevelMetricsEnabled =
           updateHandler.boolAttr("aggregateNodeLevelMetricsEnabled", false);
-      this.alignCommitTime = updateHandler.get("autoSoftCommit").get("alignCommitTime").boolVal(false);
+      this.alignCommitTime =
+          updateHandler.get("autoSoftCommit").get("alignCommitTime").boolVal(false);
     }
 
     @Override

--- a/solr/core/src/java/org/apache/solr/core/SolrConfig.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrConfig.java
@@ -877,7 +877,7 @@ public class SolrConfig implements MapSerializable {
       this.aggregateNodeLevelMetricsEnabled =
           updateHandler.boolAttr("aggregateNodeLevelMetricsEnabled", false);
       this.alignCommitTime =
-          updateHandler.get("autoSoftCommit").get("alignCommitTime").boolVal(false);
+          updateHandler.get("alignCommitTime").boolVal(false);
     }
 
     @Override

--- a/solr/core/src/java/org/apache/solr/update/CommitTracker.java
+++ b/solr/core/src/java/org/apache/solr/update/CommitTracker.java
@@ -143,7 +143,7 @@ public final class CommitTracker implements Runnable {
   private void _scheduleCommitWithin(long commitMaxTime) {
     if (commitMaxTime <= 0) return;
     synchronized (this) {
-      long drift = core.getCoreDescriptor().getCollectionName().hashCode() % commitMaxTime;
+      long drift = Math.abs(core.getCoreDescriptor().getCollectionName().hashCode()) % commitMaxTime;
       long currentTime = System.currentTimeMillis();
       commitMaxTime = drift + commitMaxTime - (currentTime % commitMaxTime);
 

--- a/solr/core/src/java/org/apache/solr/update/CommitTracker.java
+++ b/solr/core/src/java/org/apache/solr/update/CommitTracker.java
@@ -280,7 +280,7 @@ public final class CommitTracker implements Runnable {
   @Override
   public void run() {
     synchronized (this) {
-      // log.info("###start commit. pending=null");
+      log.info("###start commit. pending=null");
       pending = null; // allow a new commit to be scheduled
     }
 
@@ -320,7 +320,7 @@ public final class CommitTracker implements Runnable {
       }
       MDCLoggingContext.clear();
     }
-    // log.info("###done committing");
+     log.info("###done committing");
   }
 
   // to facilitate testing: blocks if called during commit

--- a/solr/core/src/java/org/apache/solr/update/CommitTracker.java
+++ b/solr/core/src/java/org/apache/solr/update/CommitTracker.java
@@ -155,9 +155,7 @@ public final class CommitTracker implements Runnable {
       if (shouldAlignCommitTime()) {
         commitMaxTime =
             alignCommitMaxTime(
-                core.getCoreDescriptor().getCollectionName(),
-                commitMaxTime,
-                new Date().getTime());
+                core.getCoreDescriptor().getCollectionName(), commitMaxTime, new Date().getTime());
       }
 
       if (pending != null && pending.getDelay(TimeUnit.MILLISECONDS) <= commitMaxTime) {
@@ -203,18 +201,24 @@ public final class CommitTracker implements Runnable {
   static long alignCommitMaxTime(String collection, long commitMaxTime, long currentTimeMillis) {
     int collectionHash = collection.hashCode() & 0x7FFFFFFF;
     long jitter =
-        collectionHash
-            % commitMaxTime; // a positive jitter less than commitMaxTime, so different collections
-    // will spread out their commits
-    long msSinceCommitPoint =
-        currentTimeMillis
-            % commitMaxTime; // time since the last possible commit point, for example if
-    // commitMaxTime is 1min, then it's how many millisec since the start
-    // of the minute etc
+        collectionHash % commitMaxTime; // a positive jitter to spread out commits per collection
 
-    return commitMaxTime
-        - msSinceCommitPoint
-        + jitter; // deduct by msSinceCommitPoint to align to previous commit point, then add jitter
+    /*
+     * An adjustment to be used to re-align the commit time to the absolute commit time frame
+     * (without jitter) then apply the jitter.
+     *
+     * For example, if commitMaxTime is 60000, currentTimeMillis % commitMaxTime will align the time
+     * back to the beginning of a minute, then we add the jitter and % commitMaxTime the whole
+     * adjustment to ensure such adjustment is within the range of 0 to commitMaxTime.
+     */
+    long adjustment = (currentTimeMillis + jitter) % commitMaxTime;
+
+    /*
+     * The adjustment is then subtracted from commitMaxTime * 3 / 2 to ensure the returned
+     * commitMaxTime is always within 0.5 * commitMaxTime to 1.5 * commitMaxTime, so commits are
+     * batched together as far as they are within half the commitMaxTime.
+     */
+    return commitMaxTime * 3 / 2 - adjustment;
   }
 
   /**

--- a/solr/core/src/java/org/apache/solr/update/CommitTracker.java
+++ b/solr/core/src/java/org/apache/solr/update/CommitTracker.java
@@ -189,14 +189,16 @@ public final class CommitTracker implements Runnable {
   }
 
   /**
-   * Aligns the commit time with 2 policies:
+   * Aligns the commit time per collection with 2 policies:
    *
    * <ol>
-   *   <li>Align the commit time by "padding" to the next commit point based on commitMaxTime
-   *   <li>Jitter the time per collection, adding a value up to commitMaxTime
+   *   <li>Adjust the commit time by aligning to absolute commit point based on commitMaxTime. For
+   *       example if commitMaxTime is 60000 (60sec), then absolute commit point will be at the
+   *       start of every minute
+   *   <li>Jitter the time per collection up to commitMaxTime
    * </ol>
    *
-   * @return the adjusted commit max time to be used for scheduling
+   * @return the adjusted commit max time to be used for scheduling aligned commits
    */
   static long alignCommitMaxTime(String collection, long commitMaxTime, long currentTimeMillis) {
     int collectionHash = collection.hashCode() & 0x7FFFFFFF;

--- a/solr/core/src/java/org/apache/solr/update/CommitTracker.java
+++ b/solr/core/src/java/org/apache/solr/update/CommitTracker.java
@@ -311,51 +311,56 @@ public final class CommitTracker implements Runnable {
   /** This is the worker part for the ScheduledFuture * */
   @Override
   public void run() {
-    synchronized (this) {
-      if (openSearcher) {
-        log.info("###start commit that openSearcher. pending=null");
-      }
-      pending = null; // allow a new commit to be scheduled
-    }
-
-    MDCLoggingContext.setCore(core);
-    RTimer timer = timeUpperBound > 0 ? new RTimer() : null;
-    try (SolrQueryRequest req = new LocalSolrQueryRequest(core, new ModifiableSolrParams())) {
-      CommitUpdateCommand command = new CommitUpdateCommand(req, false);
-      command.openSearcher = openSearcher;
-      command.waitSearcher = WAIT_SEARCHER;
-      command.softCommit = softCommit;
-      command.autoCommit = true;
-      if (core.getCoreDescriptor().getCloudDescriptor() != null
-          && core.getCoreDescriptor().getCloudDescriptor().isLeader()
-          && !softCommit) {
-        command.version = core.getUpdateHandler().getUpdateLog().getVersionInfo().getNewClock();
-      }
-      // no need for command.maxOptimizeSegments = 1; since it is not optimizing
-
-      // we increment this *before* calling commit because it was causing a race
-      // in the tests (the new searcher was registered and the test proceeded
-      // to check the commit count before we had incremented it.)
-      autoCommitCount.incrementAndGet();
-
-      core.getUpdateHandler().commit(command);
-    } catch (Exception e) {
-      log.error("auto commit error...", e);
-    } finally {
-      if (timer != null) {
-        long elapsed = (long) timer.stop();
-        if (timeUpperBound > 0 && elapsed > timeUpperBound) {
-          log.warn(
-              "Spent {} millisec on {} auto-commit, which is longer than the configured commit interval of {} millisec",
-              elapsed,
-              softCommit ? "soft" : "hard",
-              timeUpperBound);
+    try {
+      MDCLoggingContext.setCore(core);
+      synchronized (this) {
+        if (openSearcher) {
+          log.info("###start commit that openSearcher. pending=null");
         }
+        pending = null; // allow a new commit to be scheduled
       }
+
+      MDCLoggingContext.setCore(core);
+      RTimer timer = timeUpperBound > 0 ? new RTimer() : null;
+      try (SolrQueryRequest req = new LocalSolrQueryRequest(core, new ModifiableSolrParams())) {
+        CommitUpdateCommand command = new CommitUpdateCommand(req, false);
+        command.openSearcher = openSearcher;
+        command.waitSearcher = WAIT_SEARCHER;
+        command.softCommit = softCommit;
+        command.autoCommit = true;
+        if (core.getCoreDescriptor().getCloudDescriptor() != null
+                && core.getCoreDescriptor().getCloudDescriptor().isLeader()
+                && !softCommit) {
+          command.version = core.getUpdateHandler().getUpdateLog().getVersionInfo().getNewClock();
+        }
+        // no need for command.maxOptimizeSegments = 1; since it is not optimizing
+
+        // we increment this *before* calling commit because it was causing a race
+        // in the tests (the new searcher was registered and the test proceeded
+        // to check the commit count before we had incremented it.)
+        autoCommitCount.incrementAndGet();
+
+        core.getUpdateHandler().commit(command);
+      } catch (Exception e) {
+        log.error("auto commit error...", e);
+      } finally {
+        if (timer != null) {
+          long elapsed = (long) timer.stop();
+          if (timeUpperBound > 0 && elapsed > timeUpperBound) {
+            log.warn(
+                    "Spent {} millisec on {} auto-commit, which is longer than the configured commit interval of {} millisec",
+                    elapsed,
+                    softCommit ? "soft" : "hard",
+                    timeUpperBound);
+          }
+        }
+        MDCLoggingContext.clear();
+      }
+      if (openSearcher) {
+        log.info("###done committing with openSearcher");
+      }
+    } finally {
       MDCLoggingContext.clear();
-    }
-    if (openSearcher) {
-      log.info("###done committing with openSearcher");
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/update/CommitTracker.java
+++ b/solr/core/src/java/org/apache/solr/update/CommitTracker.java
@@ -143,11 +143,9 @@ public final class CommitTracker implements Runnable {
   private void _scheduleCommitWithin(long commitMaxTime) {
     if (commitMaxTime <= 0) return;
     synchronized (this) {
-      int collectionHash = core.getCoreDescriptor().getCollectionName().hashCode() & 0x7FFFFFFF;
-      long originalCommitMaxTime = commitMaxTime;
-      long drift = collectionHash % commitMaxTime;
-      long currentTime = System.currentTimeMillis();
-      commitMaxTime = drift + commitMaxTime - (currentTime % commitMaxTime);
+      if (openSearcher) {
+        commitMaxTime = adjustCommitMaxTime(core, commitMaxTime);
+      }
 
       if (pending != null && pending.getDelay(TimeUnit.MILLISECONDS) <= commitMaxTime) {
         // There is already a pending commit that will happen first, so
@@ -174,13 +172,24 @@ public final class CommitTracker implements Runnable {
 
       // log.info("###scheduling for " + commitMaxTime);
 
-      ZonedDateTime zonedDateTime = Instant.ofEpochMilli(currentTime + commitMaxTime)
+      ZonedDateTime zonedDateTime = Instant.ofEpochMilli(System.currentTimeMillis() + commitMaxTime)
               .atZone(ZoneId.systemDefault());
-      log.info("###scheduling {} with delay of {}ms drift {}ms, collection hash {}, ori. commitMaxTime {}. Target time will be {}", name, commitMaxTime, drift, collectionHash, originalCommitMaxTime, zonedDateTime.format(formatter));
       // schedule our new commit
+      if (openSearcher) {
+        log.info("###scheduling {} with commitMaxTime {}. Target commit execution time will be {}", name, commitMaxTime, zonedDateTime.format(formatter));
+      }
       pending = scheduler.schedule(this, commitMaxTime, TimeUnit.MILLISECONDS);
     }
   }
+
+  private static long adjustCommitMaxTime(SolrCore core, long commitMaxTime) {
+    int collectionHash = core.getCoreDescriptor().getCollectionName().hashCode() & 0x7FFFFFFF;
+    long jitter = collectionHash % commitMaxTime; // a positive jitter less than commitMaxTime, so different collections will spread out their commits
+    long msSinceCommitPoint = System.currentTimeMillis() % commitMaxTime; //time since the last possible commit point, for example if commitMaxTime is 1min, then it's how many millisec since the start of the minute etc
+
+    return commitMaxTime - msSinceCommitPoint + jitter; // deduct by msSinceCommitPoint to align to previous commit point, then add jitter
+  }
+
 
   /**
    * Indicate that documents have been added

--- a/solr/core/src/java/org/apache/solr/update/CommitTracker.java
+++ b/solr/core/src/java/org/apache/solr/update/CommitTracker.java
@@ -143,7 +143,7 @@ public final class CommitTracker implements Runnable {
   private void _scheduleCommitWithin(long commitMaxTime) {
     if (commitMaxTime <= 0) return;
     synchronized (this) {
-      long drift = Math.abs(core.getCoreDescriptor().getCollectionName().hashCode()) % commitMaxTime;
+      long drift = core.getCoreDescriptor().getCollectionName().hashCode() & 0x7FFFFFFF % commitMaxTime;
       long currentTime = System.currentTimeMillis();
       commitMaxTime = drift + commitMaxTime - (currentTime % commitMaxTime);
 

--- a/solr/core/src/java/org/apache/solr/update/CommitTracker.java
+++ b/solr/core/src/java/org/apache/solr/update/CommitTracker.java
@@ -147,7 +147,7 @@ public final class CommitTracker implements Runnable {
   private static DateTimeFormatter formatter =
       DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS z");
 
-  private boolean isAlignCommitTime() {
+  private boolean shouldAlignCommitTime() {
     if (!openSearcher) { // only align commit time for cache/searcher refresh
       return false;
     }
@@ -161,7 +161,7 @@ public final class CommitTracker implements Runnable {
   private void _scheduleCommitWithin(long commitMaxTime) {
     if (commitMaxTime <= 0) return;
     synchronized (this) {
-      boolean alignCommitTime = isAlignCommitTime();
+      boolean alignCommitTime = shouldAlignCommitTime();
       if (alignCommitTime) {
         commitMaxTime = alignCommitMaxTime(core, commitMaxTime);
       }

--- a/solr/core/src/java/org/apache/solr/update/CommitTracker.java
+++ b/solr/core/src/java/org/apache/solr/update/CommitTracker.java
@@ -143,7 +143,9 @@ public final class CommitTracker implements Runnable {
   private void _scheduleCommitWithin(long commitMaxTime) {
     if (commitMaxTime <= 0) return;
     synchronized (this) {
-      long drift = core.getCoreDescriptor().getCollectionName().hashCode() & 0x7FFFFFFF % commitMaxTime;
+      int collectionHash = core.getCoreDescriptor().getCollectionName().hashCode() & 0x7FFFFFFF;
+      long originalCommitMaxTime = commitMaxTime;
+      long drift = collectionHash % commitMaxTime;
       long currentTime = System.currentTimeMillis();
       commitMaxTime = drift + commitMaxTime - (currentTime % commitMaxTime);
 
@@ -174,7 +176,7 @@ public final class CommitTracker implements Runnable {
 
       ZonedDateTime zonedDateTime = Instant.ofEpochMilli(currentTime + commitMaxTime)
               .atZone(ZoneId.systemDefault());
-      log.info("###scheduling {} with delay of {}ms drift {}ms. Target time will be {}", name, commitMaxTime, drift, zonedDateTime.format(formatter));
+      log.info("###scheduling {} with delay of {}ms drift {}ms, collection hash {}, ori. commitMaxTime {}. Target time will be {}", name, commitMaxTime, drift, collectionHash, originalCommitMaxTime, zonedDateTime.format(formatter));
       // schedule our new commit
       pending = scheduler.schedule(this, commitMaxTime, TimeUnit.MILLISECONDS);
     }

--- a/solr/core/src/java/org/apache/solr/update/CommitTracker.java
+++ b/solr/core/src/java/org/apache/solr/update/CommitTracker.java
@@ -17,10 +17,6 @@
 package org.apache.solr.update;
 
 import java.lang.invoke.MethodHandles;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -29,7 +25,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongSupplier;
-import org.apache.solr.cloud.ZkController;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.SolrNamedThreadFactory;
 import org.apache.solr.core.SolrCore;
@@ -57,7 +52,6 @@ public final class CommitTracker implements Runnable {
   public static final int DOC_COMMIT_DELAY_MS = 1;
   // scheduler delay for maxSize-triggered autocommits
   public static final int SIZE_COMMIT_DELAY_MS = 1;
-  private final ZkController zkController;
   private final boolean alignCommitTime;
 
   // settings, not final so we can change them in testing
@@ -93,7 +87,6 @@ public final class CommitTracker implements Runnable {
       boolean softCommit,
       boolean alignCommitTime) {
     this.core = core;
-    this.zkController = core.getCoreContainer().getZkController();
     this.name = name;
     pending = null;
 
@@ -144,9 +137,6 @@ public final class CommitTracker implements Runnable {
     }
   }
 
-  private static DateTimeFormatter formatter =
-      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS z");
-
   private boolean shouldAlignCommitTime() {
     if (!openSearcher) { // only align commit time for cache/searcher refresh
       return false;
@@ -161,8 +151,7 @@ public final class CommitTracker implements Runnable {
   private void _scheduleCommitWithin(long commitMaxTime) {
     if (commitMaxTime <= 0) return;
     synchronized (this) {
-      boolean alignCommitTime = shouldAlignCommitTime();
-      if (alignCommitTime) {
+      if (shouldAlignCommitTime()) {
         commitMaxTime = alignCommitMaxTime(core, commitMaxTime);
       }
 
@@ -191,21 +180,23 @@ public final class CommitTracker implements Runnable {
 
       // log.info("###scheduling for " + commitMaxTime);
 
-      ZonedDateTime zonedDateTime =
-          Instant.ofEpochMilli(System.currentTimeMillis() + commitMaxTime)
-              .atZone(ZoneId.systemDefault());
       // schedule our new commit
-      if (log.isInfoEnabled() && alignCommitTime) {
-        log.info(
-            "###scheduling {} with commitMaxTime {}. Target commit execution time will be {}",
-            name,
-            commitMaxTime,
-            zonedDateTime.format(formatter));
-      }
       pending = scheduler.schedule(this, commitMaxTime, TimeUnit.MILLISECONDS);
     }
   }
 
+  /**
+   * Aligns the commit time with 2 policies:
+   *
+   * <ol>
+   *   <li>Align the commit time by "padding" to the next commit point based on commitMaxTime
+   *   <li>Jitter the time per collection, adding a value up to commitMaxTime
+   * </ol>
+   *
+   * @param core
+   * @param commitMaxTime
+   * @return the adjusted commit max time to be used for scheduling
+   */
   private static long alignCommitMaxTime(SolrCore core, long commitMaxTime) {
     int collectionHash = core.getCoreDescriptor().getCollectionName().hashCode() & 0x7FFFFFFF;
     long jitter =
@@ -311,57 +302,48 @@ public final class CommitTracker implements Runnable {
   /** This is the worker part for the ScheduledFuture * */
   @Override
   public void run() {
-    try {
-      MDCLoggingContext.setCore(core);
-      synchronized (this) {
-        if (openSearcher) {
-          log.info("###start commit that openSearcher. pending=null");
-        }
-        pending = null; // allow a new commit to be scheduled
-      }
+    synchronized (this) {
+      // log.info("###start commit. pending=null");
+      pending = null; // allow a new commit to be scheduled
+    }
 
-      MDCLoggingContext.setCore(core);
-      RTimer timer = timeUpperBound > 0 ? new RTimer() : null;
-      try (SolrQueryRequest req = new LocalSolrQueryRequest(core, new ModifiableSolrParams())) {
-        CommitUpdateCommand command = new CommitUpdateCommand(req, false);
-        command.openSearcher = openSearcher;
-        command.waitSearcher = WAIT_SEARCHER;
-        command.softCommit = softCommit;
-        command.autoCommit = true;
-        if (core.getCoreDescriptor().getCloudDescriptor() != null
-                && core.getCoreDescriptor().getCloudDescriptor().isLeader()
-                && !softCommit) {
-          command.version = core.getUpdateHandler().getUpdateLog().getVersionInfo().getNewClock();
-        }
-        // no need for command.maxOptimizeSegments = 1; since it is not optimizing
-
-        // we increment this *before* calling commit because it was causing a race
-        // in the tests (the new searcher was registered and the test proceeded
-        // to check the commit count before we had incremented it.)
-        autoCommitCount.incrementAndGet();
-
-        core.getUpdateHandler().commit(command);
-      } catch (Exception e) {
-        log.error("auto commit error...", e);
-      } finally {
-        if (timer != null) {
-          long elapsed = (long) timer.stop();
-          if (timeUpperBound > 0 && elapsed > timeUpperBound) {
-            log.warn(
-                    "Spent {} millisec on {} auto-commit, which is longer than the configured commit interval of {} millisec",
-                    elapsed,
-                    softCommit ? "soft" : "hard",
-                    timeUpperBound);
-          }
-        }
-        MDCLoggingContext.clear();
+    MDCLoggingContext.setCore(core);
+    RTimer timer = timeUpperBound > 0 ? new RTimer() : null;
+    try (SolrQueryRequest req = new LocalSolrQueryRequest(core, new ModifiableSolrParams())) {
+      CommitUpdateCommand command = new CommitUpdateCommand(req, false);
+      command.openSearcher = openSearcher;
+      command.waitSearcher = WAIT_SEARCHER;
+      command.softCommit = softCommit;
+      command.autoCommit = true;
+      if (core.getCoreDescriptor().getCloudDescriptor() != null
+          && core.getCoreDescriptor().getCloudDescriptor().isLeader()
+          && !softCommit) {
+        command.version = core.getUpdateHandler().getUpdateLog().getVersionInfo().getNewClock();
       }
-      if (openSearcher) {
-        log.info("###done committing with openSearcher");
-      }
+      // no need for command.maxOptimizeSegments = 1; since it is not optimizing
+
+      // we increment this *before* calling commit because it was causing a race
+      // in the tests (the new searcher was registered and the test proceeded
+      // to check the commit count before we had incremented it.)
+      autoCommitCount.incrementAndGet();
+
+      core.getUpdateHandler().commit(command);
+    } catch (Exception e) {
+      log.error("auto commit error...", e);
     } finally {
+      if (timer != null) {
+        long elapsed = (long) timer.stop();
+        if (timeUpperBound > 0 && elapsed > timeUpperBound) {
+          log.warn(
+              "Spent {} millisec on {} auto-commit, which is longer than the configured commit interval of {} millisec",
+              elapsed,
+              softCommit ? "soft" : "hard",
+              timeUpperBound);
+        }
+      }
       MDCLoggingContext.clear();
     }
+    // log.info("###done committing");
   }
 
   // to facilitate testing: blocks if called during commit

--- a/solr/core/src/java/org/apache/solr/update/CommitTracker.java
+++ b/solr/core/src/java/org/apache/solr/update/CommitTracker.java
@@ -17,6 +17,7 @@
 package org.apache.solr.update;
 
 import java.lang.invoke.MethodHandles;
+import java.util.Date;
 import java.util.Locale;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -156,7 +157,7 @@ public final class CommitTracker implements Runnable {
             alignCommitMaxTime(
                 core.getCoreDescriptor().getCollectionName(),
                 commitMaxTime,
-                System.currentTimeMillis());
+                new Date().getTime());
       }
 
       if (pending != null && pending.getDelay(TimeUnit.MILLISECONDS) <= commitMaxTime) {

--- a/solr/core/src/java/org/apache/solr/update/CommitTracker.java
+++ b/solr/core/src/java/org/apache/solr/update/CommitTracker.java
@@ -17,6 +17,10 @@
 package org.apache.solr.update;
 
 import java.lang.invoke.MethodHandles;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -134,9 +138,15 @@ public final class CommitTracker implements Runnable {
     }
   }
 
+  private static DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS z");
+
   private void _scheduleCommitWithin(long commitMaxTime) {
     if (commitMaxTime <= 0) return;
     synchronized (this) {
+      long drift = core.getCoreDescriptor().getCollectionName().hashCode() % commitMaxTime;
+      long currentTime = System.currentTimeMillis();
+      commitMaxTime = drift + commitMaxTime - (currentTime % commitMaxTime);
+
       if (pending != null && pending.getDelay(TimeUnit.MILLISECONDS) <= commitMaxTime) {
         // There is already a pending commit that will happen first, so
         // nothing else to do here.
@@ -162,6 +172,9 @@ public final class CommitTracker implements Runnable {
 
       // log.info("###scheduling for " + commitMaxTime);
 
+      ZonedDateTime zonedDateTime = Instant.ofEpochMilli(currentTime + commitMaxTime)
+              .atZone(ZoneId.systemDefault());
+      log.info("###scheduling {} with delay of {}ms drift {}ms. Target time will be {}", name, commitMaxTime, drift, zonedDateTime.format(formatter));
       // schedule our new commit
       pending = scheduler.schedule(this, commitMaxTime, TimeUnit.MILLISECONDS);
     }

--- a/solr/core/src/java/org/apache/solr/update/CommitTracker.java
+++ b/solr/core/src/java/org/apache/solr/update/CommitTracker.java
@@ -22,7 +22,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
-import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -30,7 +29,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongSupplier;
-
 import org.apache.solr.cloud.ZkController;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.SolrNamedThreadFactory;
@@ -60,6 +58,7 @@ public final class CommitTracker implements Runnable {
   // scheduler delay for maxSize-triggered autocommits
   public static final int SIZE_COMMIT_DELAY_MS = 1;
   private final ZkController zkController;
+  private final boolean alignCommitTime;
 
   // settings, not final so we can change them in testing
   private int docsUpperBound;
@@ -91,7 +90,8 @@ public final class CommitTracker implements Runnable {
       int timeUpperBound,
       long tLogFileSizeUpperBound,
       boolean openSearcher,
-      boolean softCommit) {
+      boolean softCommit,
+      boolean alignCommitTime) {
     this.core = core;
     this.zkController = core.getCoreContainer().getZkController();
     this.name = name;
@@ -103,6 +103,7 @@ public final class CommitTracker implements Runnable {
 
     this.softCommit = softCommit;
     this.openSearcher = openSearcher;
+    this.alignCommitTime = alignCommitTime;
 
     log.info("{} AutoCommit: {}", name, this);
   }
@@ -143,13 +144,26 @@ public final class CommitTracker implements Runnable {
     }
   }
 
-  private static DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS z");
+  private static DateTimeFormatter formatter =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS z");
+
+  private boolean isAlignCommitTime() {
+    if (!openSearcher) { // only align commit time for cache/searcher refresh
+      return false;
+    }
+    Boolean override = CommitTrackerManager.getAlignCommitTimeOverride();
+    if (override != null) {
+      return override;
+    }
+    return alignCommitTime;
+  }
 
   private void _scheduleCommitWithin(long commitMaxTime) {
     if (commitMaxTime <= 0) return;
     synchronized (this) {
-      if (openSearcher && CommitTrackerManager.isAdjustCommitTime()) {
-        commitMaxTime = adjustCommitMaxTime(core, commitMaxTime);
+      boolean alignCommitTime = isAlignCommitTime();
+      if (alignCommitTime) {
+        commitMaxTime = alignCommitMaxTime(core, commitMaxTime);
       }
 
       if (pending != null && pending.getDelay(TimeUnit.MILLISECONDS) <= commitMaxTime) {
@@ -177,24 +191,37 @@ public final class CommitTracker implements Runnable {
 
       // log.info("###scheduling for " + commitMaxTime);
 
-      ZonedDateTime zonedDateTime = Instant.ofEpochMilli(System.currentTimeMillis() + commitMaxTime)
+      ZonedDateTime zonedDateTime =
+          Instant.ofEpochMilli(System.currentTimeMillis() + commitMaxTime)
               .atZone(ZoneId.systemDefault());
       // schedule our new commit
-      if (openSearcher) {
-        log.info("###scheduling {} with commitMaxTime {}. Target commit execution time will be {}", name, commitMaxTime, zonedDateTime.format(formatter));
+      if (log.isInfoEnabled() && alignCommitTime) {
+        log.info(
+            "###scheduling {} with commitMaxTime {}. Target commit execution time will be {}",
+            name,
+            commitMaxTime,
+            zonedDateTime.format(formatter));
       }
       pending = scheduler.schedule(this, commitMaxTime, TimeUnit.MILLISECONDS);
     }
   }
 
-  private static long adjustCommitMaxTime(SolrCore core, long commitMaxTime) {
+  private static long alignCommitMaxTime(SolrCore core, long commitMaxTime) {
     int collectionHash = core.getCoreDescriptor().getCollectionName().hashCode() & 0x7FFFFFFF;
-    long jitter = collectionHash % commitMaxTime; // a positive jitter less than commitMaxTime, so different collections will spread out their commits
-    long msSinceCommitPoint = System.currentTimeMillis() % commitMaxTime; //time since the last possible commit point, for example if commitMaxTime is 1min, then it's how many millisec since the start of the minute etc
+    long jitter =
+        collectionHash
+            % commitMaxTime; // a positive jitter less than commitMaxTime, so different collections
+    // will spread out their commits
+    long msSinceCommitPoint =
+        System.currentTimeMillis()
+            % commitMaxTime; // time since the last possible commit point, for example if
+    // commitMaxTime is 1min, then it's how many millisec since the start
+    // of the minute etc
 
-    return commitMaxTime - msSinceCommitPoint + jitter; // deduct by msSinceCommitPoint to align to previous commit point, then add jitter
+    return commitMaxTime
+        - msSinceCommitPoint
+        + jitter; // deduct by msSinceCommitPoint to align to previous commit point, then add jitter
   }
-
 
   /**
    * Indicate that documents have been added
@@ -280,7 +307,6 @@ public final class CommitTracker implements Runnable {
       docsSinceCommit.set(0);
     }
   }
-
 
   /** This is the worker part for the ScheduledFuture * */
   @Override

--- a/solr/core/src/java/org/apache/solr/update/CommitTracker.java
+++ b/solr/core/src/java/org/apache/solr/update/CommitTracker.java
@@ -22,6 +22,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -29,6 +30,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongSupplier;
+
+import org.apache.solr.cloud.ZkController;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.SolrNamedThreadFactory;
 import org.apache.solr.core.SolrCore;
@@ -56,6 +59,7 @@ public final class CommitTracker implements Runnable {
   public static final int DOC_COMMIT_DELAY_MS = 1;
   // scheduler delay for maxSize-triggered autocommits
   public static final int SIZE_COMMIT_DELAY_MS = 1;
+  private final ZkController zkController;
 
   // settings, not final so we can change them in testing
   private int docsUpperBound;
@@ -89,6 +93,7 @@ public final class CommitTracker implements Runnable {
       boolean openSearcher,
       boolean softCommit) {
     this.core = core;
+    this.zkController = core.getCoreContainer().getZkController();
     this.name = name;
     pending = null;
 
@@ -143,7 +148,7 @@ public final class CommitTracker implements Runnable {
   private void _scheduleCommitWithin(long commitMaxTime) {
     if (commitMaxTime <= 0) return;
     synchronized (this) {
-      if (openSearcher) {
+      if (openSearcher && CommitTrackerManager.isAdjustCommitTime()) {
         commitMaxTime = adjustCommitMaxTime(core, commitMaxTime);
       }
 
@@ -276,11 +281,14 @@ public final class CommitTracker implements Runnable {
     }
   }
 
+
   /** This is the worker part for the ScheduledFuture * */
   @Override
   public void run() {
     synchronized (this) {
-      log.info("###start commit. pending=null");
+      if (openSearcher) {
+        log.info("###start commit that openSearcher. pending=null");
+      }
       pending = null; // allow a new commit to be scheduled
     }
 
@@ -320,7 +328,9 @@ public final class CommitTracker implements Runnable {
       }
       MDCLoggingContext.clear();
     }
-     log.info("###done committing");
+    if (openSearcher) {
+      log.info("###done committing with openSearcher");
+    }
   }
 
   // to facilitate testing: blocks if called during commit

--- a/solr/core/src/java/org/apache/solr/update/CommitTracker.java
+++ b/solr/core/src/java/org/apache/solr/update/CommitTracker.java
@@ -116,7 +116,7 @@ public final class CommitTracker implements Runnable {
 
   /** schedule individual commits */
   public void scheduleCommitWithin(long commitMaxTime) {
-    _scheduleCommitWithin(commitMaxTime);
+    _scheduleCommitWithin(commitMaxTime, true);
   }
 
   public void cancelPendingCommit() {
@@ -134,7 +134,7 @@ public final class CommitTracker implements Runnable {
     long ctime = (commitWithin > 0) ? commitWithin : timeUpperBound;
 
     if (ctime > 0) {
-      _scheduleCommitWithin(ctime);
+      _scheduleCommitWithin(ctime, true);
     }
   }
 
@@ -149,10 +149,10 @@ public final class CommitTracker implements Runnable {
     return alignCommitTime;
   }
 
-  private void _scheduleCommitWithin(long commitMaxTime) {
+  private void _scheduleCommitWithin(long commitMaxTime, boolean allowAlign) {
     if (commitMaxTime <= 0) return;
     synchronized (this) {
-      if (shouldAlignCommitTime()) {
+      if (allowAlign && shouldAlignCommitTime()) {
         commitMaxTime =
             alignCommitMaxTime(
                 core.getCoreDescriptor().getCollectionName(), commitMaxTime, new Date().getTime());
@@ -261,7 +261,7 @@ public final class CommitTracker implements Runnable {
       if (docs == docsUpperBound + 1) {
         // reset the count here instead of run() so we don't miss other documents being added
         docsSinceCommit.set(0);
-        _scheduleCommitWithin(DOC_COMMIT_DELAY_MS);
+        _scheduleCommitWithin(DOC_COMMIT_DELAY_MS, false);
       }
     }
   }
@@ -290,7 +290,7 @@ public final class CommitTracker implements Runnable {
   private void _scheduleMaxSizeTriggeredCommitIfNeeded(LongSupplier currentTlogSize) {
     if (tLogFileSizeUpperBound > 0 && currentTlogSize.getAsLong() > tLogFileSizeUpperBound) {
       docsSinceCommit.set(0);
-      _scheduleCommitWithin(SIZE_COMMIT_DELAY_MS);
+      _scheduleCommitWithin(SIZE_COMMIT_DELAY_MS, false);
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/update/CommitTracker.java
+++ b/solr/core/src/java/org/apache/solr/update/CommitTracker.java
@@ -152,7 +152,11 @@ public final class CommitTracker implements Runnable {
     if (commitMaxTime <= 0) return;
     synchronized (this) {
       if (shouldAlignCommitTime()) {
-        commitMaxTime = alignCommitMaxTime(core, commitMaxTime);
+        commitMaxTime =
+            alignCommitMaxTime(
+                core.getCoreDescriptor().getCollectionName(),
+                commitMaxTime,
+                System.currentTimeMillis());
       }
 
       if (pending != null && pending.getDelay(TimeUnit.MILLISECONDS) <= commitMaxTime) {
@@ -193,18 +197,16 @@ public final class CommitTracker implements Runnable {
    *   <li>Jitter the time per collection, adding a value up to commitMaxTime
    * </ol>
    *
-   * @param core
-   * @param commitMaxTime
    * @return the adjusted commit max time to be used for scheduling
    */
-  private static long alignCommitMaxTime(SolrCore core, long commitMaxTime) {
-    int collectionHash = core.getCoreDescriptor().getCollectionName().hashCode() & 0x7FFFFFFF;
+  static long alignCommitMaxTime(String collection, long commitMaxTime, long currentTimeMillis) {
+    int collectionHash = collection.hashCode() & 0x7FFFFFFF;
     long jitter =
         collectionHash
             % commitMaxTime; // a positive jitter less than commitMaxTime, so different collections
     // will spread out their commits
     long msSinceCommitPoint =
-        System.currentTimeMillis()
+        currentTimeMillis
             % commitMaxTime; // time since the last possible commit point, for example if
     // commitMaxTime is 1min, then it's how many millisec since the start
     // of the minute etc

--- a/solr/core/src/java/org/apache/solr/update/CommitTrackerManager.java
+++ b/solr/core/src/java/org/apache/solr/update/CommitTrackerManager.java
@@ -1,0 +1,29 @@
+package org.apache.solr.update;
+
+import org.apache.solr.common.cloud.ClusterProperties;
+import org.apache.solr.common.cloud.ZkStateReader;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class CommitTrackerManager {
+  public static final String ADJUST_COMMIT_TIME =
+          ClusterProperties.EXT_PROPRTTY_PREFIX + "adjustCommitTime";
+  private static final boolean DEFAULT_ADJUST_COMMIT_TIME = true; //adjust by default
+  private static final AtomicBoolean adjustCommitTime = new AtomicBoolean(DEFAULT_ADJUST_COMMIT_TIME);
+  private CommitTrackerManager() {
+  }
+  public static void init(ZkStateReader zkStateReader) {
+    zkStateReader.registerClusterPropertiesListener((Map<String, Object> properties) -> {
+      Boolean val = (Boolean) properties.get(ADJUST_COMMIT_TIME);
+      adjustCommitTime.set(Objects.requireNonNullElse(val, DEFAULT_ADJUST_COMMIT_TIME));
+      return false;
+    });
+  }
+
+  public static boolean isAdjustCommitTime() {
+    return adjustCommitTime.get();
+  }
+
+}

--- a/solr/core/src/java/org/apache/solr/update/CommitTrackerManager.java
+++ b/solr/core/src/java/org/apache/solr/update/CommitTrackerManager.java
@@ -1,11 +1,15 @@
 package org.apache.solr.update;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Map;
 import org.apache.solr.common.cloud.ClusterProperties;
 import org.apache.solr.common.cloud.ZkStateReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CommitTrackerManager {
-  public static final String ALIGN_COMMIT_TIME =
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  public static final String ALIGN_COMMIT_TIME_KEY =
       ClusterProperties.EXT_PROPRTTY_PREFIX + "alignCommitTime";
   private static volatile Boolean alignCommitTimeOverride;
 
@@ -14,7 +18,8 @@ public class CommitTrackerManager {
   public static void init(ZkStateReader zkStateReader) {
     zkStateReader.registerClusterPropertiesListener(
         (Map<String, Object> properties) -> {
-          alignCommitTimeOverride = (Boolean) properties.get(ALIGN_COMMIT_TIME);
+          alignCommitTimeOverride = (Boolean) properties.get(ALIGN_COMMIT_TIME_KEY);
+          log.info("{} change detected serving alignCommitTimeOverride: {}", ALIGN_COMMIT_TIME_KEY, alignCommitTimeOverride);
           return false;
         });
   }

--- a/solr/core/src/java/org/apache/solr/update/CommitTrackerManager.java
+++ b/solr/core/src/java/org/apache/solr/update/CommitTrackerManager.java
@@ -7,6 +7,10 @@ import org.apache.solr.common.cloud.ZkStateReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * De-couple the commit tracker config management logic from CommitTracker instance. <br>
+ * This only tracks and manage the ext.alignCommitTime override property for now.
+ */
 public class CommitTrackerManager {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   public static final String ALIGN_COMMIT_TIME_KEY =
@@ -19,7 +23,10 @@ public class CommitTrackerManager {
     zkStateReader.registerClusterPropertiesListener(
         (Map<String, Object> properties) -> {
           alignCommitTimeOverride = (Boolean) properties.get(ALIGN_COMMIT_TIME_KEY);
-          log.info("{} change detected serving alignCommitTimeOverride: {}", ALIGN_COMMIT_TIME_KEY, alignCommitTimeOverride);
+          log.info(
+              "{} change detected serving alignCommitTimeOverride: {}",
+              ALIGN_COMMIT_TIME_KEY,
+              alignCommitTimeOverride);
           return false;
         });
   }

--- a/solr/core/src/java/org/apache/solr/update/CommitTrackerManager.java
+++ b/solr/core/src/java/org/apache/solr/update/CommitTrackerManager.java
@@ -1,29 +1,25 @@
 package org.apache.solr.update;
 
+import java.util.Map;
 import org.apache.solr.common.cloud.ClusterProperties;
 import org.apache.solr.common.cloud.ZkStateReader;
 
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 public class CommitTrackerManager {
-  public static final String ADJUST_COMMIT_TIME =
-          ClusterProperties.EXT_PROPRTTY_PREFIX + "adjustCommitTime";
-  private static final boolean DEFAULT_ADJUST_COMMIT_TIME = true; //adjust by default
-  private static final AtomicBoolean adjustCommitTime = new AtomicBoolean(DEFAULT_ADJUST_COMMIT_TIME);
-  private CommitTrackerManager() {
-  }
+  public static final String ALIGN_COMMIT_TIME =
+      ClusterProperties.EXT_PROPRTTY_PREFIX + "alignCommitTime";
+  private static volatile Boolean alignCommitTimeOverride;
+
+  private CommitTrackerManager() {}
+
   public static void init(ZkStateReader zkStateReader) {
-    zkStateReader.registerClusterPropertiesListener((Map<String, Object> properties) -> {
-      Boolean val = (Boolean) properties.get(ADJUST_COMMIT_TIME);
-      adjustCommitTime.set(Objects.requireNonNullElse(val, DEFAULT_ADJUST_COMMIT_TIME));
-      return false;
-    });
+    zkStateReader.registerClusterPropertiesListener(
+        (Map<String, Object> properties) -> {
+          alignCommitTimeOverride = (Boolean) properties.get(ALIGN_COMMIT_TIME);
+          return false;
+        });
   }
 
-  public static boolean isAdjustCommitTime() {
-    return adjustCommitTime.get();
+  public static Boolean getAlignCommitTimeOverride() {
+    return alignCommitTimeOverride;
   }
-
 }

--- a/solr/core/src/java/org/apache/solr/update/DirectUpdateHandler2.java
+++ b/solr/core/src/java/org/apache/solr/update/DirectUpdateHandler2.java
@@ -136,7 +136,8 @@ public class DirectUpdateHandler2 extends UpdateHandler
             timeUpperBound,
             fileSizeUpperBound,
             updateHandlerInfo.openSearcher,
-            false);
+            false,
+            updateHandlerInfo.alignCommitTime);
 
     int softCommitDocsUpperBound = updateHandlerInfo.autoSoftCommmitMaxDocs;
     int softCommitTimeUpperBound = updateHandlerInfo.autoSoftCommmitMaxTime;
@@ -148,7 +149,8 @@ public class DirectUpdateHandler2 extends UpdateHandler
             softCommitTimeUpperBound,
             NO_FILE_SIZE_UPPER_BOUND_PLACEHOLDER,
             true,
-            true);
+            true,
+            updateHandlerInfo.alignCommitTime);
 
     commitWithinSoftCommit = updateHandlerInfo.commitWithinSoftCommit;
 
@@ -179,7 +181,8 @@ public class DirectUpdateHandler2 extends UpdateHandler
             timeUpperBound,
             fileSizeUpperBound,
             updateHandlerInfo.openSearcher,
-            false);
+            false,
+            updateHandlerInfo.alignCommitTime);
 
     int softCommitDocsUpperBound = updateHandlerInfo.autoSoftCommmitMaxDocs;
     int softCommitTimeUpperBound = updateHandlerInfo.autoSoftCommmitMaxTime;
@@ -191,7 +194,8 @@ public class DirectUpdateHandler2 extends UpdateHandler
             softCommitTimeUpperBound,
             NO_FILE_SIZE_UPPER_BOUND_PLACEHOLDER,
             updateHandlerInfo.openSearcher,
-            true);
+            true,
+            updateHandlerInfo.alignCommitTime);
 
     commitWithinSoftCommit = updateHandlerInfo.commitWithinSoftCommit;
 

--- a/solr/core/src/test/org/apache/solr/cloud/ReplicateFromLeaderTest.java
+++ b/solr/core/src/test/org/apache/solr/cloud/ReplicateFromLeaderTest.java
@@ -28,43 +28,43 @@ public class ReplicateFromLeaderTest {
   public void determinePollIntervalString() {
     SolrConfig.UpdateHandlerInfo updateHandlerInfo =
         new SolrConfig.UpdateHandlerInfo(
-            "solr.DirectUpdateHandler2", -1, 15000, -1, true, -1, 60000, false);
+            "solr.DirectUpdateHandler2", -1, 15000, -1, true, -1, 60000, false, false);
     String pollInterval = ReplicateFromLeader.determinePollInterval(updateHandlerInfo);
     assertEquals("0:0:7", pollInterval);
 
     updateHandlerInfo =
         new SolrConfig.UpdateHandlerInfo(
-            "solr.DirectUpdateHandler2", -1, 60000, -1, true, -1, 15000, false);
+            "solr.DirectUpdateHandler2", -1, 60000, -1, true, -1, 15000, false, false);
     pollInterval = ReplicateFromLeader.determinePollInterval(updateHandlerInfo);
     assertEquals("0:0:30", pollInterval);
 
     updateHandlerInfo =
         new SolrConfig.UpdateHandlerInfo(
-            "solr.DirectUpdateHandler2", -1, 15000, -1, false, -1, 60000, false);
+            "solr.DirectUpdateHandler2", -1, 15000, -1, false, -1, 60000, false, false);
     pollInterval = ReplicateFromLeader.determinePollInterval(updateHandlerInfo);
     assertEquals("0:0:30", pollInterval);
 
     updateHandlerInfo =
         new SolrConfig.UpdateHandlerInfo(
-            "solr.DirectUpdateHandler2", -1, 60000, -1, false, -1, 15000, false);
+            "solr.DirectUpdateHandler2", -1, 60000, -1, false, -1, 15000, false, false);
     pollInterval = ReplicateFromLeader.determinePollInterval(updateHandlerInfo);
     assertEquals("0:0:30", pollInterval);
 
     updateHandlerInfo =
         new SolrConfig.UpdateHandlerInfo(
-            "solr.DirectUpdateHandler2", -1, -1, -1, false, -1, 60000, false);
+            "solr.DirectUpdateHandler2", -1, -1, -1, false, -1, 60000, false, false);
     pollInterval = ReplicateFromLeader.determinePollInterval(updateHandlerInfo);
     assertEquals("0:0:30", pollInterval);
 
     updateHandlerInfo =
         new SolrConfig.UpdateHandlerInfo(
-            "solr.DirectUpdateHandler2", -1, 15000, -1, false, -1, -1, false);
+            "solr.DirectUpdateHandler2", -1, 15000, -1, false, -1, -1, false, false);
     pollInterval = ReplicateFromLeader.determinePollInterval(updateHandlerInfo);
     assertEquals("0:0:7", pollInterval);
 
     updateHandlerInfo =
         new SolrConfig.UpdateHandlerInfo(
-            "solr.DirectUpdateHandler2", -1, 60000, -1, true, -1, -1, false);
+            "solr.DirectUpdateHandler2", -1, 60000, -1, true, -1, -1, false, false);
     pollInterval = ReplicateFromLeader.determinePollInterval(updateHandlerInfo);
     assertEquals("0:0:30", pollInterval);
   }

--- a/solr/core/src/test/org/apache/solr/update/CommitTrackerTest.java
+++ b/solr/core/src/test/org/apache/solr/update/CommitTrackerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.solr.update;
 
+import com.carrotsearch.randomizedtesting.RandomizedContext;
 import java.lang.invoke.MethodHandles;
 import java.util.Random;
 import org.apache.solr.SolrTestCaseJ4;
@@ -61,9 +62,8 @@ public class CommitTrackerTest extends SolrTestCaseJ4 {
 
   private static String generateRandomString() {
     int length = 10;
-    Random random = new Random();
+    Random random = RandomizedContext.current().getRandom();
     StringBuilder sb = new StringBuilder(length);
-
     for (int i = 0; i < length; i++) {
       char randomChar = (char) ('a' + random.nextInt(26));
       sb.append(randomChar);

--- a/solr/core/src/test/org/apache/solr/update/CommitTrackerTest.java
+++ b/solr/core/src/test/org/apache/solr/update/CommitTrackerTest.java
@@ -17,6 +17,7 @@
 package org.apache.solr.update;
 
 import java.lang.invoke.MethodHandles;
+import java.util.Random;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.util.LogLevel;
 import org.junit.Test;
@@ -30,18 +31,44 @@ public class CommitTrackerTest extends SolrTestCaseJ4 {
 
   @Test
   public void testAlignCommitTime() {
-    long time1 = CommitTracker.alignCommitMaxTime("A", 60000, 0);
-    assertTrue(time1 >= 0 && time1 < 60000 * 2); // at most jitter a whole commitMaxTime
-    long time2 = CommitTracker.alignCommitMaxTime("A", 60000, 1000);
-    assertTrue(time2 >= 0 && time2 < 60000 * 2); // at most jitter a whole commitMaxTime
-    // jitter should be same for same collection now 1sec has past hence adjusted time should be
-    // 1sec less (wait for 1 less sec)
-    assertEquals(time1 - 1000, time2);
-    long time3 = CommitTracker.alignCommitMaxTime("A", 60000, 60000);
-    assertEquals(time1, time3); // after 1 commitMaxTime, should be the same wait time
+    long commitMaxTime = 60000;
 
-    long time4 = CommitTracker.alignCommitMaxTime("B", 60000, 0);
-    assertTrue(time4 >= 0 && time4 < 60000 * 2); // at most jitter a whole commitMaxTime
-    assertNotEquals(time1, time4); // different collection different jitter
+    long time1 = CommitTracker.alignCommitMaxTime("A", commitMaxTime, 0);
+    assertTrue(time1 >= commitMaxTime / 2 && time1 < commitMaxTime * 3 / 2);
+    long time2 = CommitTracker.alignCommitMaxTime("A", commitMaxTime, 1000);
+    assertTrue(time2 >= commitMaxTime / 2 && time2 < commitMaxTime * 3 / 2);
+    // jitter should be same for same collection now 1sec has past hence adjusted time should be
+    // 1sec less (wait for 1 less sec when in the same commit frame)
+    // This COULD fail if the jitter is > 59 sec, but we know that's not the case for "A"
+    assertEquals(time1 - 1000, time2);
+
+    long time3 = CommitTracker.alignCommitMaxTime("B", commitMaxTime, 0);
+    assertTrue(time3 >= commitMaxTime / 2 && time3 < commitMaxTime * 3 / 2);
+    assertNotEquals(time1, time3); // different collection different jitter
+
+    for (int i = 0; i < 1000; i++) {
+      String coll = generateRandomString();
+      long waitTime = CommitTracker.alignCommitMaxTime(coll, commitMaxTime, 0);
+      assertTrue(waitTime >= commitMaxTime / 2 && waitTime < commitMaxTime * 3 / 2);
+      long nextWaitTime =
+          CommitTracker.alignCommitMaxTime(
+              coll,
+              commitMaxTime,
+              waitTime); // right at the commit point, it should ask to wait for full 60sec again
+      assertEquals(commitMaxTime, nextWaitTime);
+    }
+  }
+
+  private static String generateRandomString() {
+    int length = 10;
+    Random random = new Random();
+    StringBuilder sb = new StringBuilder(length);
+
+    for (int i = 0; i < length; i++) {
+      char randomChar = (char) ('a' + random.nextInt(26));
+      sb.append(randomChar);
+    }
+
+    return sb.toString();
   }
 }

--- a/solr/core/src/test/org/apache/solr/update/CommitTrackerTest.java
+++ b/solr/core/src/test/org/apache/solr/update/CommitTrackerTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.solr.update;
 
-import com.carrotsearch.randomizedtesting.RandomizedContext;
 import java.lang.invoke.MethodHandles;
 import java.util.Random;
 import org.apache.solr.SolrTestCaseJ4;
@@ -62,7 +61,7 @@ public class CommitTrackerTest extends SolrTestCaseJ4 {
 
   private static String generateRandomString() {
     int length = 10;
-    Random random = RandomizedContext.current().getRandom();
+    Random random = random();
     StringBuilder sb = new StringBuilder(length);
     for (int i = 0; i < length; i++) {
       char randomChar = (char) ('a' + random.nextInt(26));

--- a/solr/core/src/test/org/apache/solr/update/CommitTrackerTest.java
+++ b/solr/core/src/test/org/apache/solr/update/CommitTrackerTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.update;
+
+import java.lang.invoke.MethodHandles;
+import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.util.LogLevel;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@LogLevel("org.apache.solr.update=INFO")
+public class CommitTrackerTest extends SolrTestCaseJ4 {
+
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  @Test
+  public void testAlignCommitTime() {
+    long time1 = CommitTracker.alignCommitMaxTime("A", 60000, 0);
+    assertTrue(time1 >= 0 && time1 < 60000 * 2); // at most jitter a whole commitMaxTime
+    long time2 = CommitTracker.alignCommitMaxTime("A", 60000, 1000);
+    assertTrue(time2 >= 0 && time2 < 60000 * 2); // at most jitter a whole commitMaxTime
+    // jitter should be same for same collection now 1sec has past hence adjusted time should be
+    // 1sec less (wait for 1 less sec)
+    assertEquals(time1 - 1000, time2);
+    long time3 = CommitTracker.alignCommitMaxTime("A", 60000, 60000);
+    assertEquals(time1, time3); // after 1 commitMaxTime, should be the same wait time
+
+    long time4 = CommitTracker.alignCommitMaxTime("B", 60000, 0);
+    assertTrue(time4 >= 0 && time4 < 60000 * 2); // at most jitter a whole commitMaxTime
+    assertNotEquals(time1, time4); // different collection different jitter
+  }
+}


### PR DESCRIPTION
## Description
As proposed by @hiteshk25 (slack [thread](https://fullstory.slack.com/archives/C08RM0SGP43/p1757634993450419)), we can try to synchronize new search creation/replacement time to avoid query on high core count collection being slowed down due to certain core searchers being just refreshed.

## Solution
1. Add logic to the commit scheduling logic in `CommitTracker` with policies of:
   1. Only attempt to align/synchronize on commits with `openSearcher` as true
   2. Align the commit time by "padding" to the next commit point based on commitMaxTime. 
   3. Jitter the time per collection, adding a value up to commitMaxTime
   4. For example, if the current time is 12:00:15 and `commitMaxTime` is 60s (1 min). For collection A, jitter is 5 sec. Then the next commit time should be first padded to next commit point 12:01:00 then add jitter so 12:01:05. Hence the adjust `commitMaxTime` should now be 50 sec
2. Introduce `UpdateHandler.alignCommitTime` (default as `false`). If true, we will apply such alignment for commits with `openSearcher=true`
3. Introduce `CommitTrackerManager` which registers to clusterprops of key `ext.alignCommitTime`, this is an override that allows dynamics changes (w/o solr restart) to enable/disable such time alignment

## Test 
1. Added unit test case
2. Deployed on playpen:
   1. Set  `alignCommitTime` to true in config. Observed that for a collection `BF2`, message `o.a.s.c.SolrCore Registered new searcher autowarm time` were printed across multiple nodes within the same 100ms
   2. Set in clusterprops.json `"ext.alignCommitTime":false`. The new searcher message no longer aligns

## Remarks
For collection that has long commit/warm time, this might not work that perfectly. 

There were also concerns of clock time drift across nodes