### PR TITLE
TestSegAwareCachingParity should test union, not intersection

### DIFF
--- a/solr/core/src/test/org/apache/solr/search/TestSegAwareCachingParity.java
+++ b/solr/core/src/test/org/apache/solr/search/TestSegAwareCachingParity.java
@@ -139,7 +139,7 @@ public class TestSegAwareCachingParity extends SolrTestCaseJ4 {
     vals.subList(0, count)
         .forEach(
             (i) -> {
-              builder.add(new TermQuery(new Term("field_s", "d" + i)), BooleanClause.Occur.MUST);
+              builder.add(new TermQuery(new Term("field_s", "d" + i)), BooleanClause.Occur.SHOULD);
             });
     return builder.build();
   }
@@ -173,13 +173,14 @@ public class TestSegAwareCachingParity extends SolrTestCaseJ4 {
                 if (i == 1 || s.numDocs() == 0) {
                   // special case for MatchAllDocsQuery and empty index
                   assertEquals(docSet, uncachedDocSet);
-                } else {
+                }
+                int size = docSet.size();
+                if (size != s.numDocs()) {
                   assertNotEquals(
                       "cached and uncached should be different! compare: " + docSet,
                       docSet,
                       uncachedDocSet);
                 }
-                int size = docSet.size();
                 assertEquals(size, uncachedDocSet.size());
                 assertEquals(size, docSet.intersectionSize(uncachedDocSet));
                 return null;


### PR DESCRIPTION
due to an oversight, this test was testing intersection, not union, of terms! This meant that it wasn't really exercising all the relevant code paths. Now it is.