### PR TITLE
SAI-5386: Support dynamic cache overrides on class using clusterprops.json as well

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/CacheConfig.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheConfig.java
@@ -215,7 +215,7 @@ public class CacheConfig implements MapSerializable {
    * The existing config should not be modified
    *
    * @param newArgs new arguments to merge into the existing config, overrides existing values
-   * @param core  the core to create the cache for
+   * @param core the core to create the cache for
    */
   public CacheConfig withArgs(Map<String, String> newArgs, SolrCore core) {
     if (newArgs == null || newArgs.isEmpty()) {
@@ -226,15 +226,26 @@ public class CacheConfig implements MapSerializable {
     Class<? extends SolrCache> cacheClass;
     String classOverride = newArgs.get("class");
 
-    //compare against the explicitly configured value first, it could be the shortened class name (not fully qualified class name)
-    String previousClassName = (this.args != null && this.args.get("class") != null) ? this.args.get("class") : this.cacheImpl;
+    // compare against the explicitly configured value first, it could be the shortened class name
+    // (not fully qualified class name)
+    String previousClassName =
+        (this.args != null && this.args.get("class") != null)
+            ? this.args.get("class")
+            : this.cacheImpl;
     boolean classChanged = classOverride != null && !classOverride.equals(previousClassName);
     if (classChanged) {
-      log.info("Cache class overridden from {} to {}, loading the new class", previousClassName, classOverride);
-      cacheClass = core.getResourceLoader().findClass(
-              new PluginInfo("cache", Collections.singletonMap("class", classOverride)),
-              SolrCache.class,
-              true);
+      if (log.isDebugEnabled()) {
+        log.debug(
+            "Cache class overridden from {} to {}, loading the new class",
+            previousClassName,
+            classOverride);
+      }
+      cacheClass =
+          core.getResourceLoader()
+              .findClass(
+                  new PluginInfo("cache", Collections.singletonMap("class", classOverride)),
+                  SolrCache.class,
+                  true);
     } else {
       cacheClass = this.clazz.get();
     }

--- a/solr/core/src/java/org/apache/solr/search/CacheConfig.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheConfig.java
@@ -109,7 +109,7 @@ public class CacheConfig implements MapSerializable {
     return getConfig(solrConfig.getResourceLoader(), solrConfig, nodeName, attrs, xpath);
   }
 
-  public static CacheConfig getConfig(
+  static CacheConfig getConfig(
       SolrResourceLoader loader,
       SolrConfig solrConfig,
       String nodeName,
@@ -215,17 +215,36 @@ public class CacheConfig implements MapSerializable {
    * The existing config should not be modified
    *
    * @param newArgs new arguments to merge into the existing config, overrides existing values
+   * @param core  the core to create the cache for
    */
-  public CacheConfig withArgs(Map<String, String> newArgs) {
+  public CacheConfig withArgs(Map<String, String> newArgs, SolrCore core) {
     if (newArgs == null || newArgs.isEmpty()) {
       return this;
     }
+
+    @SuppressWarnings({"rawtypes"})
+    Class<? extends SolrCache> cacheClass;
+    String classOverride = newArgs.get("class");
+
+    //compare against the explicitly configured value first, it could be the shortened class name (not fully qualified class name)
+    String previousClassName = (this.args != null && this.args.get("class") != null) ? this.args.get("class") : this.cacheImpl;
+    boolean classChanged = classOverride != null && !classOverride.equals(previousClassName);
+    if (classChanged) {
+      log.info("Cache class overridden from {} to {}, loading the new class", previousClassName, classOverride);
+      cacheClass = core.getResourceLoader().findClass(
+              new PluginInfo("cache", Collections.singletonMap("class", classOverride)),
+              SolrCache.class,
+              true);
+    } else {
+      cacheClass = this.clazz.get();
+    }
+
     if (this.args == null) {
-      return new CacheConfig(this.clazz.get(), new HashMap<>(newArgs), this.regenerator);
+      return new CacheConfig(cacheClass, new HashMap<>(newArgs), this.regenerator);
     } else {
       Map<String, String> finalArgs = new HashMap<>(this.args);
       finalArgs.putAll(newArgs);
-      return new CacheConfig(this.clazz.get(), finalArgs, this.regenerator);
+      return new CacheConfig(cacheClass, finalArgs, this.regenerator);
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/search/CacheConfig.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheConfig.java
@@ -74,13 +74,13 @@ public class CacheConfig implements MapSerializable {
       Class<? extends SolrCache> clazz,
       Map<String, String> args,
       CacheRegenerator regenerator,
-      Object[] persistence) {
+      Object persistenceObj) {
     this.clazz = () -> clazz;
     this.cacheImpl = clazz.getName();
     this.args = args;
     this.regenerator = regenerator;
     this.nodeName = args.get(NAME);
-    this.persistence = persistence;
+    this.persistence[0] = persistenceObj;
   }
 
   public CacheRegenerator getRegenerator() {
@@ -262,11 +262,11 @@ public class CacheConfig implements MapSerializable {
 
     if (this.args == null) {
       return new CacheConfig(
-          cacheClass, new HashMap<>(newArgs), this.regenerator, this.persistence);
+          cacheClass, new HashMap<>(newArgs), this.regenerator, this.persistence[0]);
     } else {
       Map<String, String> finalArgs = new HashMap<>(this.args);
       finalArgs.putAll(newArgs);
-      return new CacheConfig(cacheClass, finalArgs, this.regenerator, this.persistence);
+      return new CacheConfig(cacheClass, finalArgs, this.regenerator, this.persistence[0]);
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/search/CacheConfig.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheConfig.java
@@ -223,8 +223,8 @@ public class CacheConfig implements MapSerializable {
   /**
    * Returns a CacheConfig with the given arguments merged into the existing ones. <br>
    * The existing config should not be modified.
-   * <p>
-   * Take note that the cloned config should only be used to instantiate the same "cache type"
+   *
+   * <p>Take note that the cloned config should only be used to instantiate the same "cache type"
    * (filterCache, queryResultCache etc.) of this config
    *
    * @param newArgs new arguments to merge into the existing config, overrides existing values

--- a/solr/core/src/java/org/apache/solr/search/CacheConfig.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheConfig.java
@@ -71,7 +71,10 @@ public class CacheConfig implements MapSerializable {
 
   @SuppressWarnings({"rawtypes"})
   private CacheConfig(
-          Class<? extends SolrCache> clazz, Map<String, String> args, CacheRegenerator regenerator, Object[] persistence) {
+      Class<? extends SolrCache> clazz,
+      Map<String, String> args,
+      CacheRegenerator regenerator,
+      Object[] persistence) {
     this.clazz = () -> clazz;
     this.cacheImpl = clazz.getName();
     this.args = args;
@@ -258,7 +261,8 @@ public class CacheConfig implements MapSerializable {
     }
 
     if (this.args == null) {
-      return new CacheConfig(cacheClass, new HashMap<>(newArgs), this.regenerator, this.persistence);
+      return new CacheConfig(
+          cacheClass, new HashMap<>(newArgs), this.regenerator, this.persistence);
     } else {
       Map<String, String> finalArgs = new HashMap<>(this.args);
       finalArgs.putAll(newArgs);

--- a/solr/core/src/java/org/apache/solr/search/CacheConfig.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheConfig.java
@@ -66,7 +66,7 @@ public class CacheConfig implements MapSerializable {
   @SuppressWarnings({"rawtypes"})
   public CacheConfig(
       Class<? extends SolrCache> clazz, Map<String, String> args, CacheRegenerator regenerator) {
-    this(clazz, args, regenerator, null);
+    this(clazz, args, regenerator, new Object[1]);
   }
 
   @SuppressWarnings({"rawtypes"})
@@ -74,13 +74,13 @@ public class CacheConfig implements MapSerializable {
       Class<? extends SolrCache> clazz,
       Map<String, String> args,
       CacheRegenerator regenerator,
-      Object persistenceObj) {
+      Object[] persistence) {
     this.clazz = () -> clazz;
     this.cacheImpl = clazz.getName();
     this.args = args;
     this.regenerator = regenerator;
     this.nodeName = args.get(NAME);
-    this.persistence[0] = persistenceObj;
+    this.persistence = persistence;
   }
 
   public CacheRegenerator getRegenerator() {
@@ -222,7 +222,10 @@ public class CacheConfig implements MapSerializable {
 
   /**
    * Returns a CacheConfig with the given arguments merged into the existing ones. <br>
-   * The existing config should not be modified
+   * The existing config should not be modified.
+   * <p>
+   * Take note that the cloned config should only be used to instantiate the same "cache type"
+   * (filterCache, queryResultCache etc.) of this config
    *
    * @param newArgs new arguments to merge into the existing config, overrides existing values
    * @param core the core to create the cache for
@@ -262,11 +265,11 @@ public class CacheConfig implements MapSerializable {
 
     if (this.args == null) {
       return new CacheConfig(
-          cacheClass, new HashMap<>(newArgs), this.regenerator, this.persistence[0]);
+          cacheClass, new HashMap<>(newArgs), this.regenerator, this.persistence);
     } else {
       Map<String, String> finalArgs = new HashMap<>(this.args);
       finalArgs.putAll(newArgs);
-      return new CacheConfig(cacheClass, finalArgs, this.regenerator, this.persistence[0]);
+      return new CacheConfig(cacheClass, finalArgs, this.regenerator, this.persistence);
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/search/CacheConfig.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheConfig.java
@@ -66,11 +66,18 @@ public class CacheConfig implements MapSerializable {
   @SuppressWarnings({"rawtypes"})
   public CacheConfig(
       Class<? extends SolrCache> clazz, Map<String, String> args, CacheRegenerator regenerator) {
+    this(clazz, args, regenerator, null);
+  }
+
+  @SuppressWarnings({"rawtypes"})
+  private CacheConfig(
+          Class<? extends SolrCache> clazz, Map<String, String> args, CacheRegenerator regenerator, Object[] persistence) {
     this.clazz = () -> clazz;
     this.cacheImpl = clazz.getName();
     this.args = args;
     this.regenerator = regenerator;
     this.nodeName = args.get(NAME);
+    this.persistence = persistence;
   }
 
   public CacheRegenerator getRegenerator() {
@@ -251,11 +258,11 @@ public class CacheConfig implements MapSerializable {
     }
 
     if (this.args == null) {
-      return new CacheConfig(cacheClass, new HashMap<>(newArgs), this.regenerator);
+      return new CacheConfig(cacheClass, new HashMap<>(newArgs), this.regenerator, this.persistence);
     } else {
       Map<String, String> finalArgs = new HashMap<>(this.args);
       finalArgs.putAll(newArgs);
-      return new CacheConfig(cacheClass, finalArgs, this.regenerator);
+      return new CacheConfig(cacheClass, finalArgs, this.regenerator, this.persistence);
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
+++ b/solr/core/src/java/org/apache/solr/search/CacheOverridesManager.java
@@ -200,7 +200,7 @@ public class CacheOverridesManager {
   public CacheConfig applyOverrides(CacheConfig cacheConfig, String cacheName, SolrCore core) {
     List<Map<String, String>> overridesEntries = getOverrides(cacheName, core);
     for (Map<String, String> overrides : overridesEntries) {
-      cacheConfig = cacheConfig.withArgs(overrides);
+      cacheConfig = cacheConfig.withArgs(overrides, core);
     }
     return cacheConfig;
   }

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -379,7 +379,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     this.queryResultMaxDocsCached = solrConfig.queryResultMaxDocsCached;
     this.useFilterForSortedQuery = solrConfig.useFilterForSortedQuery;
 
-    ordMapCache = solrConfig.ordMapCacheConfig.newInstance(core);
+    ordMapCache = buildCache(solrConfig, "ordMapCache", core);
     assert ordMapCache != null;
     this.leafReader = SlowCompositeReaderWrapper.wrap(this.reader, ordMapCache);
 
@@ -439,6 +439,9 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       SolrConfig solrConfig, String cacheName, SolrCore core) {
     CacheConfig cacheConfig;
     switch (cacheName) {
+      case "ordMapCache":
+        cacheConfig = solrConfig.ordMapCacheConfig;
+        break;
       case "fieldValueCache":
         cacheConfig = solrConfig.fieldValueCacheConfig;
         break;


### PR DESCRIPTION
## Description
Currently we cannot change the cache class dynamically using `clusterprops`'s `ext.cacheOverrides` as class is loaded before cache config constructions. 

This PR explores the option to support cache class loading override. Take note that with such capability, we can create dedicate non-shared cache for particular collections while other collections use the common shared cache

## Solution
On detection of overrides having different class as the original config, we can load such class by providing the `core` (with access to the resource loader) during invocation with `withArgs` method and pass the loaded class for the overridden `CacheConfig` instantiation

Take note that `ordMapCache` is refactored to use the main cache config creation flow so overrides would work on it as well

## Remarks
Also add a fix to pass on the `persistence` field from original instance to the new instance from `withArgs` method

## Test
Deployed on playpen as feature branch, observe core with constant background update/commits
1. without any overrides, filtercache is using class `mn.fs.solr.sharedcache.CaffeineCache`
<img width="995" height="73" alt="image" src="https://github.com/user-attachments/assets/f39c4ece-3b30-4f8f-8a50-3593f4adca58" />
2. Add overrides to `ext.cacheOverrides` as below 

```
{
     "filterCache": { "class" : "solr.CaffeineCache" },
     "collections" : [ "..." ]
}
```
3. Such core is refreshed after a while using the apache cache (non shared cache)
<img width="1071" height="69" alt="image" src="https://github.com/user-attachments/assets/d4c3279f-a5ff-4d42-822e-355f5381ed6e" />
4. Verify other cores NOT from that collection are still using the shared cache
5. Now remove the overrides. The filter cache is reverted back to shared cache
<img width="1016" height="64" alt="image" src="https://github.com/user-attachments/assets/703edfd9-c44c-4ae0-b501-d5987c9aa4eb" />

 
