### PR TITLE
Hitesh/cache entries metrics

### DIFF
--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -958,6 +958,30 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
         "Bytes used from local fcache-docs-hot cache store (vs backing shared cache store)",
         "ramBytesUsed",
         PrometheusMetricType.GAUGE),
+    DOCUMENT_CACHE_LOCAL_SIZE(
+        "CACHE.searcher.documentCache",
+        "document_cache_store_local_size",
+        "Number of entries in local document cache store (vs backing shared cache store)",
+        "size",
+        PrometheusMetricType.GAUGE),
+    FILTER_CACHE_LOCAL_SIZE(
+        "CACHE.searcher.filterCache",
+        "filter_cache_store_local_size",
+        "Number of entries in local filter cache store (vs backing shared cache store)",
+        "size",
+        PrometheusMetricType.GAUGE),
+    QUERY_RESULT_CACHE_LOCAL_SIZE(
+        "CACHE.searcher.queryResultCache",
+        "query_result_cache_store_local_size",
+        "Number of entries in local query result cache store (vs backing shared cache store)",
+        "size",
+        PrometheusMetricType.GAUGE),
+    FCACHE_DOCS_HOT_LOCAL_SIZE(
+        "CACHE.searcher.fcache-docs-hot",
+        "fcache_docs_hot_local_size",
+        "Number of entries in local fcache-docs-hot cache store (vs backing shared cache store)",
+        "size",
+        PrometheusMetricType.GAUGE),
     HTTP_CLIENT_OUTSTANDING_REQUESTS(
         "QUERY.httpShardHandler.httpClientOutstandingRequests",
         "http_client_outstanding_requests",
@@ -1201,7 +1225,11 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
             CoreMetric.QUERY_RESULT_CACHE_LOCAL_BYTES_USED,
             CoreMetric.DOCUMENT_CACHE_LOCAL_BYTES_USED,
             CoreMetric.FILTER_CACHE_LOCAL_BYTES_USED,
-            CoreMetric.FCACHE_DOCS_HOT_LOCAL_BYTES_USED);
+            CoreMetric.FCACHE_DOCS_HOT_LOCAL_BYTES_USED,
+            CoreMetric.DOCUMENT_CACHE_LOCAL_SIZE,
+            CoreMetric.FILTER_CACHE_LOCAL_SIZE,
+            CoreMetric.QUERY_RESULT_CACHE_LOCAL_SIZE,
+            CoreMetric.FCACHE_DOCS_HOT_LOCAL_SIZE);
 
     @Override
     protected String buildQueryString(ResultContext resultContext) {

--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -88,6 +88,7 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
 
   private final Map<String, PrometheusMetricType> cacheMetricTypes =
       Map.of(
+          "size", PrometheusMetricType.GAUGE,
           "ramBytesUsed", PrometheusMetricType.GAUGE,
           "lookups", PrometheusMetricType.COUNTER,
           "hits", PrometheusMetricType.COUNTER,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk, additive changes to metrics export only; primary impact is slightly larger metrics queries/output which could affect monitoring expectations but not core Solr behavior.
> 
> **Overview**
> Adds new Prometheus metrics that expose the **entry count (`size`)** of local cache stores (`documentCache`, `filterCache`, `queryResultCache`, and `fcache-docs-hot`) alongside the existing bytes/lookup/hit/eviction metrics.
> 
> Also updates shared-cache metric type mapping so `size` is exported as a GAUGE when present, and includes the new `*_local_size` metrics in the collection-aggregated cache metrics list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 125b5c3eba952e5391c39b67488bb96e8f9399a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->