### PR TITLE
SAI-6015: Simple fixes to TimeLimitingHttpShardHandler.java

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/TimeLimitingHttpShardHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/TimeLimitingHttpShardHandler.java
@@ -75,14 +75,11 @@ class TimeLimitingHttpShardHandler extends HttpShardHandler {
             k -> {
               List<ShardRequestActor> actors = new ArrayList<>();
               actors.add(new NodeStatsCollector(slowNodeDetector));
-              if (shardsTolerant) {
+              Set<String> slowNodes = slowNodeDetector.getSlowNodes();
+              if (shardsTolerant && !slowNodes.isEmpty()) {
                 actors.add(
                     new SlowNodeTimeoutActor(
-                        slowNodeTimeout,
-                        dryRun,
-                        slowNodeDetector.getSlowNodes(),
-                        timeoutCallback,
-                        executorService));
+                        slowNodeTimeout, dryRun, slowNodes, timeoutCallback, executorService));
               }
               return new ShardRequestTracker(actors);
             });
@@ -308,7 +305,9 @@ class SlowNodeTimeoutActor implements ShardRequestActor {
     }
 
     // all pending reqs are from slow nodes, start a countdown to possibly cancel those requests
-    if (cancelCountDownLatch == null && pendingFutureCountFromFastNode.get() <= 0) {
+    if (!pendingFutures.isEmpty()
+        && cancelCountDownLatch == null
+        && pendingFutureCountFromFastNode.get() <= 0) {
       cancelCountDownLatch = new CountDownLatch(1);
       executorService.submit(
           () -> {


### PR DESCRIPTION
## Description
1. Do not start the "wait" thread if there's no pending requests
2. Do not create SlowNodeTimeoutActor if there's no slow nodes detected

## Test
1. Existing unit test cases passed
2. Debugged locally to ensure SlowNodeTimeoutActor logic is no longer triggered in normal (no slow node cases)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Avoids unnecessary timeout work when there are no slow nodes or pending requests.
> 
> - Instantiate `SlowNodeTimeoutActor` only if shard handling is tolerant and `slowNodeDetector.getSlowNodes()` is non-empty; pass the pre-fetched `slowNodes` set to the actor
> - In `SlowNodeTimeoutActor.onRequestCompleted`, initiate the cancel countdown only when `pendingFutures` is non-empty and there are no fast-node futures, preventing an idle wait thread
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffb46181526262e6b3ec9585a744646f620d3b8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->