### PR TITLE
SAI-6021 : Fix slow node detection metric context leaks

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/SlowNodeDetector.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SlowNodeDetector.java
@@ -33,6 +33,7 @@ class SlowNodeDetector implements SolrMetricProducer {
   private final int maxSlowResponsePercentage;
   private final int minShardCountPerRequest;
   private final int slowLatencyThreshold;
+  private SolrMetricsContext metricsContext;
 
   /**
    * @param latencyDropRatioThreshold identify as a latency drop point when current latency is < 0.5
@@ -213,29 +214,16 @@ class SlowNodeDetector implements SolrMetricProducer {
 
   @Override
   public void initializeMetrics(SolrMetricsContext parentContext, String scope) {
-    String nodeRegistry = SolrMetricManager.getRegistryName(SolrInfoBean.Group.node);
-    SolrMetricManager manager = parentContext.getMetricManager();
-    manager.registerGauge(
-        parentContext,
-        nodeRegistry,
-        slowNodes::keySet,
-        parentContext.getTag(),
-        SolrMetricManager.ResolutionStrategy.REPLACE,
-        "slowNodes",
-        scope);
-    manager.registerGauge(
-        parentContext,
-        nodeRegistry,
-        slowNodes::size,
-        parentContext.getTag(),
-        SolrMetricManager.ResolutionStrategy.REPLACE,
-        "slowNodeCount",
-        scope);
+    metricsContext = parentContext.getChildContext(this);
+    String expandedScope = SolrMetricManager.mkName(scope, SolrInfoBean.Category.QUERY.name());
+
+    metricsContext.gauge(slowNodes::keySet, true, "slowNodes", expandedScope);
+    metricsContext.gauge(slowNodes::size, true, "slowNodeCount", expandedScope);
   }
 
   @Override
   public SolrMetricsContext getSolrMetricsContext() { // using the same context as parent
-    return null;
+    return metricsContext;
   }
 
   static class Builder {

--- a/solr/core/src/java/org/apache/solr/handler/component/SlowNodeDetector.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SlowNodeDetector.java
@@ -215,10 +215,9 @@ class SlowNodeDetector implements SolrMetricProducer {
   @Override
   public void initializeMetrics(SolrMetricsContext parentContext, String scope) {
     metricsContext = parentContext.getChildContext(this);
-    String expandedScope = SolrMetricManager.mkName(scope, SolrInfoBean.Category.QUERY.name());
 
-    metricsContext.gauge(slowNodes::keySet, true, "slowNodes", expandedScope);
-    metricsContext.gauge(slowNodes::size, true, "slowNodeCount", expandedScope);
+    metricsContext.gauge(slowNodes::keySet, true, "slowNodes", scope);
+    metricsContext.gauge(slowNodes::size, true, "slowNodeCount", scope);
   }
 
   @Override

--- a/solr/core/src/java/org/apache/solr/handler/component/SlowNodeDetector.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SlowNodeDetector.java
@@ -13,8 +13,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import org.apache.solr.core.SolrInfoBean;
-import org.apache.solr.metrics.SolrMetricManager;
 import org.apache.solr.metrics.SolrMetricProducer;
 import org.apache.solr.metrics.SolrMetricsContext;
 import org.slf4j.Logger;

--- a/solr/core/src/java/org/apache/solr/handler/component/TimeLimitingHttpShardHandlerFactory.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/TimeLimitingHttpShardHandlerFactory.java
@@ -17,6 +17,7 @@
 package org.apache.solr.handler.component;
 
 import com.codahale.metrics.Counter;
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.concurrent.ExecutorService;
 import org.apache.solr.common.util.ExecutorUtil;
@@ -45,7 +46,6 @@ public class TimeLimitingHttpShardHandlerFactory extends HttpShardHandlerFactory
   private static final String DRY_RUN_CONFIG_KEY = "dryRun";
 
   private SlowNodeDetector slowNodeDetector;
-  private SolrMetricsContext solrMetricsContext;
   Counter cancelledSlowNodeRequests;
   Counter cancelledDryRunSlowNodeRequests;
   private ExecutorService executorService;
@@ -153,26 +153,28 @@ public class TimeLimitingHttpShardHandlerFactory extends HttpShardHandlerFactory
   @Override
   public void initializeMetrics(SolrMetricsContext parentContext, String scope) {
     super.initializeMetrics(parentContext, scope);
-    solrMetricsContext = parentContext.getChildContext(this);
     String expandedScope = SolrMetricManager.mkName(scope, SolrInfoBean.Category.QUERY.name());
     cancelledSlowNodeRequests =
-        solrMetricsContext.counter("cancelledSlowNodeRequests", expandedScope);
+        getSolrMetricsContext().counter("cancelledSlowNodeRequests", expandedScope);
     cancelledDryRunSlowNodeRequests =
-        solrMetricsContext.counter("cancelledDryRunSlowNodeRequests", expandedScope);
+        getSolrMetricsContext().counter("cancelledDryRunSlowNodeRequests", expandedScope);
 
     if (slowNodeDetector != null) {
-      slowNodeDetector.initializeMetrics(solrMetricsContext, expandedScope);
+      slowNodeDetector.initializeMetrics(getSolrMetricsContext(), expandedScope);
     }
-  }
-
-  @Override
-  public SolrMetricsContext getSolrMetricsContext() {
-    return solrMetricsContext;
   }
 
   @Override
   public void close() {
     super.close();
+    if (slowNodeDetector != null) {
+      try {
+        slowNodeDetector.close();
+      } catch (IOException e) {
+        log.warn("Failed to close the slowNodeDetector", e);
+      }
+    }
+
     if (executorService != null) {
       ExecutorUtil.shutdownNowAndAwaitTermination(executorService);
     }


### PR DESCRIPTION
## Description
There are 2 potential `SolrMetricsContextLeak` (1 discovered by AI and another by @magibney, assuming he's not AI 🤖 )

1. `TimeLimitingHttpShardHandlerFactory#initializeMetrics` calls both `super.initializeMetrics(parentContext, scope);` AND    `solrMetricsContext = parentContext.getChildContext(this);`. Both calls create new metrics, but only the latter one got closed via the `SolrMetricProducer.super.close()`
2. `SlowNodeDetector` registers gauge metrics via `SolrMetricManager` directly and never unregister them. This technically does not cause any leaks (if the parent context is closed properly), however it's probably better to call `SolrMetricsContext#gauge` method instead. 


In reality this should be rather minimal in impact:
1.  As @magibney pointed out, there's only a single synthetic core created on QA node. So only one instance of `TimeLimitingHttpShardHandlerFactory` and `SlowNodeDetector` (the core container one is not using the same config, hence not a `TimeLimitingHttpShardHandlerFactory`). `TimeLimitingHttpShardHandlerFactory` is not applied to non QA node (which could have way more cores hence more problematic)
2. The metrics created in `TimeLimitingHttpShardHandlerFactory` are only counters. They are likely not an issue for memory as:
   1. `SolrMetricsContext#unregister` only unregister gauges and not care about other metrics. My guess is that other metrics are just not a concern?
   2. Further to point 1. Existing usages of counters in other classes do not manually unregister them neither


## Solution
1. `TimeLimitingHttpShardHandlerFactory` should no longer call `parentContext.getChildContext(this)`. It should just use the context from its parent class `HttpShardHandlerFactory`. Remove the overridden `getSolrMetricsContext` method
2. `SlowNodeDetector` will no longer directly register gauges via the manager, it should use the create a child context from the parent context (in this case from `TimeLimitingHttpShardHandlerFactory`)'s `gauge` method, which should take care of the gauges on closing. The overridden `getSolrMetricsContext` should return this new child context instead of null. Take note that in theory `SlowNodeDetector` can just use the parent context from `TimeLimitingHttpShardHandlerFactory` since they share the same life cycle (for now). However, I don't really like that coupling, and is probably better oof having its own dedicated context 



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily refactors metrics registration/cleanup to use `SolrMetricsContext` correctly and adds explicit close handling; minimal behavioral impact outside metrics lifecycle management.
> 
> **Overview**
> Fixes potential metrics context leaks in slow-node detection and query shard handling.
> 
> `TimeLimitingHttpShardHandlerFactory` now uses the metrics context created by `HttpShardHandlerFactory` (removing its extra child context) and ensures `SlowNodeDetector` is closed during factory shutdown. `SlowNodeDetector` switches from direct `SolrMetricManager.registerGauge` calls to a dedicated child `SolrMetricsContext` with `gauge(...)`, and returns that context via `getSolrMetricsContext()` so gauges are properly unregistered on close.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9983ffc53f5cd66ff6abf32d801b942c31b65907. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->