### PR TITLE
SAI-6041: debug/investigate missing `filterStats` 

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/component/ResponseBuilder.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/ResponseBuilder.java
@@ -102,6 +102,12 @@ public class ResponseBuilder {
   // and docSetIdCount (docSet size)
   private final List<NamedList<Object>> filterStats = new ArrayList<>();
 
+  private FilterStatsTriggerType filterStatsTriggerType;
+
+  public enum FilterStatsTriggerType {
+    FACET, SESSION_STITCH
+  }
+
   SolrRequestInfo requestInfo;
 
   public ResponseBuilder(
@@ -328,6 +334,14 @@ public class ResponseBuilder {
 
   public void addFilterStats(NamedList<Object> entry) {
     this.filterStats.add(entry);
+  }
+
+  public void setFilterStatsTriggerType(FilterStatsTriggerType filterStatsTriggerType) {
+    this.filterStatsTriggerType = filterStatsTriggerType;
+  }
+
+  public FilterStatsTriggerType getFilterStatsTriggerType() {
+    return filterStatsTriggerType;
   }
 
   public int getFieldFlags() {

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -554,6 +554,10 @@ public class SearchHandler extends RequestHandlerBase
         if (!rb.getFilterStats()
             .isEmpty()) { // always attempt to add filter cache stats if possible
           NamedList<Object> headers = rb.rsp.getResponseHeader();
+          for (NamedList<Object> entry : rb.getFilterStats()) {
+            log.info("Adding filter stats to response and logs with entry {}", entry);
+          }
+
           if (headers != null) {
             headers.add("filtersStats", rb.getFilterStats());
           }

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -554,10 +554,6 @@ public class SearchHandler extends RequestHandlerBase
         if (!rb.getFilterStats()
             .isEmpty()) { // always attempt to add filter cache stats if possible
           NamedList<Object> headers = rb.rsp.getResponseHeader();
-          for (NamedList<Object> entry : rb.getFilterStats()) {
-            log.info("Adding filter stats to response and logs with entry {}", entry);
-          }
-
           if (headers != null) {
             headers.add("filtersStats", rb.getFilterStats());
           }

--- a/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/component/SearchHandler.java
@@ -56,6 +56,7 @@ import org.apache.solr.common.params.ShardParams;
 import org.apache.solr.common.params.SolrParams;
 import org.apache.solr.common.util.EnvUtils;
 import org.apache.solr.common.util.NamedList;
+import org.apache.solr.common.util.Utils;
 import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.solr.common.util.StrUtils;
 import org.apache.solr.core.CloseHook;
@@ -557,7 +558,7 @@ public class SearchHandler extends RequestHandlerBase
           if (headers != null) {
             headers.add("filtersStats", rb.getFilterStats());
           }
-          rsp.getToLog().add("filtersStats", rb.getFilterStats());
+          rsp.getToLog().add("filtersStats", Utils.toJSONString(rb.getFilterStats(), -1));
         }
       }
     } else {

--- a/solr/core/src/java/org/apache/solr/query/SolrRangeQuery.java
+++ b/solr/core/src/java/org/apache/solr/query/SolrRangeQuery.java
@@ -444,7 +444,8 @@ public final class SolrRangeQuery extends ExtendedQueryBase implements DocSetPro
           long start = System.nanoTime();
           answer = solrSearcher.getFilterCache().get(SolrRangeQuery.this);
           log.info("SolrRangeQuery reading filter cache");
-          SolrIndexSearcher.addCacheStats(SolrRangeQuery.this, answer != null, answer != null ? answer.size() : -1, start);
+          SolrIndexSearcher.addCacheStats(
+              SolrRangeQuery.this, answer != null, answer != null ? answer.size() : -1, start);
         }
       } else {
         doCheck = false;

--- a/solr/core/src/java/org/apache/solr/query/SolrRangeQuery.java
+++ b/solr/core/src/java/org/apache/solr/query/SolrRangeQuery.java
@@ -17,6 +17,7 @@
 package org.apache.solr.query;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -59,11 +60,14 @@ import org.apache.solr.search.DocSetUtil;
 import org.apache.solr.search.ExtendedQueryBase;
 import org.apache.solr.search.SolrIndexSearcher;
 import org.apache.solr.util.TestInjection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @lucene.experimental
  */
 public final class SolrRangeQuery extends ExtendedQueryBase implements DocSetProducer {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private final String field;
   private final BytesRef lower;
   private final BytesRef upper;
@@ -437,7 +441,10 @@ public final class SolrRangeQuery extends ExtendedQueryBase implements DocSetPro
         if (solrSearcher.getFilterCache() == null) {
           doCheck = false;
         } else {
+          long start = System.nanoTime();
           answer = solrSearcher.getFilterCache().get(SolrRangeQuery.this);
+          log.info("SolrRangeQuery reading filter cache");
+          SolrIndexSearcher.addCacheStats(SolrRangeQuery.this, answer != null, answer != null ? answer.size() : -1, start);
         }
       } else {
         doCheck = false;

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1421,14 +1421,17 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       TermQuery key = new TermQuery(new Term(deState.fieldName, deState.termsEnum.term()));
       AtomicBoolean cacheHit = new AtomicBoolean(true);
       long startTime = System.nanoTime();
-      DocSet result = filterCache.computeIfAbsent(
-          key,
-          (IOFunction<? super Query, ? extends DocSet>) k -> {
-            cacheHit.set(false);
-            return getResult(deState, largestPossible);
-          });
+      DocSet result =
+          filterCache.computeIfAbsent(
+              key,
+              (IOFunction<? super Query, ? extends DocSet>)
+                  k -> {
+                    cacheHit.set(false);
+                    return getResult(deState, largestPossible);
+                  });
       log.info("getDocSet with DocsNumState");
-      addCacheStats(key, cacheHit.get(), result.size(), startTime);
+      addCacheStats(key, cacheHit.get(), result != null ? result.size() : -1, startTime);
+      return result;
     }
 
     return getResult(deState, largestPossible);
@@ -1544,9 +1547,12 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
 
       reqInfo.getResponseBuilder().addFilterStats(stat);
 
-      log.info("Added cache stats for query: {}, cacheHit: {}, docSetIdCount: {}, elapsedMs: {}",
-              key, cacheHit, docSetIdCount,
-              java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNanos));
+      log.info(
+          "Added cache stats for query: {}, cacheHit: {}, docSetIdCount: {}, elapsedMs: {}",
+          key,
+          cacheHit,
+          docSetIdCount,
+          java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNanos));
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1418,7 +1418,6 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     boolean useCache = filterCache != null && largestPossible >= deState.minSetSizeCached;
 
     if (useCache) {
-      log.info("getDocSet with DocsNumState", new Throwable("just to print track"));
       TermQuery key = new TermQuery(new Term(deState.fieldName, deState.termsEnum.term()));
       AtomicBoolean cacheHit = new AtomicBoolean(true);
       long startTime = System.nanoTime();
@@ -1428,6 +1427,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
             cacheHit.set(false);
             return getResult(deState, largestPossible);
           });
+      log.info("getDocSet with DocsNumState");
       addCacheStats(key, cacheHit.get(), result.size(), startTime);
     }
 

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1521,7 +1521,7 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     return getDocSet(query, null);
   }
 
-  private static void addCacheStats(
+  public static void addCacheStats(
       Query key, boolean cacheHit, int docSetIdCount, long startTimeNanos) {
     SolrRequestInfo reqInfo = SolrRequestInfo.getRequestInfo();
     if (reqInfo != null && reqInfo.getResponseBuilder() != null) {

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1530,8 +1530,8 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
           new org.apache.solr.common.util.SimpleOrderedMap<>();
 
       String keyString = key.toString();
-      if (keyString.length() > 50) {
-        keyString = keyString.substring(0, 50) + "...";
+      if (keyString.length() > 500) {
+        keyString = keyString.substring(0, 500) + "...";
       }
       stat.add("key", keyString);
 

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1524,6 +1524,10 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
   public static void addCacheStats(
       Query key, boolean cacheHit, int docSetIdCount, long startTimeNanos) {
     SolrRequestInfo reqInfo = SolrRequestInfo.getRequestInfo();
+
+    log.info("Attempt to add cache stats for query: {}, cacheHit: {}, docSetIdCount: {}, elapsedMs: {}",
+        key, cacheHit, docSetIdCount,
+        java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNanos));
     if (reqInfo != null && reqInfo.getResponseBuilder() != null) {
       org.apache.solr.common.util.NamedList<Object> stat =
           new org.apache.solr.common.util.SimpleOrderedMap<>();
@@ -1542,6 +1546,10 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       stat.add("docSetIdCount", docSetIdCount);
 
       reqInfo.getResponseBuilder().addFilterStats(stat);
+
+      log.info("Added cache stats for query: {}, cacheHit: {}, docSetIdCount: {}, elapsedMs: {}",
+              key, cacheHit, docSetIdCount,
+              java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNanos));
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1418,10 +1418,17 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     boolean useCache = filterCache != null && largestPossible >= deState.minSetSizeCached;
 
     if (useCache) {
+      log.info("getDocSet with DocsNumState", new Throwable("just to print track"));
       TermQuery key = new TermQuery(new Term(deState.fieldName, deState.termsEnum.term()));
-      return filterCache.computeIfAbsent(
+      AtomicBoolean cacheHit = new AtomicBoolean(true);
+      long startTime = System.nanoTime();
+      DocSet result = filterCache.computeIfAbsent(
           key,
-          (IOFunction<? super Query, ? extends DocSet>) k -> getResult(deState, largestPossible));
+          (IOFunction<? super Query, ? extends DocSet>) k -> {
+            cacheHit.set(false);
+            return getResult(deState, largestPossible);
+          });
+      addCacheStats(key, cacheHit.get(), result.size(), startTime);
     }
 
     return getResult(deState, largestPossible);

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1528,14 +1528,15 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       Query key, boolean cacheHit, int docSetIdCount, long startTimeNanos) {
     SolrRequestInfo reqInfo = SolrRequestInfo.getRequestInfo();
 
+    String keyString = key != null ? key.toString() : "null";
+    if (keyString.length() > 500) {
+      keyString = keyString.substring(0, 500) + "...";
+    }
+
     if (reqInfo != null && reqInfo.getResponseBuilder() != null) {
       org.apache.solr.common.util.NamedList<Object> stat =
           new org.apache.solr.common.util.SimpleOrderedMap<>();
 
-      String keyString = key.toString();
-      if (keyString.length() > 500) {
-        keyString = keyString.substring(0, 500) + "...";
-      }
       stat.add("key", keyString);
 
       long elapsedMs =
@@ -1546,13 +1547,10 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       stat.add("docSetIdCount", docSetIdCount);
 
       reqInfo.getResponseBuilder().addFilterStats(stat);
-
-      log.info(
-          "Added cache stats for query: {}, cacheHit: {}, docSetIdCount: {}, elapsedMs: {}",
-          key,
-          cacheHit,
-          docSetIdCount,
-          java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNanos));
+    } else {
+      log.warn(
+          "Unexpected filter cache that has no request info or response builder: key {}",
+          keyString);
     }
   }
 

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1546,6 +1546,10 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       stat.add("cacheHit", cacheHit);
       stat.add("docSetIdCount", docSetIdCount);
 
+      if (reqInfo.getResponseBuilder().getFilterStatsTriggerType() != null) {
+        stat.add("triggerType", reqInfo.getResponseBuilder().getFilterStatsTriggerType());
+      }
+
       reqInfo.getResponseBuilder().addFilterStats(stat);
     } else {
       log.warn(

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -1525,9 +1525,6 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       Query key, boolean cacheHit, int docSetIdCount, long startTimeNanos) {
     SolrRequestInfo reqInfo = SolrRequestInfo.getRequestInfo();
 
-    log.info("Attempt to add cache stats for query: {}, cacheHit: {}, docSetIdCount: {}, elapsedMs: {}",
-        key, cacheHit, docSetIdCount,
-        java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNanos));
     if (reqInfo != null && reqInfo.getResponseBuilder() != null) {
       org.apache.solr.common.util.NamedList<Object> stat =
           new org.apache.solr.common.util.SimpleOrderedMap<>();

--- a/solr/core/src/java/org/apache/solr/search/facet/FacetRequest.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetRequest.java
@@ -28,7 +28,9 @@ import java.util.Set;
 import org.apache.lucene.search.Query;
 import org.apache.solr.common.SolrException;
 import org.apache.solr.common.params.SolrParams;
+import org.apache.solr.handler.component.ResponseBuilder;
 import org.apache.solr.request.SolrQueryRequest;
+import org.apache.solr.request.SolrRequestInfo;
 import org.apache.solr.search.DocSet;
 import org.apache.solr.search.JoinQParserPlugin;
 import org.apache.solr.search.QueryContext;
@@ -462,20 +464,30 @@ public abstract class FacetRequest {
     FacetProcessor<?> facetProcessor = createFacetProcessor(fcontext);
 
     FacetDebugInfo debugInfo = fcontext.getDebugInfo();
-    if (debugInfo == null) {
-      facetProcessor.process();
-    } else {
-      if (fcontext.filter != null) {
-        debugInfo.setFilter(fcontext.filter.toString());
+    ResponseBuilder rb = SolrRequestInfo.getRequestInfo() != null ? SolrRequestInfo.getRequestInfo().getResponseBuilder() : null;
+    try {
+      if (rb != null) {
+        rb.setFilterStatsTriggerType(ResponseBuilder.FilterStatsTriggerType.FACET);
       }
-      debugInfo.setReqDescription(getFacetDescription());
-      debugInfo.setProcessor(facetProcessor.getClass().getSimpleName());
-      debugInfo.putInfoItem("domainSize", (long) fcontext.base.size());
-      RTimer timer = new RTimer();
-      try {
+      if (debugInfo == null) {
         facetProcessor.process();
-      } finally {
-        debugInfo.setElapse((long) timer.getTime());
+      } else {
+        if (fcontext.filter != null) {
+          debugInfo.setFilter(fcontext.filter.toString());
+        }
+        debugInfo.setReqDescription(getFacetDescription());
+        debugInfo.setProcessor(facetProcessor.getClass().getSimpleName());
+        debugInfo.putInfoItem("domainSize", (long) fcontext.base.size());
+        RTimer timer = new RTimer();
+        try {
+          facetProcessor.process();
+        } finally {
+          debugInfo.setElapse((long) timer.getTime());
+        }
+      }
+    } finally {
+      if (rb != null) {
+        rb.setFilterStatsTriggerType(null);
       }
     }
 


### PR DESCRIPTION
## Description
Comparing BQ logs (filtersStats added in #314) shows some discrepancies with some filter access unaccounted for with the change in #314 

One known path is the `/stitch` operations. However even with that included, there are still ~12% cache lookup unaccounted for. 

Adding a bit more debug info for several possible paths that we could have missed instrumentation.

We would need to at least deploy this to staging (which ...


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core search/cache code paths and adds `INFO`-level logging plus extra per-lookup bookkeeping, which may impact query latency and log volume if exercised heavily.
> 
> **Overview**
> Adds a `FilterStatsTriggerType` to `ResponseBuilder` and propagates it into `SolrIndexSearcher.addCacheStats()` entries so cache activity can be attributed (e.g. `FACET`, `SESSION_STITCH`).
> 
> Expands filter-cache instrumentation to additional lookup paths (notably `SolrRangeQuery` and `SolrIndexSearcher.getDocSet(DocsEnumState)`), including timing/size reporting and a warning when cache access occurs without request context.
> 
> Updates `FacetRequest` to set/reset the trigger type around facet processing, and changes `SearchHandler` request logging to emit `filtersStats` as a JSON string instead of a raw `NamedList`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea8d7e8dc1a8959f0e196418d9fe0865ab207e11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->