### PR TITLE
SAI-6035: fix segment-aware cache exception handling

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
+++ b/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
@@ -224,60 +224,7 @@ public class CaffeineCache<K, V> extends SolrCacheBase
     CompletableFuture<V> result = asyncCache.asMap().putIfAbsent(key, future);
     lookups.increment();
     if (result != null) {
-      try {
-        // Another thread is already working on this computation, wait for them to finish
-        QueryLimits queryLimits = QueryLimits.getCurrentLimits();
-        // TODO: below respects `TimeAllowedLimit` for the calling thread, but in order to
-        //  support query limits more generically, we would need to poll `queryLimits.shouldExit()`
-        //  in a loop in conjunction with `result.get(long, TimeUnit)`.
-        //  NOTE: the only other currently available limit is `CpuAllowedLimit`, which in the
-        //  case of a thread blocking on a result to be made available from another thread's
-        //  computation, should be a non-issue in practice.
-        Long nanosElapsed;
-        V value;
-        if (queryLimits != null
-            && (nanosElapsed =
-                    (Long) queryLimits.currentLimitValueFor(TimeAllowedLimit.class).orElse(null))
-                != null) {
-          SolrRequestInfo requestInfo = SolrRequestInfo.getRequestInfo();
-          assert requestInfo != null
-              : "non-null QueryLimits should guarantee non-null SolrRequestInfo";
-          SolrQueryRequest req = requestInfo.getReq();
-          assert req != null
-              : "TimeAllowedLimit is set from request, so non-null TimeAllowedLimit implies non-null req";
-          long timeAllowedMillis = req.getParams().getLong(CommonParams.TIME_ALLOWED, -1L);
-          assert timeAllowedMillis >= 0 : "TimeAllowedLimit implies timeAllowed >= 0";
-          long nanosRemaining = TimeUnit.MILLISECONDS.toNanos(timeAllowedMillis) - nanosElapsed;
-          value = result.get(nanosRemaining, TimeUnit.NANOSECONDS);
-        } else {
-          value = result.get(); // prefer `get()`, since `join()` is uninterruptible
-        }
-        hits.increment();
-        return value;
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        throw new CompletionException(e);
-      } catch (TimeoutException e) {
-        // we are almost certainly in violation of `TimeAllowedLimit`, but the easiest thing to
-        // do is attempt to compute the result ourselves and allow (e.g.) ExitingDirectoryReader
-        // to handle appropriately.
-        return mappingFunction.apply(key);
-      } catch (ExecutionException e) {
-        Throwable cause = e.getCause();
-        if (cause instanceof IOException) {
-          // Computation had an IOException, likely index problems, so fail this result too
-          throw (IOException) cause;
-        }
-        if (cause == REQUEST_SCOPED_EXCEPTION) {
-          // The reserved slot that we were waiting for failed for a reason associated with the
-          // computing thread, rather than the computation _per se_, so we fallback to compute
-          // directly. If we go back to waiting for a new cache result then that can lead to thread
-          // starvation.
-          // We implicitly "record" a cache miss here (by not incrementing `hits`).
-          return mappingFunction.apply(key);
-        }
-        throw new CompletionException(cause);
-      }
+      return getV(key, mappingFunction, result, onCached);
     }
     try {
       // We reserved the slot, so we do the work
@@ -299,8 +246,73 @@ public class CaffeineCache<K, V> extends SolrCacheBase
     }
   }
 
+  @SuppressWarnings("UnnecessaryLambda")
+  private final Runnable onCached = () -> hits.increment();
+
+  public static <K, V> V getV(
+      K key,
+      IOFunction<? super K, ? extends V> mappingFunction,
+      CompletableFuture<V> result,
+      Runnable onCached)
+      throws IOException {
+    try {
+      // Another thread is already working on this computation, wait for them to finish
+      QueryLimits queryLimits = QueryLimits.getCurrentLimits();
+      // TODO: below respects `TimeAllowedLimit` for the calling thread, but in order to
+      //  support query limits more generically, we would need to poll `queryLimits.shouldExit()`
+      //  in a loop in conjunction with `result.get(long, TimeUnit)`.
+      //  NOTE: the only other currently available limit is `CpuAllowedLimit`, which in the
+      //  case of a thread blocking on a result to be made available from another thread's
+      //  computation, should be a non-issue in practice.
+      Long nanosElapsed;
+      V value;
+      if (queryLimits != null
+          && (nanosElapsed =
+                  (Long) queryLimits.currentLimitValueFor(TimeAllowedLimit.class).orElse(null))
+              != null) {
+        SolrRequestInfo requestInfo = SolrRequestInfo.getRequestInfo();
+        assert requestInfo != null
+            : "non-null QueryLimits should guarantee non-null SolrRequestInfo";
+        SolrQueryRequest req = requestInfo.getReq();
+        assert req != null
+            : "TimeAllowedLimit is set from request, so non-null TimeAllowedLimit implies non-null req";
+        long timeAllowedMillis = req.getParams().getLong(CommonParams.TIME_ALLOWED, -1L);
+        assert timeAllowedMillis >= 0 : "TimeAllowedLimit implies timeAllowed >= 0";
+        long nanosRemaining = TimeUnit.MILLISECONDS.toNanos(timeAllowedMillis) - nanosElapsed;
+        value = result.get(nanosRemaining, TimeUnit.NANOSECONDS);
+      } else {
+        value = result.get(); // prefer `get()`, since `join()` is uninterruptible
+      }
+      onCached.run();
+      return value;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new CompletionException(e);
+    } catch (TimeoutException e) {
+      // we are almost certainly in violation of `TimeAllowedLimit`, but the easiest thing to
+      // do is attempt to compute the result ourselves and allow (e.g.) ExitingDirectoryReader
+      // to handle appropriately.
+      return mappingFunction.apply(key);
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof IOException) {
+        // Computation had an IOException, likely index problems, so fail this result too
+        throw (IOException) cause;
+      }
+      if (cause == REQUEST_SCOPED_EXCEPTION) {
+        // The reserved slot that we were waiting for failed for a reason associated with the
+        // computing thread, rather than the computation _per se_, so we fallback to compute
+        // directly. If we go back to waiting for a new cache result then that can lead to thread
+        // starvation.
+        // We implicitly "record" a cache miss here (by not calling `onCached.run()`).
+        return mappingFunction.apply(key);
+      }
+      throw new CompletionException(cause);
+    }
+  }
+
   @SuppressWarnings("StaticAssignmentOfThrowable")
-  private static final RuntimeException REQUEST_SCOPED_EXCEPTION = new RequestScopedException();
+  public static final RuntimeException REQUEST_SCOPED_EXCEPTION = new RequestScopedException();
 
   private static final class RequestScopedException extends RuntimeException {
     @Override

--- a/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
+++ b/solr/core/src/java/org/apache/solr/search/CaffeineCache.java
@@ -246,8 +246,11 @@ public class CaffeineCache<K, V> extends SolrCacheBase
     }
   }
 
-  @SuppressWarnings("UnnecessaryLambda")
-  private final Runnable onCached = () -> hits.increment();
+  private final Runnable onCached = this::incrementHits;
+
+  private void incrementHits() {
+    hits.increment();
+  }
 
   public static <K, V> V getV(
       K key,

--- a/solr/core/src/java/org/apache/solr/search/KeepAliveRegenerator.java
+++ b/solr/core/src/java/org/apache/solr/search/KeepAliveRegenerator.java
@@ -38,6 +38,7 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.ConstantScoreScorer;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.Explanation;
@@ -476,7 +477,9 @@ public class KeepAliveRegenerator<M extends MetaEntry<Query, DocSet, M>>
         return DocSetUtil.createDocSetGeneric(searcher, this);
       } else {
         final Weight backingWeight =
-            backing.createWeight(searcher, ScoreMode.COMPLETE_NO_SCORES, 1f);
+            searcher
+                .rewrite(new ConstantScoreQuery(backing))
+                .createWeight(searcher, ScoreMode.COMPLETE_NO_SCORES, 1f);
         final long[][] staleBits;
         if (stale instanceof BitDocSet) {
           staleBits = ((BitDocSet) stale).getBits().getBits();

--- a/solr/core/src/java/org/apache/solr/search/KeepAliveRegenerator.java
+++ b/solr/core/src/java/org/apache/solr/search/KeepAliveRegenerator.java
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.LongAdder;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.ExitableDirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.Term;
@@ -47,6 +48,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.TimeLimitingCollector;
 import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.Bits;
@@ -279,9 +281,19 @@ public class KeepAliveRegenerator<M extends MetaEntry<Query, DocSet, M>>
         throws IOException {
       AbstractMap.SimpleImmutableEntry<SegmentMap, CompletableFuture<DocSet>> ref = this.ref.get();
       accessTimestampNanos = System.nanoTime();
+      DocSet[] weComputed = new DocSet[1];
+      IOFunction<? super Query, ? extends DocSet> wrappedMappingFunction =
+          (k) -> {
+            if (mappingFunction == null) {
+              return null;
+            }
+            DocSet ret = mappingFunction.apply(k);
+            weComputed[0] = ret;
+            return ret;
+          };
       try {
         if (ref.getKey() == segMap) {
-          return ref.getValue().get();
+          return CaffeineCache.getV(key, wrappedMappingFunction, ref.getValue(), NOOP);
         } else if (mappingFunction == null) {
           return null;
         }
@@ -292,27 +304,55 @@ public class KeepAliveRegenerator<M extends MetaEntry<Query, DocSet, M>>
             this.ref.compareAndExchange(ref, newRef);
         if (witness == ref) {
           // we compute
-          Query frankenstein =
-              new FrankensteinQuery(key, ref.getKey().segments, ref.getValue().get());
-          DocSet computed = mappingFunction.apply(frankenstein);
-          f.complete(computed);
-          partialHits.increment();
-          partialHitsRatio.add(ref.getKey().getOverlap(segMap.key));
-          return computed;
+          try {
+            DocSet stale = CaffeineCache.getV(key, (k) -> null, ref.getValue(), NOOP);
+            DocSet computed;
+            if (stale == null) {
+              // nothing to reconstruct from; just run the query
+              computed = mappingFunction.apply(key);
+              f.complete(computed);
+            } else {
+              Query frankenstein = new FrankensteinQuery(key, ref.getKey().segments, stale);
+              computed = mappingFunction.apply(frankenstein);
+              f.complete(computed); // asap
+              partialHits.increment();
+              partialHitsRatio.add(ref.getKey().getOverlap(segMap.key));
+            }
+            return computed;
+          } catch (TimeLimitingCollector.TimeExceededException
+              | CancellableCollector.QueryCancelledException
+              | ExitableDirectoryReader.ExitingReaderException e) {
+            // These exceptions are related to the calling thread, so are "recoverable" from other
+            // threads
+            // that might be waiting for our computation to complete.
+            f.completeExceptionally(CaffeineCache.REQUEST_SCOPED_EXCEPTION);
+            throw e;
+          } catch (Error | RuntimeException | IOException e) {
+            f.completeExceptionally(e); // This will remove the future from the cache
+            throw e;
+          }
         } else if (witness.getKey() == segMap) {
-          return witness.getValue().get();
+          return CaffeineCache.getV(key, wrappedMappingFunction, witness.getValue(), NOOP);
         } else {
-          return mappingFunction.apply(key);
+          return wrappedMappingFunction.apply(key);
         }
-      } catch (InterruptedException ex) {
-        Thread.currentThread().interrupt();
-        throw new RuntimeException(ex);
-      } catch (ExecutionException ex) {
-        Throwable cause = ex.getCause();
-        if (cause instanceof IOException) {
-          throw (IOException) cause;
-        } else {
-          throw new RuntimeException(ex);
+      } finally {
+        // Here we attempt to avoid a situation where we have successfully computed a result, but
+        // somehow have a stored exceptional result. We already have the `KeepAliveSegAwareValue`
+        // cache entry, and a valid value. Replace the extant value if it's stale, or completed
+        // exceptionally.
+        DocSet outOfBandComputed = weComputed[0];
+        if (outOfBandComputed != null) {
+          this.ref.updateAndGet(
+              (extant) -> {
+                if (extant.getKey() != segMap || extant.getValue().isCompletedExceptionally()) {
+                  CompletableFuture<DocSet> opportunistic = new CompletableFuture<>();
+                  opportunistic.complete(outOfBandComputed);
+                  return new AbstractMap.SimpleImmutableEntry<>(segMap, opportunistic);
+                } else {
+                  return extant;
+                }
+              });
         }
       }
     }
@@ -322,6 +362,9 @@ public class KeepAliveRegenerator<M extends MetaEntry<Query, DocSet, M>>
       return ramBytesUsed;
     }
   }
+
+  @SuppressWarnings("UnnecessaryLambda")
+  private static final Runnable NOOP = () -> {};
 
   private final LongAdder partialHits;
   private final DoubleAdder partialHitsRatio;

--- a/solr/core/src/java/org/apache/solr/search/KeepAliveRegenerator.java
+++ b/solr/core/src/java/org/apache/solr/search/KeepAliveRegenerator.java
@@ -159,10 +159,16 @@ public class KeepAliveRegenerator<M extends MetaEntry<Query, DocSet, M>>
     this.overlapThreshold = DEFAULT_OVERLAP_THRESHOLD;
   }
 
-  @SuppressWarnings({"unchecked", "UnnecessaryLambda"})
   private static <M> BiFunction<SegmentMap, DocSet, M> getWrapFunction(
       LongAdder partialHits, DoubleAdder partialHitsRatio) {
-    return (segMap, v) -> (M) new KeepAliveSegAwareValue(segMap, v, partialHits, partialHitsRatio);
+    // noinspection Convert2Lambda
+    return new BiFunction<SegmentMap, DocSet, M>() {
+      @Override
+      @SuppressWarnings("unchecked")
+      public M apply(SegmentMap segMap, DocSet v) {
+        return (M) new KeepAliveSegAwareValue(segMap, v, partialHits, partialHitsRatio);
+      }
+    };
   }
 
   static boolean isCrossDoc(Query q) {
@@ -363,8 +369,9 @@ public class KeepAliveRegenerator<M extends MetaEntry<Query, DocSet, M>>
     }
   }
 
-  @SuppressWarnings("UnnecessaryLambda")
-  private static final Runnable NOOP = () -> {};
+  private static void doNothing() {}
+
+  private static final Runnable NOOP = KeepAliveRegenerator::doNothing;
 
   private final LongAdder partialHits;
   private final DoubleAdder partialHitsRatio;

--- a/solr/core/src/test/org/apache/solr/search/TestSegAwareCachingParity.java
+++ b/solr/core/src/test/org/apache/solr/search/TestSegAwareCachingParity.java
@@ -17,6 +17,8 @@
 package org.apache.solr.search;
 
 import java.io.Closeable;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -29,6 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.lucene.index.ExitableDirectoryReader;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
@@ -36,20 +39,26 @@ import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TimeLimitingCollector;
 import org.apache.solr.SolrTestCaseJ4;
 import org.apache.solr.common.util.ExecutorUtil;
 import org.apache.solr.common.util.SolrNamedThreadFactory;
 import org.apache.solr.core.SolrCore;
 import org.apache.solr.metrics.MetricsMap;
 import org.apache.solr.metrics.SolrMetricManager;
+import org.apache.solr.request.LocalSolrQueryRequest;
+import org.apache.solr.request.SolrRequestInfo;
+import org.apache.solr.response.SolrQueryResponse;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Verify caching impacts of FiltersQParser and FilterQuery */
 public class TestSegAwareCachingParity extends SolrTestCaseJ4 {
 
-  // fails: `-Ptests.seed=152284B971099372`
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private static final int NUM_DOCS = 100;
   private static final String FILTER_CACHE_IMPL_CLASS_PROPNAME = "solr.filterCache.class";
@@ -144,6 +153,31 @@ public class TestSegAwareCachingParity extends SolrTestCaseJ4 {
     return builder.build();
   }
 
+  /**
+   * We need to make sure that timeout exceptions don't propagate to other callers, and that any
+   * threads blocking for the computation of an exceptional result get the propagated exception and
+   * fallback appropriately.
+   */
+  private static DocSet getDocSet(SolrIndexSearcher s, Query q, Random r) throws IOException {
+    if (r.nextInt(10) == 0) {
+      try {
+        SolrRequestInfo.setRequestInfo(
+            new SolrRequestInfo(
+                new LocalSolrQueryRequest(null, Map.of("timeAllowed", new String[] {"0"})),
+                new SolrQueryResponse()));
+        DocSet ret = s.getDocSet(q);
+        log.info("No Timeout!");
+        return ret;
+      } catch (TimeLimitingCollector.TimeExceededException
+          | ExitableDirectoryReader.ExitingReaderException ex) {
+        log.info("Yes Timeout!"); // swallow
+      } finally {
+        SolrRequestInfo.clearRequestInfo();
+      }
+    }
+    return s.getDocSet(q);
+  }
+
   private static Callable<Integer> sustainedQuerying(
       Random r,
       AtomicBoolean exit,
@@ -164,11 +198,11 @@ public class TestSegAwareCachingParity extends SolrTestCaseJ4 {
                 DocSet docSet;
                 DocSet uncachedDocSet;
                 if (r.nextBoolean()) {
-                  docSet = s.getDocSet(queries[i]);
+                  docSet = getDocSet(s, queries[i], r);
                   uncachedDocSet = s.getDocSet(noCacheQueries[i]);
                 } else {
                   uncachedDocSet = s.getDocSet(noCacheQueries[i]);
-                  docSet = s.getDocSet(queries[i]);
+                  docSet = getDocSet(s, queries[i], r);
                 }
                 if (i == 1 || s.numDocs() == 0) {
                   // special case for MatchAllDocsQuery and empty index


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core filter cache concurrency/async completion and exception propagation paths; errors could cause cache poisoning, missed hits, or query latency/timeout behavior changes under load.
> 
> **Overview**
> Fixes segment-aware filter cache concurrency/exception semantics by refactoring the “wait for in-flight computation” logic into reusable `CaffeineCache.getV(...)`, and making the `REQUEST_SCOPED_EXCEPTION` sentinel public so other components can signal “caller-scoped” failures.
> 
> Updates `KeepAliveRegenerator.KeepAliveSegAwareValue.get()` to use `getV`, correctly mark/propagate request-scoped exceptions (timeouts/cancellations), and opportunistically replace stale/exceptional cached futures with a successfully computed `DocSet`; also ensures weight creation uses a rewritten `ConstantScoreQuery`.
> 
> Extends `TestSegAwareCachingParity` to inject random `timeAllowed=0` requests and assert timeouts don’t poison shared cached results for other threads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab1b49ac512f699b2122fef9f830329f14ee431b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->