### PR TITLE
SAI-6090: Avoid metrics gap while replacing `SolrIndexerSearcher`

### DIFF
--- a/solr/core/src/java/org/apache/solr/core/SolrCore.java
+++ b/solr/core/src/java/org/apache/solr/core/SolrCore.java
@@ -2870,7 +2870,12 @@ public class SolrCore implements SolrInfoBean, Closeable {
           return; // still execute the finally block to notify anyone waiting.
         }
 
+        // When replacing a searcher, skip the old searcher's metric cleanup.
+        // The new searcher will replace the metrics via force=true in cache registration,
+        // eliminating the gap in metric availability during the transition.
         if (_searcher != null) {
+          SolrIndexSearcher oldSearcher = _searcher.get();
+          oldSearcher.setSkipMetricsCleanupOnClose();
           _searcher.decref(); // dec refcount for this._searcher
           _searcher = null;
         }

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -190,6 +190,13 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
   private Set<String> metricNames = ConcurrentHashMap.newKeySet();
   private SolrMetricsContext solrMetricsContext;
 
+  /**
+   * When true, this searcher will skip metrics cleanup during close(). This is set when the
+   * searcher is being replaced by a new one that will immediately re-register the same metrics
+   * with force=true, preventing a gap in metric availability during the transition.
+   */
+  private volatile boolean skipMetricsCleanupOnClose = false;
+
   private static DirectoryReader getReader(
       SolrCore core, SolrIndexConfig config, DirectoryFactory directoryFactory, String path)
       throws IOException {
@@ -576,6 +583,15 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
     return reader;
   }
 
+  /**
+   * Tells this searcher to skip metrics cleanup when it closes. This should be called when the
+   * searcher is being replaced by a new one that will immediately re-register the same metrics,
+   * preventing a gap in metric availability during the transition.
+   */
+  public void setSkipMetricsCleanupOnClose() {
+    this.skipMetricsCleanupOnClose = true;
+  }
+
   /** Register sub-objects such as caches and our own metrics */
   public void register() {
     final Map<String, SolrInfoBean> infoRegistry = core.getInfoRegistry();
@@ -645,10 +661,15 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
       directoryFactory.release(getIndexReader().directory());
     }
 
-    try {
-      SolrInfoBean.super.close();
-    } catch (Exception e) {
-      log.warn("Exception closing", e);
+    // Skip metrics cleanup if this searcher is being replaced by a new one.
+    // The new searcher will immediately re-register the same metrics with force=true,
+    // so unregistering here would create a gap in metric availability.
+    if (!skipMetricsCleanupOnClose) {
+      try {
+        SolrInfoBean.super.close();
+      } catch (Exception e) {
+        log.warn("Exception closing", e);
+      }
     }
 
     // do this at the end so it only gets done if there are no exceptions

--- a/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
+++ b/solr/core/src/java/org/apache/solr/search/SolrIndexSearcher.java
@@ -192,8 +192,8 @@ public class SolrIndexSearcher extends IndexSearcher implements Closeable, SolrI
 
   /**
    * When true, this searcher will skip metrics cleanup during close(). This is set when the
-   * searcher is being replaced by a new one that will immediately re-register the same metrics
-   * with force=true, preventing a gap in metric availability during the transition.
+   * searcher is being replaced by a new one that will immediately re-register the same metrics with
+   * force=true, preventing a gap in metric availability during the transition.
    */
   private volatile boolean skipMetricsCleanupOnClose = false;
 


### PR DESCRIPTION
## Description
There appears to be race condition that cause partial cache metrics of a collection on a node (for example missing 1/8 of the count) for cumulative counters (evictions for example).

This happens for both shared and dedicated filter cache based on previous metrics

The exact cause is still not found. See [this](https://github.com/cowpaths/fullstory-solr/pull/318#issuecomment-3994784490)


## Solution
The currently proposed solution wouldn't fix the issue. As the originally suspected cause was based on incorrect assumptions of metric gap between to old searcher unregister and new searcher register 😞 
