### PR TITLE
SAI-6291: Added metrics for merge durations

### DIFF
--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -635,6 +635,12 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
   enum CoreMetric {
     MAJOR_MERGE(
         "INDEX.merge.major", "merges_major", "cumulative number of major merges across cores"),
+    MAJOR_MERGE_DURATION_P50(
+            "INDEX.merge.major", "merges_major_duration_p50", "p50 latency of major merges across cores", "median_ms", PrometheusMetricType.GAUGE),
+    MAJOR_MERGE_DURATION_P95(
+            "INDEX.merge.major", "merges_major_duration_p95", "p95 latency of major merges across cores", "p95_ms", PrometheusMetricType.GAUGE),
+    MAJOR_MERGE_DURATION_P99(
+            "INDEX.merge.major", "merges_major_duration_p99", "p99 latency of major merges across cores", "p99_ms", PrometheusMetricType.GAUGE),
     MAJOR_MERGE_RUNNING_DOCS(
         "INDEX.merge.major.running.docs",
         "merges_major_current_docs",
@@ -643,6 +649,13 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
         PrometheusMetricType.GAUGE),
     MINOR_MERGE(
         "INDEX.merge.minor", "merges_minor", "cumulative number of minor merges across cores"),
+    MINOR_MERGE_DURATION_P50(
+            "INDEX.merge.minor", "merges_minor_duration_p50", "p50 latency of minor merges across cores", "median_ms", PrometheusMetricType.GAUGE),
+    MINOR_MERGE_DURATION_P95(
+            "INDEX.merge.minor", "merges_minor_duration_p95", "p95 latency of minor merges across cores", "p95_ms", PrometheusMetricType.GAUGE),
+    MINOR_MERGE_DURATION_P99(
+            "INDEX.merge.minor", "merges_minor_duration_p99", "p99 latency of minor merges across cores", "p99_ms", PrometheusMetricType.GAUGE),
+
     MINOR_MERGE_RUNNING_DOCS(
         "INDEX.merge.minor.running.docs",
         "merges_minor_current_docs",


### PR DESCRIPTION
## Description
It will be useful to export the percentiles of merge duration. Those are already exposed via the solr metrics `solr/admin/metrics` but not yet exported via our prometheus endpoint `solr/metrics`

This will help us understand current merge overhead in prod env and to monitor change after enabling time routed segment (`TemporalMergePolicy` aka `TMP`)

## Solution
Modified `PrometheusMetricsServlet` to export merge duration percentiles for major/minor merges

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only enum additions on the legacy Prometheus metrics servlet; no indexing or request-path behavior changes.
> 
> **Overview**
> Extends the legacy **`solr/metrics`** Prometheus servlet so **major and minor index merge duration percentiles** (p50, p95, p99) are exported alongside existing merge counters and running-doc gauges.
> 
> Six new **`CoreMetric`** entries map **`INDEX.merge.major`** and **`INDEX.merge.minor`** admin metrics (`median_ms`, `p95_ms`, `p99_ms`) to Prometheus gauge names such as **`merges_major_duration_p50`** and **`merges_minor_duration_p95`**, using the same pattern as query/update request-time percentiles. **`AggregateMetricsApiCaller`** and **`CoresMetricsApiCaller`** include them automatically via **`CoreMetric.values()`**, so no separate export logic was added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f1b662cf028fd238df85daec00451ae99349b1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->