### PR TITLE
SAI-6282: preferredMergePolicyFactory to allow canary merge policy

### DIFF
--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -636,11 +636,23 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
     MAJOR_MERGE(
         "INDEX.merge.major", "merges_major", "cumulative number of major merges across cores"),
     MAJOR_MERGE_DURATION_P50(
-            "INDEX.merge.major", "merges_major_duration_p50", "p50 latency of major merges across cores", "median_ms", PrometheusMetricType.GAUGE),
+        "INDEX.merge.major",
+        "merges_major_duration_p50",
+        "p50 latency of major merges across cores",
+        "median_ms",
+        PrometheusMetricType.GAUGE),
     MAJOR_MERGE_DURATION_P95(
-            "INDEX.merge.major", "merges_major_duration_p95", "p95 latency of major merges across cores", "p95_ms", PrometheusMetricType.GAUGE),
+        "INDEX.merge.major",
+        "merges_major_duration_p95",
+        "p95 latency of major merges across cores",
+        "p95_ms",
+        PrometheusMetricType.GAUGE),
     MAJOR_MERGE_DURATION_P99(
-            "INDEX.merge.major", "merges_major_duration_p99", "p99 latency of major merges across cores", "p99_ms", PrometheusMetricType.GAUGE),
+        "INDEX.merge.major",
+        "merges_major_duration_p99",
+        "p99 latency of major merges across cores",
+        "p99_ms",
+        PrometheusMetricType.GAUGE),
     MAJOR_MERGE_RUNNING_DOCS(
         "INDEX.merge.major.running.docs",
         "merges_major_current_docs",
@@ -650,11 +662,23 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
     MINOR_MERGE(
         "INDEX.merge.minor", "merges_minor", "cumulative number of minor merges across cores"),
     MINOR_MERGE_DURATION_P50(
-            "INDEX.merge.minor", "merges_minor_duration_p50", "p50 latency of minor merges across cores", "median_ms", PrometheusMetricType.GAUGE),
+        "INDEX.merge.minor",
+        "merges_minor_duration_p50",
+        "p50 latency of minor merges across cores",
+        "median_ms",
+        PrometheusMetricType.GAUGE),
     MINOR_MERGE_DURATION_P95(
-            "INDEX.merge.minor", "merges_minor_duration_p95", "p95 latency of minor merges across cores", "p95_ms", PrometheusMetricType.GAUGE),
+        "INDEX.merge.minor",
+        "merges_minor_duration_p95",
+        "p95 latency of minor merges across cores",
+        "p95_ms",
+        PrometheusMetricType.GAUGE),
     MINOR_MERGE_DURATION_P99(
-            "INDEX.merge.minor", "merges_minor_duration_p99", "p99 latency of minor merges across cores", "p99_ms", PrometheusMetricType.GAUGE),
+        "INDEX.merge.minor",
+        "merges_minor_duration_p99",
+        "p99 latency of minor merges across cores",
+        "p99_ms",
+        PrometheusMetricType.GAUGE),
 
     MINOR_MERGE_RUNNING_DOCS(
         "INDEX.merge.minor.running.docs",

--- a/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
@@ -92,9 +92,9 @@ public class SolrIndexConfig implements MapSerializable {
   public final String lockType;
 
   /**
-   * Effective merge-policy factory: {@code <preferredMergePolicyFactory>} when present,
-   * otherwise {@code <mergePolicyFactory>}. Older Solr versions ignore the preferred element
-   * and use only {@code mergePolicyFactory}.
+   * Effective merge-policy factory: {@code <preferredMergePolicyFactory>} when present, otherwise
+   * {@code <mergePolicyFactory>}. Older Solr versions ignore the preferred element and use only
+   * {@code mergePolicyFactory}.
    */
   public final PluginInfo mergePolicyFactoryInfo;
 

--- a/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
@@ -51,6 +51,11 @@ import org.slf4j.LoggerFactory;
 /**
  * This config object encapsulates IndexWriter config params, defined in the &lt;indexConfig&gt;
  * section of solrconfig.xml
+ *
+ * <p>Optional {@code <preferredMergePolicyFactory class="...">...</preferredMergePolicyFactory>}
+ * selects the merge policy factory when this Solr version understands it; if absent or without a
+ * {@code class}, {@code <mergePolicyFactory>} is used. Configsets can ship both so older nodes
+ * ignore the unknown preferred element and keep using {@code mergePolicyFactory}.
  */
 public class SolrIndexConfig implements MapSerializable {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -85,6 +90,11 @@ public class SolrIndexConfig implements MapSerializable {
 
   public final int writeLockTimeout;
   public final String lockType;
+  /**
+   * Effective merge-policy factory: {@code &lt;preferredMergePolicyFactory&gt;} when present with a
+   * non-blank {@code class} attribute, otherwise {@code &lt;mergePolicyFactory&gt;}. Older Solr
+   * versions ignore the preferred element and use only {@code mergePolicyFactory}.
+   */
   public final PluginInfo mergePolicyFactoryInfo;
   public final PluginInfo mergeSchedulerInfo;
   public final PluginInfo metricsInfo;
@@ -163,7 +173,18 @@ public class SolrIndexConfig implements MapSerializable {
 
     metricsInfo = getPluginInfo(get("metrics"), def.metricsInfo);
     mergeSchedulerInfo = getPluginInfo(get("mergeScheduler"), def.mergeSchedulerInfo);
-    mergePolicyFactoryInfo = getPluginInfo(get("mergePolicyFactory"), def.mergePolicyFactoryInfo);
+    PluginInfo mergePolicyFactory =
+        getPluginInfo(get("mergePolicyFactory"), def.mergePolicyFactoryInfo);
+    PluginInfo preferredMergePolicyFactory =
+        getPluginInfo(get("preferredMergePolicyFactory"), null);
+    if (preferredMergePolicyFactory != null) {
+      mergePolicyFactoryInfo = preferredMergePolicyFactory;
+      log.info(
+          "Using <preferredMergePolicyFactory> ({}) instead of <mergePolicyFactory>",
+          preferredMergePolicyFactory);
+    } else {
+      mergePolicyFactoryInfo = mergePolicyFactory;
+    }
 
     assertWarnOrFail(
         "Beginning with Solr 7.0, <mergePolicy> is no longer supported, use <mergePolicyFactory> instead.",
@@ -292,8 +313,9 @@ public class SolrIndexConfig implements MapSerializable {
   }
 
   /**
-   * Builds a MergePolicy using the configured MergePolicyFactory or if no factory is configured
-   * uses the configured mergePolicy PluginInfo.
+   * Builds a MergePolicy using the effective {@link #mergePolicyFactoryInfo} (see {@code
+   * preferredMergePolicyFactory} vs {@code mergePolicyFactory} in class javadoc), or the default
+   * factory if none is configured.
    */
   private MergePolicy buildMergePolicy(SolrResourceLoader resourceLoader, IndexSchema schema) {
 

--- a/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
@@ -91,8 +91,8 @@ public class SolrIndexConfig implements MapSerializable {
   public final int writeLockTimeout;
   public final String lockType;
   /**
-   * Effective merge-policy factory: {@code &lt;preferredMergePolicyFactory&gt;} when present with a
-   * non-blank {@code class} attribute, otherwise {@code &lt;mergePolicyFactory&gt;}. Older Solr
+   * Effective merge-policy factory: {@code <preferredMergePolicyFactory>} when present with a
+   * non-blank {@code class} attribute, otherwise {@code <mergePolicyFactory>}. Older Solr
    * versions ignore the preferred element and use only {@code mergePolicyFactory}.
    */
   public final PluginInfo mergePolicyFactoryInfo;

--- a/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
@@ -92,9 +92,9 @@ public class SolrIndexConfig implements MapSerializable {
   public final String lockType;
 
   /**
-   * Effective merge-policy factory: {@code <preferredMergePolicyFactory>} when present with a
-   * non-blank {@code class} attribute, otherwise {@code <mergePolicyFactory>}. Older Solr versions
-   * ignore the preferred element and use only {@code mergePolicyFactory}.
+   * Effective merge-policy factory: {@code <preferredMergePolicyFactory>} when present,
+   * otherwise {@code <mergePolicyFactory>}. Older Solr versions ignore the preferred element
+   * and use only {@code mergePolicyFactory}.
    */
   public final PluginInfo mergePolicyFactoryInfo;
 

--- a/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
@@ -90,12 +90,14 @@ public class SolrIndexConfig implements MapSerializable {
 
   public final int writeLockTimeout;
   public final String lockType;
+
   /**
    * Effective merge-policy factory: {@code <preferredMergePolicyFactory>} when present with a
-   * non-blank {@code class} attribute, otherwise {@code <mergePolicyFactory>}. Older Solr
-   * versions ignore the preferred element and use only {@code mergePolicyFactory}.
+   * non-blank {@code class} attribute, otherwise {@code <mergePolicyFactory>}. Older Solr versions
+   * ignore the preferred element and use only {@code mergePolicyFactory}.
    */
   public final PluginInfo mergePolicyFactoryInfo;
+
   public final PluginInfo mergeSchedulerInfo;
   public final PluginInfo metricsInfo;
 

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-preferred-merge-policy-factory.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-preferred-merge-policy-factory.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" ?>
+
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<config>
+  <luceneMatchVersion>${tests.luceneMatchVersion:LATEST}</luceneMatchVersion>
+  <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.RAMDirectoryFactory}"/>
+  <schemaFactory class="ClassicIndexSchemaFactory"/>
+
+  <indexConfig>
+    <useCompoundFile>${useCompoundFile:false}</useCompoundFile>
+    <mergePolicyFactory class="org.apache.solr.index.TieredMergePolicyFactory">
+      <int name="maxMergeAtOnce">7</int>
+      <int name="segmentsPerTier">9</int>
+      <double name="noCFSRatio">0.1</double>
+    </mergePolicyFactory>
+    <preferredMergePolicyFactory class="org.apache.solr.index.DefaultMergePolicyFactory">
+    </preferredMergePolicyFactory>
+    <mergeScheduler class="org.apache.lucene.index.ConcurrentMergeScheduler">
+      <int name="maxMergeCount">987</int>
+      <int name="maxThreadCount">42</int>
+    </mergeScheduler>
+  </indexConfig>
+
+  <requestHandler name="/select" class="solr.SearchHandler"></requestHandler>
+
+</config>

--- a/solr/core/src/test/org/apache/solr/update/SolrIndexConfigTest.java
+++ b/solr/core/src/test/org/apache/solr/update/SolrIndexConfigTest.java
@@ -55,6 +55,8 @@ public class SolrIndexConfigTest extends SolrTestCaseJ4 {
       "solrconfig-concurrentmergescheduler.xml";
   private static final String solrConfigFileNameSortingMergePolicyFactory =
       "solrconfig-sortingmergepolicyfactory.xml";
+  private static final String solrConfigFileNamePreferredMergePolicyFactory =
+      "solrconfig-preferred-merge-policy-factory.xml";
   private static final String schemaFileName = "schema.xml";
 
   private static boolean compoundMergePolicySort = false;
@@ -92,6 +94,17 @@ public class SolrIndexConfigTest extends SolrTestCaseJ4 {
         ex.getMessage()
             .contains(
                 "Error instantiating class: 'org.apache.solr.index.DummyMergePolicyFactory'"));
+  }
+
+  @Test
+  public void testPreferredMergePolicyFactoryOverridesMergePolicyFactory() throws Exception {
+    SolrConfig solrConfig =
+        new SolrConfig(instanceDir, solrConfigFileNamePreferredMergePolicyFactory);
+    SolrIndexConfig solrIndexConfig = new SolrIndexConfig(solrConfig, null);
+    assertNotNull(solrIndexConfig.mergePolicyFactoryInfo);
+    assertEquals(
+        org.apache.solr.index.DefaultMergePolicyFactory.class.getName(),
+        solrIndexConfig.mergePolicyFactoryInfo.className);
   }
 
   @Test


### PR DESCRIPTION
## Description
Currently we cannot easily test different merge policy on a node, as:
1. We don't want to (probably cannot) change the existing collection to another config set (without affecting other nodes not selected for canary), so we are stuck with `_FS7`
2. If we directly change the `solrconfig.xml` under `_FS7`, then nodes that are still with old hash (not selected for canary) will run into classloading issue on restart/new collections, as they are not aware of `TemporalMergePolicy`

## Solution
In `solrconfig.xml`, under `<indexConfig>`, add a new optional node `<preferredMergePolicyFactory>` which has exactly the same structure and parse logic as `<mergePolicyFactory>`, and if both defined, `<preferredMergePolicyFactory>` would take precedence

For nodes that still run the old hash, such `<preferredMergePolicyFactory>` would just be ignored. if a node is running the new hash (selected for canary), then they will pick up the preferred factory and log the contents on startup `Using <preferredMergePolicyFactory>...`

## Remarks
This is likely NOT something we want in long term. For simplicity we can still merge to `fs/branch_9_7` (there's no harm at all). But after time routed segment project concludes, we should just revert this change here?

## Test
1. Updated the _FS7 solrconfig.xml on playpen c92 to below
```
 <indexConfig aggregateNodeLevelMetricsEnabled="true">
        <mergePolicyFactory class="org.apache.solr.index.SortingMergePolicyFactory">
            ...
         </mergePolicyFactory>
	 <!-- preferredMergePolicyFactory is for canary test. Non test solr hash should just ignore it -->
        <preferredMergePolicyFactory class="org.apache.solr.index.SortingMergePolicyFactory">
            <str name="sort">IndvId asc, EventStart asc</str>
            <str name="wrapped.prefix">inner</str>
            <str name="inner.class">mn.fs.solr.index.TemporalMergePolicyFactory</str>
            <str name="inner.temporalField">EventStart</str>
            <int name="inner.minThreshold">4</int>
            <int name="inner.maxThreshold">8</int>
            <double name="inner.compactionRatio">1.5</double>
            <bool name="inner.useExponentialBuckets">true</bool>
        </preferredMergePolicyFactory> 
```
2. Without updating fs-solr hash, restart playpen c92 cluster. This emulates nodes that are NOT selected for canary, and with the existing hash, Solr startup read the new config and ignored `<preferredMergePolicyFactory...`
3. All cores should load and query on `local` returns same # of docs
4. Now add fs-solr hash override (`3843d3c071917900b7077ada0d0ecfdf7d534da9`) to playpen c92-1 to use this PR. Restart the cluster again. This emulates a canary node
5. solr-c92-1 startup log prints out  `o.a.s.u.SolrIndexConfig Using <preferredMergePolicyFactory> ({type = preferredMergePolicyFactory,class = org.apache.solr.index.SortingMergePolicyFactory,attributes = {class=org.apache.solr.index.SortingMergePolicyFactory},args = {inner.useExponentialBuckets=true, inner.minThreshold=4, inner.maxThreshold=8, sort=IndvId asc, EventStart asc, wrapped.prefix=inner, inner.class=mn.fs.solr.index.TemporalMergePolicyFactory, inner.temporalField=EventStart, inner.compactionRatio=1.5}}) instead of <mergePolicyFactory>`
6. Commented out overrides. So others can test on c92 playpen w/o surprises

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which merge policy factory drives IndexWriter on cores that enable preferred config; backward compatible for old nodes but canary nodes get different merge/index behavior.
> 
> **Overview**
> Adds optional **`<preferredMergePolicyFactory>`** under **`<indexConfig>`** in `solrconfig.xml`, parsed like **`<mergePolicyFactory>`**. When both are present with a `class`, **`SolrIndexConfig`** uses the preferred factory for **`mergePolicyFactoryInfo`** and logs `Using <preferredMergePolicyFactory>...` at startup.
> 
> This lets a shared configset keep a safe **`mergePolicyFactory`** for older Solr builds (which ignore the unknown element) while canary nodes on a newer build can point at experimental factories (e.g. custom temporal merge policies) without swapping configsets.
> 
> Includes a test fixture and **`testPreferredMergePolicyFactoryOverridesMergePolicyFactory`**. **`PrometheusMetricsServlet`** only reformats some **`CoreMetric`** enum constructor arguments (no behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc3ca9c246af4eb059d06b803a4d8e0ec1ced2d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->