### PR TITLE
VAL-9885 : Replication failure when the source file size is exact multiple of 1024 * 1024

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
@@ -1650,8 +1650,10 @@ public class ReplicationHandler extends RequestHandlerBase
             rateLimiter.pause(maxBytesBeforePause);
             maxBytesBeforePause = 0;
           }
-          // TODO: adding 2nd condition to catch edge case of file size i * 1024 * 1024, which i is integer.
-          // might want to consider removing the first condition later on as the 2nd condition is supposed to catch
+          // TODO: adding 2nd condition to catch edge case of file size i * 1024 * 1024,
+          // which i is integer.
+          // Might want to consider removing the first condition later on as the 2nd condition is
+          // supposed to catch
           // all cases
           if (read != buf.length || filelen <= offset + read) {
             writeNothingAndFlush();

--- a/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
@@ -1650,7 +1650,7 @@ public class ReplicationHandler extends RequestHandlerBase
             rateLimiter.pause(maxBytesBeforePause);
             maxBytesBeforePause = 0;
           }
-          if (read != buf.length) {
+          if (read != buf.length || filelen <= offset + read) { //all data have been read
             writeNothingAndFlush();
             // we close because DeflaterOutputStream requires a close call, but  the request
             // outputstream is protected

--- a/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
@@ -1650,7 +1650,10 @@ public class ReplicationHandler extends RequestHandlerBase
             rateLimiter.pause(maxBytesBeforePause);
             maxBytesBeforePause = 0;
           }
-          if (read != buf.length || filelen <= offset + read) { // all data have been read
+          // TODO: adding 2nd condition to catch edge case of file size i * 1024 * 1024, which i is integer.
+          // might want to consider removing the first condition later on as the 2nd condition is supposed to catch
+          // all cases
+          if (read != buf.length || filelen <= offset + read) {
             writeNothingAndFlush();
             // we close because DeflaterOutputStream requires a close call, but  the request
             // outputstream is protected

--- a/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/ReplicationHandler.java
@@ -1650,7 +1650,7 @@ public class ReplicationHandler extends RequestHandlerBase
             rateLimiter.pause(maxBytesBeforePause);
             maxBytesBeforePause = 0;
           }
-          if (read != buf.length || filelen <= offset + read) { //all data have been read
+          if (read != buf.length || filelen <= offset + read) { // all data have been read
             writeNothingAndFlush();
             // we close because DeflaterOutputStream requires a close call, but  the request
             // outputstream is protected

--- a/solr/core/src/test/org/apache/solr/handler/DirectoryFileStreamTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/DirectoryFileStreamTest.java
@@ -26,6 +26,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.util.Random;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IndexOutput;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.core.DirectoryFactory;
@@ -34,14 +36,12 @@ import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.response.SolrQueryResponse;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.apache.lucene.store.Directory;
-import org.apache.lucene.store.IndexOutput;
 
 /**
  * Tests the replication file stream protocol emitted by DirectoryFileStream.write(...).
- * <p>
- * Validates that when the file size is an exact multiple of PACKET_SZ and checksum is enabled, the
- * stream ends with a single 0-length marker and does not include a checksum for the EOF marker.
+ *
+ * <p>Validates that when the file size is an exact multiple of PACKET_SZ and checksum is enabled,
+ * the stream ends with a single 0-length marker and does not include a checksum for the EOF marker.
  */
 public class DirectoryFileStreamTest extends SolrTestCaseJ4 {
 
@@ -52,8 +52,8 @@ public class DirectoryFileStreamTest extends SolrTestCaseJ4 {
 
   @Test
   public void testDirectoryFileHandling() throws Exception {
-    testWithPackets(2); //2 whole packets
-    testWithPackets(2.5); //non-whole packets
+    testWithPackets(2); // 2 whole packets
+    testWithPackets(2.5); // non-whole packets
   }
 
   public void testWithPackets(double packetCount) throws Exception {
@@ -62,7 +62,7 @@ public class DirectoryFileStreamTest extends SolrTestCaseJ4 {
 
     // Create a file in the active index directory with size that is an exact multiple of PACKET_SZ
     final String fileName = "replication_stream_exact_multiple-" + packetCount + ".bin";
-    final int fileSize = (int)(packetCount * packetSize);
+    final int fileSize = (int) (packetCount * packetSize);
 
     final byte[] content = new byte[fileSize];
     new Random(17L).nextBytes(content);
@@ -75,15 +75,7 @@ public class DirectoryFileStreamTest extends SolrTestCaseJ4 {
 
     // Build a replication request to stream this file with checksum enabled
     final SolrQueryRequest req =
-        req(
-            CommonParams.WT,
-            FILE_STREAM,
-            COMMAND,
-            CMD_GET_FILE,
-            FILE,
-            fileName,
-            CHECKSUM,
-            "true");
+        req(CommonParams.WT, FILE_STREAM, COMMAND, CMD_GET_FILE, FILE, fileName, CHECKSUM, "true");
     final SolrQueryResponse rsp = new SolrQueryResponse();
 
     final ReplicationHandler handler =
@@ -94,8 +86,7 @@ public class DirectoryFileStreamTest extends SolrTestCaseJ4 {
 
     final Object writerObj = rsp.getValues().get(FILE_STREAM);
     assertNotNull("Response should contain filestream writer", writerObj);
-    assertTrue(
-        "filestream must be a RawWriter", writerObj instanceof SolrCore.RawWriter);
+    assertTrue("filestream must be a RawWriter", writerObj instanceof SolrCore.RawWriter);
 
     final ByteArrayOutputStream bos = new ByteArrayOutputStream();
     ((SolrCore.RawWriter) writerObj).write(bos);
@@ -126,8 +117,6 @@ public class DirectoryFileStreamTest extends SolrTestCaseJ4 {
     assertEquals("No trailing bytes expected after EOF marker", 0, dis.available());
     assertArrayEquals("Downloaded content must match original", content, downloadedContent);
 
-
     df.release(dir);
   }
 }
-

--- a/solr/core/src/test/org/apache/solr/handler/DirectoryFileStreamTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/DirectoryFileStreamTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.handler;
+
+import static org.apache.solr.handler.ReplicationHandler.CHECKSUM;
+import static org.apache.solr.handler.ReplicationHandler.CMD_GET_FILE;
+import static org.apache.solr.handler.ReplicationHandler.COMMAND;
+import static org.apache.solr.handler.ReplicationHandler.FILE;
+import static org.apache.solr.handler.ReplicationHandler.FILE_STREAM;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.util.Random;
+import org.apache.solr.SolrTestCaseJ4;
+import org.apache.solr.common.params.CommonParams;
+import org.apache.solr.core.DirectoryFactory;
+import org.apache.solr.core.SolrCore;
+import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.response.SolrQueryResponse;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IndexOutput;
+
+/**
+ * Tests the replication file stream protocol emitted by DirectoryFileStream.write(...).
+ * <p>
+ * Validates that when the file size is an exact multiple of PACKET_SZ and checksum is enabled, the
+ * stream ends with a single 0-length marker and does not include a checksum for the EOF marker.
+ */
+public class DirectoryFileStreamTest extends SolrTestCaseJ4 {
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    initCore("solrconfig.xml", "schema_latest.xml");
+  }
+
+  @Test
+  public void testDirectoryFileHandling() throws Exception {
+    testWithPackets(2); //2 whole packets
+    testWithPackets(2.5); //non-whole packets
+  }
+
+  public void testWithPackets(double packetCount) throws Exception {
+    final SolrCore core = h.getCore();
+    final int packetSize = ReplicationHandler.PACKET_SZ; // 1 MiB
+
+    // Create a file in the active index directory with size that is an exact multiple of PACKET_SZ
+    final String fileName = "replication_stream_exact_multiple-" + packetCount + ".bin";
+    final int fileSize = (int)(packetCount * packetSize);
+
+    final byte[] content = new byte[fileSize];
+    new Random(17L).nextBytes(content);
+
+    final DirectoryFactory df = core.getDirectoryFactory();
+    final Directory dir = df.get(core.getIndexDir(), DirectoryFactory.DirContext.DEFAULT, null);
+    try (IndexOutput out = dir.createOutput(fileName, DirectoryFactory.IOCONTEXT_NO_CACHE)) {
+      out.writeBytes(content, fileSize);
+    }
+
+    // Build a replication request to stream this file with checksum enabled
+    final SolrQueryRequest req =
+        req(
+            CommonParams.WT,
+            FILE_STREAM,
+            COMMAND,
+            CMD_GET_FILE,
+            FILE,
+            fileName,
+            CHECKSUM,
+            "true");
+    final SolrQueryResponse rsp = new SolrQueryResponse();
+
+    final ReplicationHandler handler =
+        (ReplicationHandler) core.getRequestHandler(ReplicationHandler.PATH);
+    assertNotNull("Replication handler must be registered", handler);
+
+    handler.handleRequestBody(req, rsp);
+
+    final Object writerObj = rsp.getValues().get(FILE_STREAM);
+    assertNotNull("Response should contain filestream writer", writerObj);
+    assertTrue(
+        "filestream must be a RawWriter", writerObj instanceof SolrCore.RawWriter);
+
+    final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    ((SolrCore.RawWriter) writerObj).write(bos);
+    final byte[] streamBytes = bos.toByteArray();
+    assertTrue(streamBytes.length > 0);
+
+    // Parse the protocol: [int length][optional long checksum][bytes]* ... [int 0] EOF
+    final ByteArrayInputStream bais = new ByteArrayInputStream(streamBytes);
+    final DataInputStream dis = new DataInputStream(bais);
+
+    int totalData = 0;
+
+    byte[] downloadedContent = new byte[fileSize];
+    while (true) {
+      final int len = dis.readInt();
+      if (len == 0) {
+        break;
+      }
+      // checksum present when CHECKSUM=true
+      dis.readLong();
+      final byte[] buf = new byte[len];
+      dis.readFully(buf);
+      System.arraycopy(buf, 0, downloadedContent, totalData, len);
+      totalData += len;
+    }
+
+    // After EOF marker, there should be no extra bytes
+    assertEquals("No trailing bytes expected after EOF marker", 0, dis.available());
+    assertArrayEquals("Downloaded content must match original", content, downloadedContent);
+
+
+    df.release(dir);
+  }
+}
+

--- a/solr/core/src/test/org/apache/solr/handler/DirectoryFileStreamTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/DirectoryFileStreamTest.java
@@ -25,7 +25,6 @@ import static org.apache.solr.handler.ReplicationHandler.FILE_STREAM;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
-import java.util.Random;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.solr.SolrTestCaseJ4;

--- a/solr/core/src/test/org/apache/solr/handler/DirectoryFileStreamTest.java
+++ b/solr/core/src/test/org/apache/solr/handler/DirectoryFileStreamTest.java
@@ -65,7 +65,7 @@ public class DirectoryFileStreamTest extends SolrTestCaseJ4 {
     final int fileSize = (int) (packetCount * packetSize);
 
     final byte[] content = new byte[fileSize];
-    new Random(17L).nextBytes(content);
+    random().nextBytes(content);
 
     final DirectoryFactory df = core.getDirectoryFactory();
     final Directory dir = df.get(core.getIndexDir(), DirectoryFactory.DirContext.DEFAULT, null);


### PR DESCRIPTION
## Description
Found exception of below twice while moving shard (ADDREPLICA step) on the same core file

```
o.a.s.h.IndexFetcher Error in fetching file: _2.fdt (downloaded 30408704 of 30408704 bytes)
java.io.EOFException: null
	at org.apache.solr.common.util.FastInputStream.readFully(FastInputStream.java:178) 
	at org.apache.solr.common.util.FastInputStream.readFully(FastInputStream.java:170) 
	at org.apache.solr.handler.IndexFetcher$FileFetcher.fetchPackets(IndexFetcher.java:1864) 
	at org.apache.solr.handler.IndexFetcher$FileFetcher.fetch(IndexFetcher.java:1809) 
	at org.apache.solr.handler.IndexFetcher$FileFetcher.fetchFile(IndexFetcher.java:1791) 
	at org.apache.solr.handler.IndexFetcher.downloadIndexFiles(IndexFetcher.java:1211) 
	at org.apache.solr.handler.IndexFetcher.fetchLatestIndex(IndexFetcher.java:697) 
	at org.apache.solr.handler.IndexFetcher.fetchLatestIndex(IndexFetcher.java:425) 
	at org.apache.solr.handler.ReplicationHandler.doFetch(ReplicationHandler.java:467) 
	at org.apache.solr.cloud.RecoveryStrategy.replicate(RecoveryStrategy.java:243) 
	at org.apache.solr.cloud.RecoveryStrategy.doSyncOrReplicateRecovery(RecoveryStrategy.java:697) 
	at org.apache.solr.cloud.RecoveryStrategy.doRecovery(RecoveryStrategy.java:333) 
	at org.apache.solr.cloud.RecoveryStrategy.run(RecoveryStrategy.java:309) 
...
```


## Cause
With the help of Cursor! 🤖 

1. The file is exactly 29 * 1024 * 1024
2. In the "Server" logic (the source node), `ReplicationHandler` iterates and writes in chunks, for each chunk, it starts with an int for the chunk size, then a long as checksum (computed by chunk size), then write the actual chunk bytes
3. However, in the case of whole 1024*1024 file. After writing the last chunk, the code logic will write an additional `0` (usually indicates EOF) with an additional checksum
4. Now on the "Client" logic (the ADDREPLICA node that pulls the data), `IndexFetcher#fetchPackets` reads all the chunks correctly. After the last chunk, it would read `0` (end of stream). Normally, it would iterate the loop once more and `fis.peek()` would gives -1, however, in this case, after the `0`, there's still a long checksum, so it reads the first half of the checksum and thought it's a valid "chunk size" int, then it proceeds to read the checksum (long), but now the input stream only has 4 bytes left (the 4 was mistakenly read as chunk size), hence throws `EOFException` at line 1864

## Solution
Even though the client side logic is a bit weird (why does it not just stop reading once reading the `0`), it is the server side `ReplicationHandler` that is incorrect technically. as it should never writes a `0` (indicates end of the file) and still writes a checksum.

Therefore we will catch the "end condition" better by checking read bytes vs the file len

## Test
Added unit test case to ensure the case works for files with whole packets (multiples of MB) or non whole ones (common case)
