### PR TITLE
Updated QA node to handle stream call

### DIFF
--- a/solr/core/src/java/org/apache/solr/api/CoordinatorV2HttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/api/CoordinatorV2HttpSolrCall.java
@@ -44,7 +44,7 @@ public class CoordinatorV2HttpSolrCall extends V2HttpCall {
     this.collectionName = collectionName;
     SolrCore core = super.getCoreByCollection(collectionName, isPreferLeader);
     if (core != null) return core;
-    if (!path.endsWith("/select")) return null;
+    if (!(path.endsWith("/select") || path.endsWith("/stream"))) return null;
     return CoordinatorHttpSolrCall.getCore(factory, this, collectionName, isPreferLeader);
   }
 

--- a/solr/core/src/java/org/apache/solr/servlet/CoordinatorHttpSolrCall.java
+++ b/solr/core/src/java/org/apache/solr/servlet/CoordinatorHttpSolrCall.java
@@ -72,7 +72,7 @@ public class CoordinatorHttpSolrCall extends HttpSolrCall {
     this.collectionName = collectionName;
     SolrCore core = super.getCoreByCollection(collectionName, isPreferLeader);
     if (core != null) return core;
-    if (!path.endsWith("/select")) return null;
+    if (!(path.endsWith("/select") || path.endsWith("/stream"))) return null;
     return getCore(factory, this, collectionName, isPreferLeader);
   }
 


### PR DESCRIPTION
Currently, solr coordinator node handles `select` call only. But, It forwards `stream` call to other data node as there is no shard for that collection on coordinator node. Added check for stream handler in coordinator, now it executes stream call from coordinator.

Today, we see log like that on data node, where QA node forwards the stream call to data node. I see this log on `data node`

```
o.a.s.c.S.Request webapp=/solr path=/stream params={indent=off&expr=select(search(o-QV7-eu1,q%3D"*:*",fq%3DKind:user,fq%3D(UserAppKey:016b7abb\-5bf6\-4c9e\-89b5\-93c838ccc678+OR+IndvId:8464625305277020037),fl%3D"UserId,UserDisplayNameStr,UserEmailStr,UserId",sort%3D"UserId+asc",qt%3D"/export"),UserDisplayNameStr+as+UserDisplayName,UserEmailStr+as+UserEmail,UserId,UserId)&wat=BACKGROUND_GetUserInfo&rid=e6c551bd279e0807bc43b78ef03fb72d-eedac3bb13a51bc2&_forwardedCount=1&wt=json} status=0 QTime=0
```

See `_forwardedCount=1` in above log

After fixing this issue, I see following log in `QA node`

```
2025-11-19 00:15:00.338 INFO  (qtp41765385-31-solrqueryaggregator-c92-1-111) [c:BF2 s: r: x: rid:] o.a.s.c.S.Request webapp=/solr path=/stream params={expr=search(2H,d%3D"*:*",fq%3DKind:user,+fl%3D"UserId,UserDisplayNameStr",+sort%3D"UserId+asc",qt%3D"export")&_=1763509363791} status=0 QTime=1
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allow coordinator node to handle `/stream` requests (in addition to `/select`) by resolving to the synthetic core when no local core exists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eff9456adc9708a2b7206a1f74bb7b3387ea5ca8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->