### PR TITLE
SAI-5994 : Added metrics `QUERY.httpShardHandler.httpClientAvailablePermits`

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
@@ -454,5 +454,10 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory
             null,
             solrMetricsContext.getMetricRegistry(),
             SolrMetricManager.mkName("httpShardExecutor", expandedScope, "threadPool"));
+    solrMetricsContext.gauge(
+        () -> defaultClient.getAvailablePermits(),
+        false,
+        "httpClientAvailablePermits",
+        expandedScope);
   }
 }

--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -956,6 +956,12 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
         "fcache_docs_hot_local_bytes_used",
         "Bytes used from local fcache-docs-hot cache store (vs backing shared cache store)",
         "ramBytesUsed",
+        PrometheusMetricType.GAUGE),
+    HTTP_CLIENT_AVAILABLE_PERMITS(
+        "QUERY.httpShardHandler.httpClientAvailablePermits",
+        "http_client_available_permits",
+        "Available permits in the HTTP client used by the httpShardHandler",
+        null,
         PrometheusMetricType.GAUGE);
     final String key, metricName, desc, property;
     private final PrometheusMetricType metricType;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -898,6 +898,10 @@ public class Http2SolrClient extends HttpSolrClientBase {
     }
   }
 
+  public int getAvailablePermits() {
+    return asyncTracker.available.availablePermits();
+  }
+
   public static class Builder
       extends HttpSolrClientBuilderBase<Http2SolrClient.Builder, Http2SolrClient> {
 


### PR DESCRIPTION
## Description
We have found that `Http2SolrClient defaultClient` in `HttpShardHandlerFactory` (which gives `HttpShardHandler`) might have exhausted the available permits in certain scenarios.

## Solution
Expose the "available permits" from the `Http2SolrClient` and report such number as gauge via the `HttpShardHandlerFactory`

Added `http_client_available_permits` in `PrometheusServlet`.

## Test
Deployed locally and ensure the metrics is found in /metrics endpoint as

```
# HELP http_client_available_permits Available permits in the HTTP client used by the httpShardHandler[node aggregated]
# TYPE http_client_available_permits gauge
http_client_available_permits 10000
```