### PR TITLE
SAI-6231: Display segment EventStart range in admin UI

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/admin/SegmentsInfoRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/SegmentsInfoRequestHandler.java
@@ -28,7 +28,6 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.apache.lucene.codecs.PointsFormat;
 import org.apache.lucene.codecs.PointsReader;
 import org.apache.lucene.document.LongPoint;
@@ -195,7 +194,7 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
           segmentInfo.add("temporalMaxDate", new Date(segmentDateRange.maxDate));
         }
       } catch (IOException e) {
-        log.warn("Exception segment range info on segment {}", segmentCommitInfo.info.name,  e);
+        log.warn("Exception segment range info on segment {}", segmentCommitInfo.info.name, e);
       }
 
       segmentInfos.add((String) segmentInfo.get(NAME), segmentInfo);
@@ -500,19 +499,20 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
    * @throws IOException if there's an error reading the segment
    */
   private static SegmentDateRange extractDateRangeFromSegment(SegmentCommitInfo segmentInfo)
-          throws IOException {
+      throws IOException {
     SegmentInfo si = segmentInfo.info;
 
     // Track compound directory separately to ensure we never close si.dir
     Directory compoundDir = null;
     try {
       Directory readerDir =
-              si.getUseCompoundFile()
-                      ? (compoundDir = si.getCodec().compoundFormat().getCompoundReader(si.dir, si, IOContext.DEFAULT))
-                      : si.dir;
+          si.getUseCompoundFile()
+              ? (compoundDir =
+                  si.getCodec().compoundFormat().getCompoundReader(si.dir, si, IOContext.DEFAULT))
+              : si.dir;
 
       FieldInfos fieldInfos =
-              si.getCodec().fieldInfosFormat().read(readerDir, si, "", IOContext.READONCE);
+          si.getCodec().fieldInfosFormat().read(readerDir, si, "", IOContext.READONCE);
 
       String temporalField = "EventStart";
       // Validate that the temporal field exists and is a point field
@@ -537,8 +537,8 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
       // Read point values using the codec
       PointsFormat pointsFormat = si.getCodec().pointsFormat();
       try (PointsReader pointsReader =
-                   pointsFormat.fieldsReader(
-                           new SegmentReadState(readerDir, si, fieldInfos, IOContext.READONCE))) {
+          pointsFormat.fieldsReader(
+              new SegmentReadState(readerDir, si, fieldInfos, IOContext.READONCE))) {
 
         PointValues pointValues = pointsReader.getValues(temporalField);
         if (pointValues == null) {

--- a/solr/core/src/java/org/apache/solr/handler/admin/SegmentsInfoRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/SegmentsInfoRequestHandler.java
@@ -518,16 +518,15 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
       }
 
       if (fieldInfo.getPointDimensionCount() == 0) {
-        log.warn(
-                "Segment "
-                        + si.name
-                        + ": temporal field '"
-                        + temporalField
-                        + "' is not indexed as a point field (found: "
-                        + fieldInfo
-                        + "). "
-                        + "Skipping this segment for date-tiered merging. This may occur with legacy segments "
-                        + "or after schema changes.");
+        if (log.isWarnEnabled()) {
+          log.warn(
+              "Segment {}: temporal field '{}' is not indexed as a point field (found: {}). "
+                  + "Skipping this segment for date-tiered merging. This may occur with legacy segments "
+                  + "or after schema changes.",
+              si.name,
+              temporalField,
+              fieldInfo);
+        }
         return null;
       }
 

--- a/solr/core/src/java/org/apache/solr/handler/admin/SegmentsInfoRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/SegmentsInfoRequestHandler.java
@@ -28,6 +28,10 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import org.apache.lucene.codecs.PointsFormat;
+import org.apache.lucene.codecs.PointsReader;
+import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
@@ -41,11 +45,15 @@ import org.apache.lucene.index.MergePolicy;
 import org.apache.lucene.index.MergePolicy.MergeSpecification;
 import org.apache.lucene.index.MergePolicy.OneMerge;
 import org.apache.lucene.index.MergeTrigger;
+import org.apache.lucene.index.PointValues;
 import org.apache.lucene.index.SegmentCommitInfo;
+import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentReader;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.apache.lucene.util.Version;
 import org.apache.solr.common.luke.FieldFlag;
@@ -179,6 +187,13 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
       if (mergeCandidates.contains(segmentCommitInfo.info.name)) {
         segmentInfo.add("mergeCandidate", true);
       }
+
+      SegmentDateRange segmentDateRange = extractDateRangeFromSegment(segmentCommitInfo);
+      if (segmentDateRange != null) {
+        segmentInfo.add("temporalMinDate", new Date(segmentDateRange.minDate));
+        segmentInfo.add("temporalMaxDate", new Date(segmentDateRange.maxDate));
+      }
+
       segmentInfos.add((String) segmentInfo.get(NAME), segmentInfo);
     }
 
@@ -471,5 +486,116 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
   @Override
   public Name getPermissionName(AuthorizationContext request) {
     return Name.METRICS_READ_PERM;
+  }
+
+  /**
+   * Extract date range (min/max timestamps) from a single segment by reading point values.
+   *
+   * @param segmentInfo the segment to read from
+   * @return the date range, or null if the temporal field is not present or has no values
+   * @throws IOException if there's an error reading the segment
+   */
+  private static SegmentDateRange extractDateRangeFromSegment(SegmentCommitInfo segmentInfo)
+          throws IOException {
+    SegmentInfo si = segmentInfo.info;
+
+    // Track compound directory separately to ensure we never close si.dir
+    Directory compoundDir = null;
+    try {
+      Directory readerDir =
+              si.getUseCompoundFile()
+                      ? (compoundDir = si.getCodec().compoundFormat().getCompoundReader(si.dir, si, IOContext.DEFAULT))
+                      : si.dir;
+
+      FieldInfos fieldInfos =
+              si.getCodec().fieldInfosFormat().read(readerDir, si, "", IOContext.READONCE);
+
+      String temporalField = "EventStart";
+      // Validate that the temporal field exists and is a point field
+      FieldInfo fieldInfo = fieldInfos.fieldInfo(temporalField);
+      if (fieldInfo == null) {
+        return null;
+      }
+
+      if (fieldInfo.getPointDimensionCount() == 0) {
+        log.warn(
+                "Segment "
+                        + si.name
+                        + ": temporal field '"
+                        + temporalField
+                        + "' is not indexed as a point field (found: "
+                        + fieldInfo
+                        + "). "
+                        + "Skipping this segment for date-tiered merging. This may occur with legacy segments "
+                        + "or after schema changes.");
+        return null;
+      }
+
+      // Read point values using the codec
+      PointsFormat pointsFormat = si.getCodec().pointsFormat();
+      try (PointsReader pointsReader =
+                   pointsFormat.fieldsReader(
+                           new SegmentReadState(readerDir, si, fieldInfos, IOContext.READONCE))) {
+
+        PointValues pointValues = pointsReader.getValues(temporalField);
+        if (pointValues == null) {
+          return null;
+        }
+
+        byte[] minPackedValue = pointValues.getMinPackedValue();
+        byte[] maxPackedValue = pointValues.getMaxPackedValue();
+
+        if (minPackedValue == null || maxPackedValue == null) {
+          return null;
+        }
+
+        // Decode the packed values as longs, we have to make an assumption here
+        // since we don't have the schema :/
+        long minDate = LongPoint.decodeDimension(minPackedValue, 0);
+        long maxDate = LongPoint.decodeDimension(maxPackedValue, 0);
+
+        // Convert to milliseconds based on detected unit
+        long divisor = getTemporalFieldDivisor(maxDate);
+        long minDateMillis, maxDateMillis;
+        if (divisor < 0) {
+          long multiplier = -divisor;
+          minDateMillis = minDate * multiplier;
+          maxDateMillis = maxDate * multiplier;
+        } else {
+          minDateMillis = minDate / divisor;
+          maxDateMillis = maxDate / divisor;
+        }
+
+        return new SegmentDateRange(minDateMillis, maxDateMillis);
+      }
+    } finally {
+      // Close compound directory if we opened it (never close si.dir)
+      if (compoundDir != null) {
+        compoundDir.close();
+      }
+    }
+  }
+
+  private static long getTemporalFieldDivisor(long maxValue) {
+    if (maxValue > 100_000_000_000_000L) {
+      // Values > 10^14 are microseconds
+      return 1_000;
+    } else if (maxValue > 100_000_000_000L) {
+      // Values > 10^11 are milliseconds
+      return 1;
+    } else {
+      // Values <= 10^11 are seconds
+      return -1000;
+    }
+  }
+
+  public static class SegmentDateRange {
+    public final long minDate;
+    public final long maxDate;
+
+    public SegmentDateRange(long minDate, long maxDate) {
+      this.minDate = minDate;
+      this.maxDate = maxDate;
+    }
   }
 }

--- a/solr/core/src/java/org/apache/solr/handler/admin/SegmentsInfoRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/SegmentsInfoRequestHandler.java
@@ -188,10 +188,14 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
         segmentInfo.add("mergeCandidate", true);
       }
 
-      SegmentDateRange segmentDateRange = extractDateRangeFromSegment(segmentCommitInfo);
-      if (segmentDateRange != null) {
-        segmentInfo.add("temporalMinDate", new Date(segmentDateRange.minDate));
-        segmentInfo.add("temporalMaxDate", new Date(segmentDateRange.maxDate));
+      try {
+        SegmentDateRange segmentDateRange = extractDateRangeFromSegment(segmentCommitInfo);
+        if (segmentDateRange != null) {
+          segmentInfo.add("temporalMinDate", new Date(segmentDateRange.minDate));
+          segmentInfo.add("temporalMaxDate", new Date(segmentDateRange.maxDate));
+        }
+      } catch (IOException e) {
+        log.warn("Exception segment range info on segment {}", segmentCommitInfo.info.name,  e);
       }
 
       segmentInfos.add((String) segmentInfo.get(NAME), segmentInfo);

--- a/solr/webapp/web/css/angular/segments.css
+++ b/solr/webapp/web/css/angular/segments.css
@@ -69,19 +69,39 @@ limitations under the License.
     background: #f0f0f0;
     position: absolute;
     z-index: 1000;
-    width:220px;
-    height:120px;
+    /* Wider panel + normal wrapping: parent <dd> uses white-space:nowrap which caused overlap */
+    width: 340px;
+    height:auto;
+    min-height:120px;
     margin-left: 100%;
     opacity: .8;
-    padding: 5px;
+    padding: 8px;
     border: 1px solid;
     border-radius: 5px;
+    white-space: normal;
+    word-break: break-word;
+    box-sizing: border-box;
+    overflow: hidden;
+}
+
+#content #segments .segments-holder li .tooltip > div:first-child {
+  margin-bottom: 4px;
 }
 
 #content #segments .segments-holder li .tooltip .label {
   float: left;
-  width: 20%;
+  clear: left;
+  width: 152px;
+  max-width: 46%;
+  padding-right: 8px;
+  box-sizing: border-box;
   opacity: 1;
+}
+
+/* Value column sits to the right of floated labels */
+#content #segments .segments-holder li .tooltip .label + div {
+  overflow: hidden;
+  padding-bottom: 2px;
 }
 
 #content #segments .segments-holder li:hover .tooltip {

--- a/solr/webapp/web/js/angular/controllers/segments.js
+++ b/solr/webapp/web/js/angular/controllers/segments.js
@@ -20,6 +20,19 @@ var MB_FACTOR = 1024*1024;
 solrAdminApp.controller('SegmentsController', function($scope, $routeParams, $interval, Segments, Constants) {
     $scope.resetMenu("segments", Constants.IS_CORE_PAGE);
 
+    /** Fixed decimals without locale grouping (avoids confusing commas in ms timings). */
+    $scope.formatMs = function(v, fracDigits) {
+        if (v == null || v === '') {
+            return '';
+        }
+        var n = Number(v);
+        if (!isFinite(n)) {
+            return '';
+        }
+        var d = fracDigits != null ? fracDigits : 4;
+        return n.toFixed(d);
+    };
+
     $scope.refresh = function() {
 
         Segments.get({core: $routeParams.core}, function(data) {

--- a/solr/webapp/web/partials/segments.html
+++ b/solr/webapp/web/partials/segments.html
@@ -71,6 +71,12 @@ limitations under the License.
                                              <div>{{ segment.age }}</div>
                                              <div class="label">source:</div>
                                              <div>{{ segment.source }}</div>
+                                             <div ng-if="segment.temporalMinDate">
+                                                 <div class="label">EventStart from:</div>
+                                                 <div>{{ segment.temporalMinDate }}</div>
+                                                 <div class="label">EventStart to:</div>
+                                                 <div>{{ segment.temporalMaxDate }}</div>
+                                             </div>
                                          </div>
                                          <div class="deleted" ng-show="segment.deletedDocSize"
                                               style="width: {{ segment.deletedDocSize }}%; margin-left:{{ segment.aliveDocSize}}%;">


### PR DESCRIPTION
## Description
During evaluation of Temporal Merge Policy (time routed segment). It's found in our tests that our existing merge policy does already somehow group by date range. This is probably due to how the segments are populated tho.

It will be helpful to know about the `EventStart` range in actual prod collections

## Solution
Modify the Solr admin UI, in the segment page, display the EventStart range as well on the hover modal

This is a low risk change as it only affect one page in the admin UI

## Test
Deployed on playpen c92-2 with cores of existing merge policy, verify the segment page is working as expected

<img width="430" height="253" alt="image" src="https://github.com/user-attachments/assets/da0a45fb-cdc8-4e61-8074-9a29c64f655d" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new low-level Lucene segment reads (points/fieldInfos, incl. compound-file handling) on the segments admin endpoint, which could affect performance or trigger IO/codec edge cases on unusual/legacy segments.
> 
> **Overview**
> The segments admin endpoint now attempts to compute a per-segment `EventStart` min/max timestamp by directly reading Lucene point values from each segment (handling compound vs non-compound segments) and returns these as `temporalMinDate`/`temporalMaxDate` when available.
> 
> The Segments UI tooltip is updated to display this date range when present, along with CSS tweaks to widen/unwrap the tooltip layout; the Angular controller also adds a `formatMs` helper (currently unused in the template).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9816980e6e67d6d393d81e06afde10196d2c36ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->