### PR TITLE
SAI-6041 : Report filter cache hit/miss/bypass and per filter processing time

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -1702,9 +1702,6 @@ public class QueryComponent extends SearchComponent {
             rb.getResults() == null || rb.getResults().docList == null
                 ? 0
                 : rb.getResults().docList.matches());
-    if (rb.getFilterStats() != null) {
-      rsp.getResponseHeader().add("filtersStats", rb.getFilterStats());
-    }
 
     if (!rb.req.getParams().getBool(ShardParams.IS_SHARD, false)) {
       if (null != rb.getNextCursorMark()) {

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -1671,17 +1671,11 @@ public class QueryComponent extends SearchComponent {
       ResultContext ctx = new BasicResultContext(rb, grouping.mainResult);
       rsp.addResponse(ctx);
       rsp.getToLog().add("hits", grouping.mainResult.matches());
-      if (rb.getFilterStats() != null) {
-        rsp.getResponseHeader().add("filtersStats", rb.getFilterStats());
-      }
     } else if (!grouping
         .getCommands()
         .isEmpty()) { // Can never be empty since grouping.execute() checks for this.
       rsp.add("grouped", result.groupedResults);
       rsp.getToLog().add("hits", grouping.getCommands().get(0).getMatches());
-      if (rb.getFilterStats() != null) {
-        rsp.getResponseHeader().add("filtersStats", rb.getFilterStats());
-      }
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/QueryComponent.java
@@ -1671,11 +1671,17 @@ public class QueryComponent extends SearchComponent {
       ResultContext ctx = new BasicResultContext(rb, grouping.mainResult);
       rsp.addResponse(ctx);
       rsp.getToLog().add("hits", grouping.mainResult.matches());
+      if (rb.getFilterStats() != null) {
+        rsp.getResponseHeader().add("filtersStats", rb.getFilterStats());
+      }
     } else if (!grouping
         .getCommands()
         .isEmpty()) { // Can never be empty since grouping.execute() checks for this.
       rsp.add("grouped", result.groupedResults);
       rsp.getToLog().add("hits", grouping.getCommands().get(0).getMatches());
+      if (rb.getFilterStats() != null) {
+        rsp.getResponseHeader().add("filtersStats", rb.getFilterStats());
+      }
     }
   }
 
@@ -1702,6 +1708,9 @@ public class QueryComponent extends SearchComponent {
             rb.getResults() == null || rb.getResults().docList == null
                 ? 0
                 : rb.getResults().docList.matches());
+    if (rb.getFilterStats() != null) {
+      rsp.getResponseHeader().add("filtersStats", rb.getFilterStats());
+    }
 
     if (!rb.req.getParams().getBool(ShardParams.IS_SHARD, false)) {
       if (null != rb.getNextCursorMark()) {

--- a/solr/core/src/java/org/apache/solr/handler/component/ResponseBuilder.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/ResponseBuilder.java
@@ -97,6 +97,10 @@ public class ResponseBuilder {
 
   public List<SearchComponent> components;
 
+  // Always-on per-fq filter stats aligned with original fq order.
+  // Each entry is a NamedList with keys: "time" (Long ms), "cache" (String: HIT|MISS|BYPASS_POST|BYPASS_NOCACHE)
+  private List<NamedList<Object>> filterStats;
+
   SolrRequestInfo requestInfo;
 
   public ResponseBuilder(
@@ -315,6 +319,14 @@ public class ResponseBuilder {
 
   public void setDebugInfo(NamedList<Object> debugInfo) {
     this.debugInfo = debugInfo;
+  }
+
+  public List<NamedList<Object>> getFilterStats() {
+    return filterStats;
+  }
+
+  public void setFilterStats(List<NamedList<Object>> filterStats) {
+    this.filterStats = filterStats;
   }
 
   public int getFieldFlags() {

--- a/solr/core/src/java/org/apache/solr/handler/component/ResponseBuilder.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/ResponseBuilder.java
@@ -98,7 +98,8 @@ public class ResponseBuilder {
   public List<SearchComponent> components;
 
   // Always-on per-fq filter stats aligned with original fq order.
-  // Each entry is a NamedList with keys: "time" (Long ms), "cache" (String: HIT|MISS|BYPASS_POST|BYPASS_NOCACHE)
+  // Each entry is a NamedList with keys: "time" (Long ms), "cache" (String:
+  // HIT|MISS|BYPASS)
   private List<NamedList<Object>> filterStats;
 
   SolrRequestInfo requestInfo;

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -528,11 +528,6 @@ public class SearchHandler extends RequestHandlerBase
             rb.addDebugInfo("timing", timer.asNamedList());
           }
         }
-
-        if (rb.getFilterStats() != null) {
-          rsp.getResponseHeader().add("filtersStats", rb.getFilterStats());
-          rsp.getToLog().add("filtersStats", rb.getFilterStats());
-        }
       } catch (ExitableDirectoryReader.ExitingReaderException ex) {
         log.warn("Query: {}; ", req.getParamString(), ex);
         if (rb.rsp.getResponse() == null) {
@@ -555,6 +550,14 @@ public class SearchHandler extends RequestHandlerBase
         // An IOException on a non-distributed request is typically an issue parsing the query at
         // the lucene level
         throw new SolrException(SolrException.ErrorCode.BAD_REQUEST, ex);
+      } finally {
+        if (rb.getFilterStats() != null) { // always attempt to add filter cache stats if possible
+          NamedList<Object> headers = rb.rsp.getResponseHeader();
+          if (headers != null) {
+            headers.add("filtersStats", rb.getFilterStats());
+          }
+          rsp.getToLog().add("filtersStats", rb.getFilterStats());
+        }
       }
     } else {
       // a distributed request

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -528,6 +528,11 @@ public class SearchHandler extends RequestHandlerBase
             rb.addDebugInfo("timing", timer.asNamedList());
           }
         }
+
+        if (rb.getFilterStats() != null) {
+          rsp.getResponseHeader().add("filtersStats", rb.getFilterStats());
+          rsp.getToLog().add("filtersStats", rb.getFilterStats());
+        }
       } catch (ExitableDirectoryReader.ExitingReaderException ex) {
         log.warn("Query: {}; ", req.getParamString(), ex);
         if (rb.rsp.getResponse() == null) {

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.Timer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -95,6 +96,7 @@ import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.CollectionUtil;
 import org.apache.solr.common.util.EnvUtils;
+import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.ObjectReleaseTracker;
 import org.apache.solr.core.DirectoryFactory;
 import org.apache.solr.core.DirectoryFactory.DirContext;
@@ -987,8 +989,22 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     return answerBits;
   }
 
+  private class DocSetWithStats {
+    private DocSet docSet;
+    private CacheOutcome cacheOutcome;
+
+    private DocSetWithStats(DocSet docSet, CacheOutcome cacheOutcome) {
+      this.docSet = docSet;
+      this.cacheOutcome = cacheOutcome;
+    }
+  }
+
   // only handle positive (non negative) queries
   DocSet getPositiveDocSet(Query query) throws IOException {
+    return getPositiveDocSetWithStats(query).docSet;
+  }
+
+  private DocSetWithStats getPositiveDocSetWithStats(Query query) throws IOException {
     // TODO duplicated code with getDocSet?
     boolean doCache = filterCache != null;
     if (query instanceof ExtendedQuery) {
@@ -1001,10 +1017,10 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     }
 
     if (doCache) {
-      return getAndCacheDocSet(query, filterCache);
+      return getAndCacheDocSetWithStats(query, filterCache);
     }
 
-    return getDocSetNC(query, null);
+    return new DocSetWithStats(getDocSetNC(query, null), CacheOutcome.BYPASSED);
   }
 
   /**
@@ -1047,15 +1063,20 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
    * @return the DocSet answer
    */
   public DocSet getAndCacheDocSet(Query query, SolrCache<Query, DocSet> cache) throws IOException {
+    return getAndCacheDocSetWithStats(query, cache).docSet;
+  }
+
+  private DocSetWithStats getAndCacheDocSetWithStats(Query query, SolrCache<Query, DocSet> cache) throws IOException {
     assert !(query instanceof WrappedQuery) : "should have unwrapped";
     assert cache != null : "must check for caching before calling this method";
 
     if (query instanceof MatchAllDocsQuery) {
       // bypass the filterCache for MatchAllDocsQuery
-      return getLiveDocSet();
+      return new DocSetWithStats(getLiveDocSet(), CacheOutcome.BYPASSED);
     }
 
     DocSet answer;
+    AtomicReference<CacheOutcome> cacheOutcome = new AtomicReference<>(CacheOutcome.HIT);
     if (!OPTIMISTIC_QUERY_LIMITED_CACHE_COMPUTATION
         && QueryLimits.getCurrentLimits().isLimitsEnabled()) {
       // If there is a possibility of timeout for this query, then don't reserve a computation slot.
@@ -1069,13 +1090,17 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       if (answer == null) {
         answer = getDocSetNC(query, null);
         cache.put(query, answer);
+        cacheOutcome.set(CacheOutcome.MISS);
       }
     } else {
-      answer = cache.computeIfAbsent(query, q -> getDocSetNC(q, null));
+      answer = cache.computeIfAbsent(query, q -> {
+        cacheOutcome.set(CacheOutcome.MISS);
+        return getDocSetNC(q, null);
+      });
     }
 
     assert !(answer instanceof MutableBitDocSet) : "should not be mutable";
-    return answer;
+    return new DocSetWithStats(answer, cacheOutcome.get());
   }
 
   private static final MatchAllDocsQuery MATCH_ALL_DOCS_QUERY = new MatchAllDocsQuery();
@@ -1238,6 +1263,25 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     public DelegatingCollector postFilter; // maybe null
   }
 
+
+  private enum CacheOutcome{
+    HIT,
+    MISS,
+    BYPASSED
+  }
+
+  private static void addCacheStats(java.util.List<org.apache.solr.common.util.NamedList<Object>> perFilterStats,
+                                int index,
+                                CacheOutcome cacheOutcome,
+                                Long startTimeMillisec) {
+    org.apache.solr.common.util.NamedList<Object> stat = new org.apache.solr.common.util.SimpleOrderedMap<>();
+    if (startTimeMillisec != null) {
+      stat.add("time", System.currentTimeMillis() - startTimeMillisec);
+    }
+    stat.add("cache", cacheOutcome.name());
+    perFilterStats.set(index, stat);
+  }
+
   /**
    * INTERNAL: Processes conjunction (AND) of both args into a {@link ProcessedFilter} result.
    * Either arg may be null/empty thus doesn't restrict the matching docs. Queries typically are
@@ -1252,6 +1296,14 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
         pf.filter = setFilter.makeQuery();
       }
       return pf;
+    }
+
+    // Collect per-fq timing/cache outcome aligned with original order, if possible.
+    // We'll attach this to the current ResponseBuilder (if any) at the end.
+    final java.util.List<org.apache.solr.common.util.NamedList<Object>> perFilterCacheStats =
+            new java.util.ArrayList<>(queries.size());
+    for (int i = 0; i < queries.size(); i++) {
+      perFilterCacheStats.add(null);
     }
 
     // We combine all the filter queries that come from the filter cache & setFilter into "answer".
@@ -1269,7 +1321,9 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       answer = setFilter;
     } // we are done with setFilter at this point
 
-    for (Query q : queries) {
+
+    for (int i = 0 ; i < queries.size(); i++) {
+      Query q = queries.get(i);
       if (q instanceof ExtendedQuery) {
         ExtendedQuery eq = (ExtendedQuery) q;
         if (!eq.getCache()) {
@@ -1297,7 +1351,11 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       }
 
       Query posQuery = QueryUtils.getAbs(q);
-      DocSet docSet = getPositiveDocSet(posQuery);
+      long startTime = System.currentTimeMillis();
+      DocSetWithStats result = getPositiveDocSetWithStats(posQuery);
+      addCacheStats(perFilterCacheStats, i , result.cacheOutcome, startTime);
+
+      DocSet docSet =  result.docSet;
       // Negative query if absolute value different from original
       if (Objects.equals(q, posQuery)) {
         // keep track of the smallest positive set; use "answer" for this.
@@ -1390,6 +1448,23 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
         if (prev != null) pf.postFilter.setDelegate(prev);
       }
     }
+
+    // Attach per-filter stats (aligned with original order) to current ResponseBuilder, if present.
+    org.apache.solr.request.SolrRequestInfo sri = org.apache.solr.request.SolrRequestInfo.getRequestInfo();
+    if (sri != null) {
+      org.apache.solr.handler.component.ResponseBuilder rb = sri.getResponseBuilder();
+      if (rb != null) {
+        // fill in any missing slots (continue statement w/o setting stats etc)
+        for (int i = 0; i < perFilterCacheStats.size(); i++) {
+          if (perFilterCacheStats.get(i) == null) {
+            addCacheStats(perFilterCacheStats, i , CacheOutcome.BYPASSED, null);
+          }
+        }
+
+        rb.setFilterStats(perFilterCacheStats);
+      }
+    }
+
 
     return pf;
   }

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1275,6 +1275,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       java.util.List<org.apache.solr.common.util.NamedList<Object>> perFilterStats,
       int index,
       CacheOutcome cacheOutcome,
+      Integer docSetIdCount,
       Long startTimeNanos) {
     org.apache.solr.common.util.NamedList<Object> stat =
         new org.apache.solr.common.util.SimpleOrderedMap<>();
@@ -1284,6 +1285,9 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       stat.add("time", elapsedMs);
     }
     stat.add("cache", cacheOutcome.name());
+    if (docSetIdCount != null) {
+      stat.add("docSetIdCount", docSetIdCount);
+    }
     perFilterStats.set(index, stat);
   }
 
@@ -1357,9 +1361,9 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       Query posQuery = QueryUtils.getAbs(q);
       long startTime = System.nanoTime();
       DocSetWithStats result = getPositiveDocSetWithStats(posQuery);
-      addCacheStats(perFilterCacheStats, i, result.cacheOutcome, startTime);
-
       DocSet docSet = result.docSet;
+      addCacheStats(perFilterCacheStats, i, result.cacheOutcome, docSet.size(), startTime);
+
       // Negative query if absolute value different from original
       if (Objects.equals(q, posQuery)) {
         // keep track of the smallest positive set; use "answer" for this.
@@ -1393,7 +1397,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
         // fill in any missing slots (continue statement w/o setting stats etc)
         for (int i = 0; i < perFilterCacheStats.size(); i++) {
           if (perFilterCacheStats.get(i) == null) {
-            addCacheStats(perFilterCacheStats, i, CacheOutcome.BYPASSED, null);
+            addCacheStats(perFilterCacheStats, i, CacheOutcome.BYPASSED, null, null);
           }
         }
         rb.setFilterStats(perFilterCacheStats);

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1377,6 +1377,22 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       sets[end++] = docSet;
     } // end of queries
 
+    // Attach per-filter stats (aligned with original order) to current ResponseBuilder, if present.
+    // Do it as soon as possible to ensure we don't miss it due to later short-cut returns.
+    org.apache.solr.request.SolrRequestInfo sri = org.apache.solr.request.SolrRequestInfo.getRequestInfo();
+    if (sri != null) {
+      org.apache.solr.handler.component.ResponseBuilder rb = sri.getResponseBuilder();
+      if (rb != null) {
+        // fill in any missing slots (continue statement w/o setting stats etc)
+        for (int i = 0; i < perFilterCacheStats.size(); i++) {
+          if (perFilterCacheStats.get(i) == null) {
+            addCacheStats(perFilterCacheStats, i , CacheOutcome.BYPASSED, null);
+          }
+        }
+        rb.setFilterStats(perFilterCacheStats);
+      }
+    }
+
     if (end > 0) {
       // Are all of our normal cached filters negative?
       if (answer == null) {
@@ -1448,23 +1464,6 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
         if (prev != null) pf.postFilter.setDelegate(prev);
       }
     }
-
-    // Attach per-filter stats (aligned with original order) to current ResponseBuilder, if present.
-    org.apache.solr.request.SolrRequestInfo sri = org.apache.solr.request.SolrRequestInfo.getRequestInfo();
-    if (sri != null) {
-      org.apache.solr.handler.component.ResponseBuilder rb = sri.getResponseBuilder();
-      if (rb != null) {
-        // fill in any missing slots (continue statement w/o setting stats etc)
-        for (int i = 0; i < perFilterCacheStats.size(); i++) {
-          if (perFilterCacheStats.get(i) == null) {
-            addCacheStats(perFilterCacheStats, i , CacheOutcome.BYPASSED, null);
-          }
-        }
-
-        rb.setFilterStats(perFilterCacheStats);
-      }
-    }
-
 
     return pf;
   }

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -987,9 +987,9 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     return answerBits;
   }
 
-  private class DocSetWithStats {
-    private DocSet docSet;
-    private CacheOutcome cacheOutcome;
+  private static class DocSetWithStats {
+    private final DocSet docSet;
+    private final CacheOutcome cacheOutcome;
 
     private DocSetWithStats(DocSet docSet, CacheOutcome cacheOutcome) {
       this.docSet = docSet;

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1275,11 +1275,13 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       java.util.List<org.apache.solr.common.util.NamedList<Object>> perFilterStats,
       int index,
       CacheOutcome cacheOutcome,
-      Long startTimeMillisec) {
+      Long startTimeNanos) {
     org.apache.solr.common.util.NamedList<Object> stat =
         new org.apache.solr.common.util.SimpleOrderedMap<>();
-    if (startTimeMillisec != null) {
-      stat.add("time", System.currentTimeMillis() - startTimeMillisec);
+    if (startTimeNanos != null) {
+      long elapsedMs =
+          java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNanos);
+      stat.add("time", elapsedMs);
     }
     stat.add("cache", cacheOutcome.name());
     perFilterStats.set(index, stat);
@@ -1353,7 +1355,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       }
 
       Query posQuery = QueryUtils.getAbs(q);
-      long startTime = System.currentTimeMillis();
+      long startTime = System.nanoTime();
       DocSetWithStats result = getPositiveDocSetWithStats(posQuery);
       addCacheStats(perFilterCacheStats, i, result.cacheOutcome, startTime);
 

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.Timer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -96,7 +95,6 @@ import org.apache.solr.common.params.CommonParams;
 import org.apache.solr.common.params.ModifiableSolrParams;
 import org.apache.solr.common.util.CollectionUtil;
 import org.apache.solr.common.util.EnvUtils;
-import org.apache.solr.common.util.NamedList;
 import org.apache.solr.common.util.ObjectReleaseTracker;
 import org.apache.solr.core.DirectoryFactory;
 import org.apache.solr.core.DirectoryFactory.DirContext;
@@ -1066,7 +1064,8 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     return getAndCacheDocSetWithStats(query, cache).docSet;
   }
 
-  private DocSetWithStats getAndCacheDocSetWithStats(Query query, SolrCache<Query, DocSet> cache) throws IOException {
+  private DocSetWithStats getAndCacheDocSetWithStats(Query query, SolrCache<Query, DocSet> cache)
+      throws IOException {
     assert !(query instanceof WrappedQuery) : "should have unwrapped";
     assert cache != null : "must check for caching before calling this method";
 
@@ -1093,10 +1092,13 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
         cacheOutcome.set(CacheOutcome.MISS);
       }
     } else {
-      answer = cache.computeIfAbsent(query, q -> {
-        cacheOutcome.set(CacheOutcome.MISS);
-        return getDocSetNC(q, null);
-      });
+      answer =
+          cache.computeIfAbsent(
+              query,
+              q -> {
+                cacheOutcome.set(CacheOutcome.MISS);
+                return getDocSetNC(q, null);
+              });
     }
 
     assert !(answer instanceof MutableBitDocSet) : "should not be mutable";
@@ -1263,18 +1265,19 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     public DelegatingCollector postFilter; // maybe null
   }
 
-
-  private enum CacheOutcome{
+  private enum CacheOutcome {
     HIT,
     MISS,
     BYPASSED
   }
 
-  private static void addCacheStats(java.util.List<org.apache.solr.common.util.NamedList<Object>> perFilterStats,
-                                int index,
-                                CacheOutcome cacheOutcome,
-                                Long startTimeMillisec) {
-    org.apache.solr.common.util.NamedList<Object> stat = new org.apache.solr.common.util.SimpleOrderedMap<>();
+  private static void addCacheStats(
+      java.util.List<org.apache.solr.common.util.NamedList<Object>> perFilterStats,
+      int index,
+      CacheOutcome cacheOutcome,
+      Long startTimeMillisec) {
+    org.apache.solr.common.util.NamedList<Object> stat =
+        new org.apache.solr.common.util.SimpleOrderedMap<>();
     if (startTimeMillisec != null) {
       stat.add("time", System.currentTimeMillis() - startTimeMillisec);
     }
@@ -1301,7 +1304,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     // Collect per-fq timing/cache outcome aligned with original order, if possible.
     // We'll attach this to the current ResponseBuilder (if any) at the end.
     final java.util.List<org.apache.solr.common.util.NamedList<Object>> perFilterCacheStats =
-            new java.util.ArrayList<>(queries.size());
+        new java.util.ArrayList<>(queries.size());
     for (int i = 0; i < queries.size(); i++) {
       perFilterCacheStats.add(null);
     }
@@ -1321,8 +1324,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       answer = setFilter;
     } // we are done with setFilter at this point
 
-
-    for (int i = 0 ; i < queries.size(); i++) {
+    for (int i = 0; i < queries.size(); i++) {
       Query q = queries.get(i);
       if (q instanceof ExtendedQuery) {
         ExtendedQuery eq = (ExtendedQuery) q;
@@ -1353,9 +1355,9 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       Query posQuery = QueryUtils.getAbs(q);
       long startTime = System.currentTimeMillis();
       DocSetWithStats result = getPositiveDocSetWithStats(posQuery);
-      addCacheStats(perFilterCacheStats, i , result.cacheOutcome, startTime);
+      addCacheStats(perFilterCacheStats, i, result.cacheOutcome, startTime);
 
-      DocSet docSet =  result.docSet;
+      DocSet docSet = result.docSet;
       // Negative query if absolute value different from original
       if (Objects.equals(q, posQuery)) {
         // keep track of the smallest positive set; use "answer" for this.
@@ -1379,14 +1381,15 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
 
     // Attach per-filter stats (aligned with original order) to current ResponseBuilder, if present.
     // Do it as soon as possible to ensure we don't miss it due to later short-cut returns.
-    org.apache.solr.request.SolrRequestInfo sri = org.apache.solr.request.SolrRequestInfo.getRequestInfo();
+    org.apache.solr.request.SolrRequestInfo sri =
+        org.apache.solr.request.SolrRequestInfo.getRequestInfo();
     if (sri != null) {
       org.apache.solr.handler.component.ResponseBuilder rb = sri.getResponseBuilder();
       if (rb != null) {
         // fill in any missing slots (continue statement w/o setting stats etc)
         for (int i = 0; i < perFilterCacheStats.size(); i++) {
           if (perFilterCacheStats.get(i) == null) {
-            addCacheStats(perFilterCacheStats, i , CacheOutcome.BYPASSED, null);
+            addCacheStats(perFilterCacheStats, i, CacheOutcome.BYPASSED, null);
           }
         }
         rb.setFilterStats(perFilterCacheStats);

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1387,7 +1387,9 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
         org.apache.solr.request.SolrRequestInfo.getRequestInfo();
     if (sri != null) {
       org.apache.solr.handler.component.ResponseBuilder rb = sri.getResponseBuilder();
-      if (rb != null) {
+      if (rb != null && rb.getFilterStats() == null) {
+        // in case if getProcessedFilter is called multiple times, keep only the ones from first
+        // invocation
         // fill in any missing slots (continue statement w/o setting stats etc)
         for (int i = 0; i < perFilterCacheStats.size(); i++) {
           if (perFilterCacheStats.get(i) == null) {

--- a/solr/core/src/test/org/apache/solr/TestGroupingSearch.java
+++ b/solr/core/src/test/org/apache/solr/TestGroupingSearch.java
@@ -826,7 +826,7 @@ public class TestGroupingSearch extends SolrTestCaseJ4 {
         // exact match
         "/responseHeader/status==0",
         // partial match by skipping some elements
-        "/responseHeader=={'_SKIP_':'QTime', 'status':0}",
+        "/responseHeader=={'_SKIP_':'filtersStats,QTime', 'status':0}",
         // partial match by only including some elements
         "/responseHeader=={'_MATCH_':'status', 'status':0}",
         "/grouped=={'"

--- a/solr/core/src/test/org/apache/solr/search/TestFilterStats.java
+++ b/solr/core/src/test/org/apache/solr/search/TestFilterStats.java
@@ -40,18 +40,24 @@ public class TestFilterStats extends SolrTestCaseJ4 {
     assertJQ(
         req("q", "{!cache=false}*:*", "fq", "foo_s:a", "fq", "val_i:[1 TO 3]"),
         "/responseHeader/filtersStats/[0]/cache=='MISS'",
-        "/responseHeader/filtersStats/[1]/cache=='MISS'");
+        "/responseHeader/filtersStats/[0]/docSetIdCount==2",
+        "/responseHeader/filtersStats/[1]/cache=='MISS'",
+        "/responseHeader/filtersStats/[1]/docSetIdCount==3");
 
     // Second identical request should HIT for both
     assertJQ(
         req("q", "{!cache=false}*:*", "fq", "foo_s:a", "fq", "val_i:[1 TO 3]"),
         "/responseHeader/filtersStats/[0]/cache=='HIT'",
-        "/responseHeader/filtersStats/[1]/cache=='HIT'");
+        "/responseHeader/filtersStats/[0]/docSetIdCount==2",
+        "/responseHeader/filtersStats/[1]/cache=='HIT'",
+        "/responseHeader/filtersStats/[1]/docSetIdCount==3");
 
     // 3rd request, only 2nd fq is identical, so 1st should MISS, 2nd should HIT
     assertJQ(
         req("q", "{!cache=false}*:*", "fq", "foo_s:a", "fq", "val_i:[1 TO 2]"),
         "/responseHeader/filtersStats/[0]/cache=='HIT'",
-        "/responseHeader/filtersStats/[1]/cache=='MISS'");
+        "/responseHeader/filtersStats/[0]/docSetIdCount==2",
+        "/responseHeader/filtersStats/[1]/cache=='MISS'",
+        "/responseHeader/filtersStats/[1]/docSetIdCount==2");
   }
 }

--- a/solr/core/src/test/org/apache/solr/search/TestFilterStats.java
+++ b/solr/core/src/test/org/apache/solr/search/TestFilterStats.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.solr.search;
+
+import org.apache.solr.SolrTestCaseJ4;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestFilterStats extends SolrTestCaseJ4 {
+
+  @BeforeClass
+  public static void beforeTests() throws Exception {
+    initCore("solrconfig.xml", "schema_latest.xml");
+  }
+
+  @Test
+  public void testFiltersStatsAlwaysOn() throws Exception {
+    clearIndex();
+    assertU(adoc("id", "1", "val_i", "1", "foo_s", "a"));
+    assertU(adoc("id", "2", "val_i", "2", "foo_s", "b"));
+    assertU(adoc("id", "3", "val_i", "3", "foo_s", "a"));
+    assertU(commit());
+
+    // Disable result cache on the main query using local params.
+    // First request should MISS for both fqs (empty cache)
+    assertJQ(
+        req("q", "{!cache=false}*:*", "fq", "foo_s:a", "fq", "val_i:[1 TO 3]"),
+        "/responseHeader/filtersStats/[0]/cache=='MISS'",
+        "/responseHeader/filtersStats/[1]/cache=='MISS'");
+
+    // Second identical request should HIT for both
+    assertJQ(
+        req("q", "{!cache=false}*:*", "fq", "foo_s:a", "fq", "val_i:[1 TO 3]"),
+        "/responseHeader/filtersStats/[0]/cache=='HIT'",
+        "/responseHeader/filtersStats/[1]/cache=='HIT'");
+
+    // 3rd request, only 2nd fq is identical, so 1st should MISS, 2nd should HIT
+    assertJQ(
+            req("q", "{!cache=false}*:*", "fq", "foo_s:a", "fq", "val_i:[1 TO 2]"),
+            "/responseHeader/filtersStats/[0]/cache=='HIT'",
+            "/responseHeader/filtersStats/[1]/cache=='MISS'");
+  }
+}

--- a/solr/core/src/test/org/apache/solr/search/TestFilterStats.java
+++ b/solr/core/src/test/org/apache/solr/search/TestFilterStats.java
@@ -50,8 +50,8 @@ public class TestFilterStats extends SolrTestCaseJ4 {
 
     // 3rd request, only 2nd fq is identical, so 1st should MISS, 2nd should HIT
     assertJQ(
-            req("q", "{!cache=false}*:*", "fq", "foo_s:a", "fq", "val_i:[1 TO 2]"),
-            "/responseHeader/filtersStats/[0]/cache=='HIT'",
-            "/responseHeader/filtersStats/[1]/cache=='MISS'");
+        req("q", "{!cache=false}*:*", "fq", "foo_s:a", "fq", "val_i:[1 TO 2]"),
+        "/responseHeader/filtersStats/[0]/cache=='HIT'",
+        "/responseHeader/filtersStats/[1]/cache=='MISS'");
   }
 }

--- a/solr/test-framework/src/java/org/apache/solr/BaseDistributedSearchTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/BaseDistributedSearchTestCase.java
@@ -1060,8 +1060,8 @@ public abstract class BaseDistributedSearchTestCase extends SolrTestCaseJ4 {
     handle.put("QTime", SKIPVAL);
     // rf will be different since the control collection doesn't usually have multiple replicas
     handle.put("rf", SKIPVAL);
-    // do not check filterStats
-    handle.put("filterStats", SKIPVAL);
+    // do not check filterStats, since it only shows in non-distributed queries
+    handle.put("filtersStats", SKIP);
     String cmp = compare(a.getResponse(), b.getResponse(), flags, handle);
     if (cmp != null) {
       log.error("Mismatched responses:\n{}\n{}", a, b);

--- a/solr/test-framework/src/java/org/apache/solr/BaseDistributedSearchTestCase.java
+++ b/solr/test-framework/src/java/org/apache/solr/BaseDistributedSearchTestCase.java
@@ -1060,6 +1060,8 @@ public abstract class BaseDistributedSearchTestCase extends SolrTestCaseJ4 {
     handle.put("QTime", SKIPVAL);
     // rf will be different since the control collection doesn't usually have multiple replicas
     handle.put("rf", SKIPVAL);
+    // do not check filterStats
+    handle.put("filterStats", SKIPVAL);
     String cmp = compare(a.getResponse(), b.getResponse(), flags, handle);
     if (cmp != null) {
       log.error("Mismatched responses:\n{}\n{}", a, b);


### PR DESCRIPTION
## Description
Track filter processing time and hit/miss/bypass and report the results in:
1. Response header as `filtersStats`
2. Log as `filtersStats`


Each stat entry map back to the index of the filters. The result could look like:

... `filtersStats=[{time=3473, cache=MISS}, {time=1, cache=HIT}]` ...

## Solution
Modified the filter cache execution flow with extra methods that return cache outcome. 

Currently the stats would map to the input filter by index (to avoid echoing the query again in response/log):
1. This should handle "post filter" properly, since the instrumentation point is inserted before the post filter "re-ordering"
2. In some cases, we could see an extra filter prepended by solr internal logic, see remarks point 4.

These are not exactly the most elegant changes, but probably the most minimal changes to achieve our goals 😓 w/o affecting other callers. 

We could look at improving/removing them later on!

## Remarks
1. This `filtersStats` would not show in response/log in below scenarios:
   1. On coordinator node, since there's no logic to aggregate the filter stats across nodes (it could get messy). So we will only see this on data node
   3. If the query does not reach the filter layer, for example if result cache was a hit, then we will not see `filtersStats`
2. It is a bit tricky to match with the actual filter since in data node we currently don't print the full json. So we will have to get the rid and look it up on QA node log
4. In some cases Solr might add filter that's not in the original query. For example this query: 
```
{
  "query": "*:*",
  "filter": [
    "(Kind:event AND EventStart:[NOW\\/DAY TO NOW\\/DAY\\+1DAY})"
  ],
  "limit": 0,
  "facet": {
    "_f0": "unique(IndvId,0)"
  },
  "params": {
    "NOW": "1770048318912",
    "TZ": "America/New_York",
    "echoParams": "none",
    "wat": "SingleNumberComputation"
  }
} 
```
^^ Event with only a single filter, Solr eventually prepended `*:*` (`MatchAllDocsQuery`) before hitting the instrumentation point. (seems to be enforced by `facet`). Hence the response looks like `filtersStats=[{time=0, cache=BYPASSED}, {time=0, cache=HIT}]`

Based on test on playpen, these "BYPASSED" (likely by `MatchAllDocsQuery`) are rare occurrences tho. Only 870 out of ~180k occurrences

## Test
1. Deploying to playpen, inspected logs:
With `HIT` and `MISS`
```
o.a.s.c.S.Request webapp=/solr path=/select params={distrib=false&_facet_={}&echoParams=explicit&TZ=UTC&fl=Id&fl=score&shards.purpose=1064964&start=0&fsv=true&wat=BACKGROUND_ComputeMetric:DimensionComputation&collection=o-17C2-na1&rid=4ee1fb1de49ef859a0c2628c4fcacb54-08aba5a7a05db083&rows=0&version=2&q=*:*&shards.tolerant=true&omitHeader=false&NOW=1770055223887&isShard=true&timeAllowed=119998&shards.preference=replica.type:NRT,replica.type:PULL&wt=javabin} hits=0 filtersStats=[{time=0, cache=HIT}, {time=0, cache=MISS}] status=0 QTime=0
```

With non zero filter time
```
o.a.s.c.S.Request webapp=/solr path=/select params={distrib=false&_facet_={}&echoParams=explicit&TZ=UTC&fl=Id&fl=score&shards.purpose=1064964&start=0&fsv=true&wat=BACKGROUND_ComputeMetric:DimensionComputation&collection=BF2&rid=56e006c83eb006eb41068297b36e4a78-497da3abdb6bcbf2&rows=0&version=2&q=*:*&shards.tolerant=true&omitHeader=false&NOW=1770055212489&isShard=true&timeAllowed=119998&shards.preference=replica.type:NRT,replica.type:PULL&wt=javabin} hits=74749 filtersStats=[{time=60, cache=MISS}] status=0 QTime=62
```

2. unit test case





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core filter-cache execution paths and adds always-on stats collection, which could affect query latency and cache behavior if the instrumentation changes timing or concurrency characteristics.
> 
> **Overview**
> Adds always-on per-`fq` filter instrumentation to capture **per-filter elapsed time**, **filter cache outcome** (`HIT`/`MISS`/`BYPASSED`), and `docSetIdCount`, preserving the original filter order.
> 
> Plumbs these stats from `SolrIndexSearcher.getProcessedFilter()` into `ResponseBuilder`, and has `SearchHandler` emit them as `filtersStats` in the response header and `rsp.getToLog()` for non-distributed requests; updates/extends tests to account for the new header field and ignores it in distributed response comparisons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 291d585183aa7db95a29e9ab3d73983cb9581e76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->