### PR TITLE
removed max outgoing request semaphore - to see if this helps

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
@@ -16,6 +16,7 @@
  */
 package org.apache.solr.handler.component;
 
+import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,9 +48,13 @@ import org.apache.solr.core.CoreDescriptor;
 import org.apache.solr.request.SolrQueryRequest;
 import org.apache.solr.request.SolrRequestInfo;
 import org.apache.solr.security.AllowListUrlChecker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @NotThreadSafe
 public class HttpShardHandler extends ShardHandler {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
   /**
    * If the request context map has an entry with this key and Boolean.TRUE as value, {@link
    * #prepDistributed(ResponseBuilder)} will only include {@link
@@ -164,6 +169,12 @@ public class HttpShardHandler extends ShardHandler {
     }
 
     CompletableFuture<LBSolrClient.Rsp> future = this.lbClient.requestAsync(lbReq);
+    long afterRequestAsync = System.nanoTime();
+    long delayMillis =
+        TimeUnit.MILLISECONDS.convert(afterRequestAsync - startTime, TimeUnit.NANOSECONDS);
+    if (delayMillis > 1000) {
+      log.warn("HttpShardHandler: requestAsync() call took {} milliseconds", delayMillis);
+    }
     ShardRequestCallback callback = onRequestSubmit(future, sreq, urls, params);
     future.whenComplete(
         (rsp, throwable) -> {

--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandler.java
@@ -65,6 +65,9 @@ public class HttpShardHandler extends ShardHandler {
    */
   public static String ONLY_NRT_REPLICAS = "distribOnlyRealtime";
 
+  /** Maximum delay in milliseconds before logging a warning about requestAsync() taking too long */
+  private static final long MAX_REQUEST_ASYNC_DELAY_MILLIS = 1000;
+
   private HttpShardHandlerFactory httpShardHandlerFactory;
   private Map<ShardResponse, CompletableFuture<LBSolrClient.Rsp>> responseFutureMap;
   private BlockingQueue<ShardResponse> responses;
@@ -172,7 +175,7 @@ public class HttpShardHandler extends ShardHandler {
     long afterRequestAsync = System.nanoTime();
     long delayMillis =
         TimeUnit.MILLISECONDS.convert(afterRequestAsync - startTime, TimeUnit.NANOSECONDS);
-    if (delayMillis > 1000) {
+    if (delayMillis > MAX_REQUEST_ASYNC_DELAY_MILLIS) {
       log.warn("HttpShardHandler: requestAsync() call took {} milliseconds", delayMillis);
     }
     ShardRequestCallback callback = onRequestSubmit(future, sreq, urls, params);

--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
@@ -221,10 +221,9 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory
                 long millis = TimeUnit.MILLISECONDS.convert(delayNanos, TimeUnit.NANOSECONDS);
                 log.warn(
                     "Remote shard request delayed by {} milliseconds (from listener creation to onBegin), "
-                        + "uri={}, thread={}",
+                        + "uri={}",
                     millis,
-                    request.getURI(),
-                    Thread.currentThread().getName());
+                    request.getURI());
                 if (delayedRequests != null) {
                   delayedRequests.update(millis);
                 }

--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
@@ -455,9 +455,9 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory
             solrMetricsContext.getMetricRegistry(),
             SolrMetricManager.mkName("httpShardExecutor", expandedScope, "threadPool"));
     solrMetricsContext.gauge(
-        () -> defaultClient.getAvailablePermits(),
+        () -> defaultClient.getOutstandingRequests(),
         false,
-        "httpClientAvailablePermits",
+        "httpClientOutstandingRequests",
         expandedScope);
   }
 }

--- a/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/HttpShardHandlerFactory.java
@@ -215,10 +215,16 @@ public class HttpShardHandlerFactory extends ShardHandlerFactory
               // the request. Here we add extra logging to notify us if this assumption is
               // violated. See: SOLR-16099, SOLR-16129,
               // https://github.com/fullstorydev/lucene-solr/commit/445508adb4a
-              long delayNanos = System.nanoTime() - start;
+              long beginTime = System.nanoTime();
+              long delayNanos = beginTime - start;
               if (delayNanos > DELAY_WARN_THRESHOLD) {
                 long millis = TimeUnit.MILLISECONDS.convert(delayNanos, TimeUnit.NANOSECONDS);
-                log.info("Remote shard request delayed by {} milliseconds", millis);
+                log.warn(
+                    "Remote shard request delayed by {} milliseconds (from listener creation to onBegin), "
+                        + "uri={}, thread={}",
+                    millis,
+                    request.getURI(),
+                    Thread.currentThread().getName());
                 if (delayedRequests != null) {
                   delayedRequests.update(millis);
                 }

--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -957,10 +957,10 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
         "Bytes used from local fcache-docs-hot cache store (vs backing shared cache store)",
         "ramBytesUsed",
         PrometheusMetricType.GAUGE),
-    HTTP_CLIENT_AVAILABLE_PERMITS(
-        "QUERY.httpShardHandler.httpClientAvailablePermits",
-        "http_client_available_permits",
-        "Available permits in the HTTP client used by the httpShardHandler",
+    HTTP_CLIENT_OUTSTANDING_REQUESTS(
+        "QUERY.httpShardHandler.httpClientOutstandingRequests",
+        "http_client_outstanding_requests",
+        "Current outstanding requests in the HTTP client used by the httpShardHandler",
         null,
         PrometheusMetricType.GAUGE);
     final String key, metricName, desc, property;

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -113,7 +113,7 @@ public class Http2SolrClient extends HttpSolrClientBase {
   private static volatile SSLConfig defaultSSLConfig;
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private static final String AGENT = "Solr[" + Http2SolrClient.class.getName() + "] 2.0";
-  private static final int CLIENT_SELECTORS = Integer.getInteger("solr.http2.client.selectors", 8);
+  private static final int CLIENT_SELECTORS = Integer.getInteger("solr.http2.client.selectors", 2);
   private static final int MAX_REQUESTS_QUEUED_PER_DESTINATION =
       Integer.parseInt(System.getProperty("solr.http2.maxRequestsQueuedPerDestination", "3000"));
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -113,6 +113,9 @@ public class Http2SolrClient extends HttpSolrClientBase {
   private static volatile SSLConfig defaultSSLConfig;
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private static final String AGENT = "Solr[" + Http2SolrClient.class.getName() + "] 2.0";
+  private static final int CLIENT_SELECTORS = Integer.getInteger("solr.http2.client.selectors", 8);
+  private static final int MAX_REQUESTS_QUEUED_PER_DESTINATION =
+      Integer.parseInt(System.getProperty("solr.http2.maxRequestsQueuedPerDestination", "3000"));
 
   private final HttpClient httpClient;
 
@@ -210,7 +213,7 @@ public class Http2SolrClient extends HttpSolrClientBase {
     ClientConnector clientConnector = new ClientConnector();
     clientConnector.setReuseAddress(true);
     clientConnector.setSslContextFactory(sslContextFactory);
-    clientConnector.setSelectors(8);
+    clientConnector.setSelectors(CLIENT_SELECTORS);
 
     HttpClientTransport transport;
     if (builder.useHttp1_1) {
@@ -240,8 +243,7 @@ public class Http2SolrClient extends HttpSolrClientBase {
     httpClient.setStrictEventOrdering(false);
     httpClient.setConnectBlocking(true);
     httpClient.setFollowRedirects(false);
-    httpClient.setMaxRequestsQueuedPerDestination(
-        asyncTracker.getMaxRequestsQueuedPerDestination());
+    httpClient.setMaxRequestsQueuedPerDestination(MAX_REQUESTS_QUEUED_PER_DESTINATION);
     httpClient.setUserAgentField(new HttpField(HttpHeader.USER_AGENT, AGENT));
     httpClient.setIdleTimeout(idleTimeoutMillis);
 
@@ -882,10 +884,6 @@ public class Http2SolrClient extends HttpSolrClientBase {
   }
 
   private static class AsyncTracker {
-    private static final int MAX_OUTSTANDING_REQUESTS =
-        Integer.parseInt(System.getProperty("solr.http2.maxOutstandingRequests", "1000"));
-    private static final int MAX_REQUESTS_QUEUED_PER_DESTINATION = 3000;
-
     // wait for async requests
     private final AtomicInteger activeRequests = new AtomicInteger(0);
     private final Object lock = new Object();
@@ -903,16 +901,13 @@ public class Http2SolrClient extends HttpSolrClientBase {
                     ? TimeUnit.MILLISECONDS.convert(
                         queuedTimeNanos - lastSendTimeNanos, TimeUnit.NANOSECONDS)
                     : 0;
-            if (delayFromSend > 1000) {
-              if (log.isInfoEnabled()) {
-                log.info(
-                    "Request queued: {}, thread={}, activeRequests={}, delayFromSend={}ms",
-                    request.getURI(),
-                    Thread.currentThread().getName(),
-                    activeRequests.get(),
-                    delayFromSend);
-              }
-            }
+            log.info(
+                "Request queued: {} {}, thread={}, activeRequests={}, delayFromSend={}us",
+                request.getMethod(),
+                request.getURI(),
+                Thread.currentThread().getName(),
+                activeRequests.get(),
+                delayFromSend);
             synchronized (lock) {
               activeRequests.incrementAndGet();
             }
@@ -926,14 +921,6 @@ public class Http2SolrClient extends HttpSolrClientBase {
               }
             }
           };
-    }
-
-    int getMaxRequestsQueuedPerDestination() {
-      return MAX_REQUESTS_QUEUED_PER_DESTINATION;
-    }
-
-    int getMaxOutstandingRequests() {
-      return MAX_OUTSTANDING_REQUESTS;
     }
 
     int getActiveRequests() {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -210,7 +210,7 @@ public class Http2SolrClient extends HttpSolrClientBase {
     ClientConnector clientConnector = new ClientConnector();
     clientConnector.setReuseAddress(true);
     clientConnector.setSslContextFactory(sslContextFactory);
-    clientConnector.setSelectors(2);
+    clientConnector.setSelectors(8);
 
     HttpClientTransport transport;
     if (builder.useHttp1_1) {
@@ -232,7 +232,7 @@ public class Http2SolrClient extends HttpSolrClientBase {
       transport = new HttpClientTransportOverHTTP2(http2client);
       httpClient = new HttpClient(transport);
       int maxConnections =
-          (builder.maxConnectionsPerHost != null) ? builder.maxConnectionsPerHost : 8;
+          (builder.maxConnectionsPerHost != null) ? builder.maxConnectionsPerHost : 16;
       httpClient.setMaxConnectionsPerDestination(maxConnections);
     }
 
@@ -442,6 +442,8 @@ public class Http2SolrClient extends HttpSolrClientBase {
   @Override
   public CompletableFuture<NamedList<Object>> requestAsync(
       final SolrRequest<?> solrRequest, String collection) {
+    long requestAsyncStart = System.nanoTime();
+    log.info("Http2SolrClient.requestAsync: Entry, thread={}", Thread.currentThread().getName());
     if (ClientUtils.shouldApplyDefaultCollection(collection, solrRequest)) {
       collection = defaultCollection;
     }
@@ -449,11 +451,34 @@ public class Http2SolrClient extends HttpSolrClientBase {
     final MakeRequestReturnValue mrrv;
     final String url;
     try {
+      long beforeGetUrl = System.nanoTime();
       url = getRequestUrl(solrRequest, collection);
+      long afterGetUrl = System.nanoTime();
+      long getUrlDelay =
+          TimeUnit.MILLISECONDS.convert(afterGetUrl - beforeGetUrl, TimeUnit.NANOSECONDS);
+      if (getUrlDelay > 1000) {
+        log.info("Http2SolrClient: getRequestUrl() took {} milliseconds", getUrlDelay);
+      }
+
+      long beforeMakeRequest = System.nanoTime();
       mrrv = makeRequest(solrRequest, url, true);
+      long afterMakeRequest = System.nanoTime();
+      long makeRequestDelay =
+          TimeUnit.MILLISECONDS.convert(afterMakeRequest - beforeMakeRequest, TimeUnit.NANOSECONDS);
+      if (makeRequestDelay > 1000) {
+        log.info("Http2SolrClient: makeRequest() took {} milliseconds", makeRequestDelay);
+      }
     } catch (SolrServerException | IOException e) {
       future.completeExceptionally(e);
       return future;
+    }
+
+    long beforeSend = System.nanoTime();
+    asyncTracker.lastSendTimeNanos = beforeSend;
+    long requestAsyncTotalDelay =
+        TimeUnit.MILLISECONDS.convert(beforeSend - requestAsyncStart, TimeUnit.NANOSECONDS);
+    if (requestAsyncTotalDelay > 1000) {
+      log.info("Http2SolrClient: Total time before send() {} milliseconds", requestAsyncTotalDelay);
     }
     mrrv.request
         .onRequestQueued(asyncTracker.queuedListener)
@@ -867,11 +892,27 @@ public class Http2SolrClient extends HttpSolrClientBase {
     private final Object lock = new Object();
     private final Request.QueuedListener queuedListener;
     private final Response.CompleteListener completeListener;
+    private volatile long lastSendTimeNanos = 0;
 
     AsyncTracker() {
       // TODO: what about shared instances?
       queuedListener =
           request -> {
+            long queuedTimeNanos = System.nanoTime();
+            long delayFromSend =
+                lastSendTimeNanos > 0
+                    ? TimeUnit.MILLISECONDS.convert(
+                        queuedTimeNanos - lastSendTimeNanos, TimeUnit.NANOSECONDS)
+                    : 0;
+            if (delayFromSend > 1000) {
+              log.info(
+                      "Request queued: {} {}, thread={}, activeRequests={}, delayFromSend={}us",
+                      request.getMethod(),
+                      request.getURI(),
+                      Thread.currentThread().getName(),
+                      activeRequests.get(),
+                      delayFromSend);
+            }
             synchronized (lock) {
               activeRequests.incrementAndGet();
             }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -35,9 +35,9 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.apache.solr.client.solrj.ResponseParser;
 import org.apache.solr.client.solrj.SolrRequest;
@@ -863,20 +863,25 @@ public class Http2SolrClient extends HttpSolrClientBase {
     private static final int MAX_REQUESTS_QUEUED_PER_DESTINATION = 3000;
 
     // wait for async requests
-    private final Phaser phaser;
+    private final AtomicInteger activeRequests = new AtomicInteger(0);
+    private final Object lock = new Object();
     private final Request.QueuedListener queuedListener;
     private final Response.CompleteListener completeListener;
 
     AsyncTracker() {
       // TODO: what about shared instances?
-      phaser = new Phaser(1);
       queuedListener =
           request -> {
-            phaser.register();
+            activeRequests.incrementAndGet();
           };
       completeListener =
           result -> {
-            phaser.arriveAndDeregister();
+            synchronized (lock) {
+              int remaining = activeRequests.decrementAndGet();
+              if (remaining == 0) {
+                lock.notifyAll();
+              }
+            }
           };
     }
 
@@ -885,8 +890,16 @@ public class Http2SolrClient extends HttpSolrClientBase {
     }
 
     public void waitForComplete() {
-      phaser.arriveAndAwaitAdvance();
-      phaser.arriveAndDeregister();
+      synchronized (lock) {
+        while (activeRequests.get() > 0) {
+          try {
+            lock.wait();
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+          }
+        }
+      }
     }
   }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -56,6 +56,7 @@ import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.params.UpdateParams;
 import org.apache.solr.common.util.ContentStream;
+import org.apache.solr.common.util.EnvUtils;
 import org.apache.solr.common.util.ExecutorUtil;
 import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.ObjectReleaseTracker;
@@ -113,9 +114,13 @@ public class Http2SolrClient extends HttpSolrClientBase {
   private static volatile SSLConfig defaultSSLConfig;
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private static final String AGENT = "Solr[" + Http2SolrClient.class.getName() + "] 2.0";
-  private static final int CLIENT_SELECTORS = Integer.getInteger("solr.http2.client.selectors", 2);
+  private static final int CLIENT_SELECTORS =
+      EnvUtils.getPropertyAsInteger("solr.http2.client.selectors", 2);
   private static final int MAX_REQUESTS_QUEUED_PER_DESTINATION =
-      Integer.parseInt(System.getProperty("solr.http2.maxRequestsQueuedPerDestination", "3000"));
+      EnvUtils.getPropertyAsInteger("solr.http2.maxRequestsQueuedPerDestination", 3000);
+
+  /** Maximum delay in milliseconds before logging a warning about operation taking too long */
+  private static final long MAX_OPERATION_DELAY_MILLIS = 1000;
 
   private final HttpClient httpClient;
 
@@ -457,7 +462,7 @@ public class Http2SolrClient extends HttpSolrClientBase {
       long afterGetUrl = System.nanoTime();
       long getUrlDelay =
           TimeUnit.MILLISECONDS.convert(afterGetUrl - beforeGetUrl, TimeUnit.NANOSECONDS);
-      if (getUrlDelay > 1000) {
+      if (getUrlDelay > MAX_OPERATION_DELAY_MILLIS) {
         log.info("Http2SolrClient: getRequestUrl() took {} milliseconds", getUrlDelay);
       }
 
@@ -465,8 +470,9 @@ public class Http2SolrClient extends HttpSolrClientBase {
       mrrv = makeRequest(solrRequest, url, true);
       long afterMakeRequest = System.nanoTime();
       long makeRequestDelay =
-          TimeUnit.MILLISECONDS.convert(afterMakeRequest - beforeMakeRequest, TimeUnit.NANOSECONDS);
-      if (makeRequestDelay > 1000) {
+          TimeUnit.MILLISECONDS.convert(
+              afterMakeRequest - beforeMakeRequest, TimeUnit.MILLISECONDS);
+      if (makeRequestDelay > MAX_OPERATION_DELAY_MILLIS) {
         log.info("Http2SolrClient: makeRequest() took {} milliseconds", makeRequestDelay);
       }
     } catch (SolrServerException | IOException e) {
@@ -478,7 +484,7 @@ public class Http2SolrClient extends HttpSolrClientBase {
     asyncTracker.lastSendTimeNanos = beforeSend;
     long requestAsyncTotalDelay =
         TimeUnit.MILLISECONDS.convert(beforeSend - requestAsyncStart, TimeUnit.NANOSECONDS);
-    if (requestAsyncTotalDelay > 1000) {
+    if (requestAsyncTotalDelay > MAX_OPERATION_DELAY_MILLIS) {
       log.info("Http2SolrClient: Total time before send() {} milliseconds", requestAsyncTotalDelay);
     }
     mrrv.request
@@ -886,7 +892,6 @@ public class Http2SolrClient extends HttpSolrClientBase {
   private static class AsyncTracker {
     // wait for async requests
     private final AtomicInteger activeRequests = new AtomicInteger(0);
-    private final Object lock = new Object();
     private final Request.QueuedListener queuedListener;
     private final Response.CompleteListener completeListener;
     private volatile long lastSendTimeNanos = 0;
@@ -901,25 +906,27 @@ public class Http2SolrClient extends HttpSolrClientBase {
                     ? TimeUnit.MILLISECONDS.convert(
                         queuedTimeNanos - lastSendTimeNanos, TimeUnit.NANOSECONDS)
                     : 0;
-            if (log.isInfoEnabled()) {
-              log.info(
-                  "Request queued: {} {}, thread={}, activeRequests={}, delayFromSend={}us",
-                  request.getMethod(),
-                  request.getURI(),
-                  Thread.currentThread().getName(),
-                  activeRequests.get(),
-                  delayFromSend);
+            if (delayFromSend > MAX_OPERATION_DELAY_MILLIS) {
+              if (log.isInfoEnabled()) {
+                log.info(
+                    "Request queued: {} {}, thread={}, activeRequests={}, delayFromSend={}ms",
+                    request.getMethod(),
+                    request.getURI(),
+                    Thread.currentThread().getName(),
+                    activeRequests.get(),
+                    delayFromSend);
+              }
             }
-            synchronized (lock) {
+            synchronized (activeRequests) {
               activeRequests.incrementAndGet();
             }
           };
       completeListener =
           result -> {
-            synchronized (lock) {
+            synchronized (activeRequests) {
               int remaining = activeRequests.decrementAndGet();
               if (remaining == 0) {
-                lock.notifyAll();
+                activeRequests.notifyAll();
               }
             }
           };
@@ -930,12 +937,12 @@ public class Http2SolrClient extends HttpSolrClientBase {
     }
 
     public void waitForComplete() {
-      synchronized (lock) {
+      synchronized (activeRequests) {
         while (activeRequests.get() > 0) {
           try {
-            lock.wait();
+            activeRequests.wait();
           } catch (InterruptedException e) {
-            // ignore as we are closing
+            Thread.currentThread().interrupt();
           }
         }
       }
@@ -1023,7 +1030,7 @@ public class Http2SolrClient extends HttpSolrClientBase {
 
     /**
      * Set maxConnectionsPerHost for http1 and http2 connections. For http2 connections, defaults to
-     * 4 if not specified.
+     * 16 if not specified.
      *
      * @deprecated Please use {@link #withMaxConnectionsPerHost(int)}
      */

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -872,12 +872,21 @@ public class Http2SolrClient extends HttpSolrClientBase {
       // TODO: what about shared instances?
       queuedListener =
           request -> {
-            activeRequests.incrementAndGet();
+            int count = activeRequests.incrementAndGet();
+            if (log.isInfoEnabled()) {
+              log.info("Request queued, activeRequests={}, uri={}", count, request.getURI());
+            }
           };
       completeListener =
           result -> {
             synchronized (lock) {
               int remaining = activeRequests.decrementAndGet();
+              if (log.isInfoEnabled()) {
+                log.info(
+                    "Request completed, activeRequests={}, uri={}",
+                    remaining,
+                    result.getRequest() != null ? result.getRequest().getURI() : "unknown");
+              }
               if (remaining == 0) {
                 lock.notifyAll();
               }
@@ -887,6 +896,14 @@ public class Http2SolrClient extends HttpSolrClientBase {
 
     int getMaxRequestsQueuedPerDestination() {
       return MAX_REQUESTS_QUEUED_PER_DESTINATION;
+    }
+
+    int getMaxOutstandingRequests() {
+      return MAX_OUTSTANDING_REQUESTS;
+    }
+
+    int getActiveRequests() {
+      return activeRequests.get();
     }
 
     public void waitForComplete() {
@@ -903,8 +920,12 @@ public class Http2SolrClient extends HttpSolrClientBase {
     }
   }
 
-  public int getAvailablePermits() {
-    return this.asyncTracker.activeRequests.get();
+  public int getOutstandingRequests() {
+    int count = this.asyncTracker.getActiveRequests();
+    if (log.isInfoEnabled()) {
+      log.info("getOutstandingRequests() called, returning activeRequests={}", count);
+    }
+    return count;
   }
 
   public static class Builder

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -868,7 +868,6 @@ public class Http2SolrClient extends HttpSolrClientBase {
     AsyncTracker() {
       // TODO: what about shared instances?
       phaser = new Phaser(1);
-      // available = new Semaphore(MAX_OUTSTANDING_REQUESTS, false);
       queuedListener =
           request -> {
             phaser.register();

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -471,7 +471,7 @@ public class Http2SolrClient extends HttpSolrClientBase {
       long afterMakeRequest = System.nanoTime();
       long makeRequestDelay =
           TimeUnit.MILLISECONDS.convert(
-              afterMakeRequest - beforeMakeRequest, TimeUnit.MILLISECONDS);
+              afterMakeRequest - beforeMakeRequest, TimeUnit.NANOSECONDS);
       if (makeRequestDelay > MAX_OPERATION_DELAY_MILLIS) {
         log.info("Http2SolrClient: makeRequest() took {} milliseconds", makeRequestDelay);
       }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -904,7 +904,7 @@ public class Http2SolrClient extends HttpSolrClientBase {
   }
 
   public int getAvailablePermits() {
-    return 1000;
+    return this.asyncTracker.activeRequests.get();
   }
 
   public static class Builder

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -443,7 +443,6 @@ public class Http2SolrClient extends HttpSolrClientBase {
   public CompletableFuture<NamedList<Object>> requestAsync(
       final SolrRequest<?> solrRequest, String collection) {
     long requestAsyncStart = System.nanoTime();
-    log.info("Http2SolrClient.requestAsync: Entry, thread={}", Thread.currentThread().getName());
     if (ClientUtils.shouldApplyDefaultCollection(collection, solrRequest)) {
       collection = defaultCollection;
     }
@@ -905,13 +904,14 @@ public class Http2SolrClient extends HttpSolrClientBase {
                         queuedTimeNanos - lastSendTimeNanos, TimeUnit.NANOSECONDS)
                     : 0;
             if (delayFromSend > 1000) {
-              log.info(
-                      "Request queued: {} {}, thread={}, activeRequests={}, delayFromSend={}us",
-                      request.getMethod(),
-                      request.getURI(),
-                      Thread.currentThread().getName(),
-                      activeRequests.get(),
-                      delayFromSend);
+              if(log.isInfoEnabled()) {
+                log.info(
+                        "Request queued: {}, thread={}, activeRequests={}, delayFromSend={}ms",
+                        request.getURI(),
+                        Thread.currentThread().getName(),
+                        activeRequests.get(),
+                        delayFromSend);
+              }
             }
             synchronized (lock) {
               activeRequests.incrementAndGet();

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -470,8 +470,7 @@ public class Http2SolrClient extends HttpSolrClientBase {
       mrrv = makeRequest(solrRequest, url, true);
       long afterMakeRequest = System.nanoTime();
       long makeRequestDelay =
-          TimeUnit.MILLISECONDS.convert(
-              afterMakeRequest - beforeMakeRequest, TimeUnit.NANOSECONDS);
+          TimeUnit.MILLISECONDS.convert(afterMakeRequest - beforeMakeRequest, TimeUnit.NANOSECONDS);
       if (makeRequestDelay > MAX_OPERATION_DELAY_MILLIS) {
         log.info("Http2SolrClient: makeRequest() took {} milliseconds", makeRequestDelay);
       }
@@ -909,10 +908,9 @@ public class Http2SolrClient extends HttpSolrClientBase {
             if (delayFromSend > MAX_OPERATION_DELAY_MILLIS) {
               if (log.isInfoEnabled()) {
                 log.info(
-                    "Request queued: {} {}, thread={}, activeRequests={}, delayFromSend={}ms",
+                    "Request queued: {} {}, activeRequests={}, delayFromSend={}ms",
                     request.getMethod(),
                     request.getURI(),
-                    Thread.currentThread().getName(),
                     activeRequests.get(),
                     delayFromSend);
               }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -901,13 +901,15 @@ public class Http2SolrClient extends HttpSolrClientBase {
                     ? TimeUnit.MILLISECONDS.convert(
                         queuedTimeNanos - lastSendTimeNanos, TimeUnit.NANOSECONDS)
                     : 0;
-            log.info(
-                "Request queued: {} {}, thread={}, activeRequests={}, delayFromSend={}us",
-                request.getMethod(),
-                request.getURI(),
-                Thread.currentThread().getName(),
-                activeRequests.get(),
-                delayFromSend);
+            if (log.isInfoEnabled()) {
+              log.info(
+                  "Request queued: {} {}, thread={}, activeRequests={}, delayFromSend={}us",
+                  request.getMethod(),
+                  request.getURI(),
+                  Thread.currentThread().getName(),
+                  activeRequests.get(),
+                  delayFromSend);
+            }
             synchronized (lock) {
               activeRequests.incrementAndGet();
             }

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -231,7 +231,8 @@ public class Http2SolrClient extends HttpSolrClientBase {
       HTTP2Client http2client = new HTTP2Client(clientConnector);
       transport = new HttpClientTransportOverHTTP2(http2client);
       httpClient = new HttpClient(transport);
-      int maxConnections = (builder.maxConnectionsPerHost != null) ? builder.maxConnectionsPerHost : 4;
+      int maxConnections =
+          (builder.maxConnectionsPerHost != null) ? builder.maxConnectionsPerHost : 8;
       httpClient.setMaxConnectionsPerDestination(maxConnections);
     }
 
@@ -968,8 +969,8 @@ public class Http2SolrClient extends HttpSolrClientBase {
     }
 
     /**
-     * Set maxConnectionsPerHost for http1 and http2 connections. For http2 connections, defaults
-     * to 4 if not specified.
+     * Set maxConnectionsPerHost for http1 and http2 connections. For http2 connections, defaults to
+     * 4 if not specified.
      *
      * @deprecated Please use {@link #withMaxConnectionsPerHost(int)}
      */

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -872,21 +872,14 @@ public class Http2SolrClient extends HttpSolrClientBase {
       // TODO: what about shared instances?
       queuedListener =
           request -> {
-            int count = activeRequests.incrementAndGet();
-            if (log.isInfoEnabled()) {
-              log.info("Request queued, activeRequests={}, uri={}", count, request.getURI());
+            synchronized (lock) {
+              activeRequests.incrementAndGet();
             }
           };
       completeListener =
           result -> {
             synchronized (lock) {
               int remaining = activeRequests.decrementAndGet();
-              if (log.isInfoEnabled()) {
-                log.info(
-                    "Request completed, activeRequests={}, uri={}",
-                    remaining,
-                    result.getRequest() != null ? result.getRequest().getURI() : "unknown");
-              }
               if (remaining == 0) {
                 lock.notifyAll();
               }
@@ -912,8 +905,7 @@ public class Http2SolrClient extends HttpSolrClientBase {
           try {
             lock.wait();
           } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
+            // ignore as we are closing
           }
         }
       }
@@ -922,9 +914,6 @@ public class Http2SolrClient extends HttpSolrClientBase {
 
   public int getOutstandingRequests() {
     int count = this.asyncTracker.getActiveRequests();
-    if (log.isInfoEnabled()) {
-      log.info("getOutstandingRequests() called, returning activeRequests={}", count);
-    }
     return count;
   }
 

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -36,7 +36,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Phaser;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
@@ -863,28 +862,20 @@ public class Http2SolrClient extends HttpSolrClientBase {
 
     // wait for async requests
     private final Phaser phaser;
-    // maximum outstanding requests left
-    private final Semaphore available;
     private final Request.QueuedListener queuedListener;
     private final Response.CompleteListener completeListener;
 
     AsyncTracker() {
       // TODO: what about shared instances?
       phaser = new Phaser(1);
-      available = new Semaphore(MAX_OUTSTANDING_REQUESTS, false);
+      // available = new Semaphore(MAX_OUTSTANDING_REQUESTS, false);
       queuedListener =
           request -> {
             phaser.register();
-            try {
-              available.acquire();
-            } catch (InterruptedException ignored) {
-
-            }
           };
       completeListener =
           result -> {
             phaser.arriveAndDeregister();
-            available.release();
           };
     }
 
@@ -899,7 +890,7 @@ public class Http2SolrClient extends HttpSolrClientBase {
   }
 
   public int getAvailablePermits() {
-    return asyncTracker.available.availablePermits();
+    return 1000;
   }
 
   public static class Builder

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -904,13 +904,13 @@ public class Http2SolrClient extends HttpSolrClientBase {
                         queuedTimeNanos - lastSendTimeNanos, TimeUnit.NANOSECONDS)
                     : 0;
             if (delayFromSend > 1000) {
-              if(log.isInfoEnabled()) {
+              if (log.isInfoEnabled()) {
                 log.info(
-                        "Request queued: {}, thread={}, activeRequests={}, delayFromSend={}ms",
-                        request.getURI(),
-                        Thread.currentThread().getName(),
-                        activeRequests.get(),
-                        delayFromSend);
+                    "Request queued: {}, thread={}, activeRequests={}, delayFromSend={}ms",
+                    request.getURI(),
+                    Thread.currentThread().getName(),
+                    activeRequests.get(),
+                    delayFromSend);
               }
             }
             synchronized (lock) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/Http2SolrClient.java
@@ -231,7 +231,8 @@ public class Http2SolrClient extends HttpSolrClientBase {
       HTTP2Client http2client = new HTTP2Client(clientConnector);
       transport = new HttpClientTransportOverHTTP2(http2client);
       httpClient = new HttpClient(transport);
-      httpClient.setMaxConnectionsPerDestination(4);
+      int maxConnections = (builder.maxConnectionsPerHost != null) ? builder.maxConnectionsPerHost : 4;
+      httpClient.setMaxConnectionsPerDestination(maxConnections);
     }
 
     httpClient.setExecutor(this.executor);
@@ -967,8 +968,8 @@ public class Http2SolrClient extends HttpSolrClientBase {
     }
 
     /**
-     * Set maxConnectionsPerHost for http1 connections, maximum number http2 connections is limited
-     * to 4
+     * Set maxConnectionsPerHost for http1 and http2 connections. For http2 connections, defaults
+     * to 4 if not specified.
      *
      * @deprecated Please use {@link #withMaxConnectionsPerHost(int)}
      */

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClientBuilderBase.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClientBuilderBase.java
@@ -107,7 +107,7 @@ public abstract class HttpSolrClientBuilderBase<
 
   /**
    * Set maxConnectionsPerHost for http1 and http2 connections. For http2 connections in
-   * Http2SolrClient, defaults to 4 if not specified.
+   * Http2SolrClient, defaults to 8 if not specified.
    */
   @SuppressWarnings("unchecked")
   public B withMaxConnectionsPerHost(int max) {

--- a/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClientBuilderBase.java
+++ b/solr/solrj/src/java/org/apache/solr/client/solrj/impl/HttpSolrClientBuilderBase.java
@@ -106,8 +106,8 @@ public abstract class HttpSolrClientBuilderBase<
   }
 
   /**
-   * Set maxConnectionsPerHost for http1 connections, maximum number http2 connections is limited to
-   * 4
+   * Set maxConnectionsPerHost for http1 and http2 connections. For http2 connections in
+   * Http2SolrClient, defaults to 4 if not specified.
    */
   @SuppressWarnings("unchecked")
   public B withMaxConnectionsPerHost(int max) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves inter-node HTTP performance and observability.
> 
> - Replaces `Http2SolrClient` semaphore/phaser throttling with atomic active-request tracking; adds `getOutstandingRequests()` and waits for completion via notify/wait
> - Adds timing logs: `HttpShardHandler.requestAsync()` warn if >1s; `Http2SolrClient` logs slow `getRequestUrl`, `makeRequest`, total pre-send, and queued delays (method+URI)
> - Metrics: change gauge from `httpClientAvailablePermits` to `httpClientOutstandingRequests`; updates Prometheus metric name/desc accordingly
> - HTTP client tuning: make selectors and queued-per-destination configurable via env props; raise HTTP/2 default max connections per destination to 16 (configurable); keep HTTP/1.1 using provided max
> - Minor: enhanced delayed-request listener logs URI; builder docs adjusted re: max connections
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b65bbd1726d7ddd5192f1936b7b2e64b44b2be5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->