### PR TITLE
SAI-6231: Better visualization based on temporal bucket

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/admin/SegmentsInfoRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/SegmentsInfoRequestHandler.java
@@ -88,6 +88,7 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
   public static final String RAW_SIZE_SAMPLING_PERCENT_PARAM = "rawSizeSamplingPercent";
 
   private static final List<String> FI_LEGEND;
+  private static final long[] DEFAULT_BOUNDARIES = new long[] {-9, 3, 9, 32, 94, 184};
 
   static {
     FI_LEGEND =
@@ -508,6 +509,9 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
   /**
    * Extract date range (min/max timestamps) from a single segment by reading point values.
    *
+   * <p>There's very similar code in TemporalMergePolicy in fs-solr plugin. However, this has no
+   * dependency on such plugin module so we cannot reuse that code here.
+   *
    * @param segmentInfo the segment to read from
    * @return the date range, or null if the temporal field is not present or has no values
    * @throws IOException if there's an error reading the segment
@@ -609,14 +613,14 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
   }
 
   /**
-   * Temporal field names for segment date-range display. Defaults to {@code EventStart}; overridden
-   * by {@code lucene.temporalField.name} when set (comma-separated list, first match wins per
-   * segment).
+   * Temporal field names for segment date-range display. Defaults to {@code
+   * EventStart,SessionStart,UserLastIndexedEventStart,UserTipLastEventStart}; overridden by {@code
+   * lucene.temporalField.name} when set (comma-separated list, first match wins per segment).
    */
   static List<String> resolveTemporalFields() {
     String spec = System.getProperty("lucene.temporalField.name");
     if (spec == null || spec.isBlank()) {
-      return List.of("EventStart");
+      spec = "EventStart,SessionStart,UserLastIndexedEventStart,UserTipLastEventStart";
     }
     return Arrays.stream(spec.split(", *"))
         .map(String::trim)
@@ -633,7 +637,6 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
   }
 
   private static List<Long> getBucketBoundaries() {
-    long[] DEFAULT_BOUNDARIES = new long[] {-9, 3, 9, 32, 94, 184};
     List<Long> boundaries =
         Arrays.stream(DEFAULT_BOUNDARIES)
             .mapToObj(TimeUnit.DAYS::toMillis)

--- a/solr/core/src/java/org/apache/solr/handler/admin/SegmentsInfoRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/SegmentsInfoRequestHandler.java
@@ -26,7 +26,10 @@ import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.lucene.codecs.PointsFormat;
 import org.apache.lucene.codecs.PointsReader;
@@ -50,6 +53,7 @@ import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.index.SegmentRoutingUtil;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
@@ -180,6 +184,10 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
     SimpleOrderedMap<Object> runningMerges = getMergeInformation(req, infos, mergeCandidates);
     List<LeafReaderContext> leafContexts = searcher.getIndexReader().leaves();
     IndexSchema schema = req.getSchema();
+
+    //better debugging for segment temporal buckets
+    long now = SegmentRoutingUtil.getNow();
+    Map<String, Integer> temporalBucketCounters = new HashMap<>();
     for (SegmentCommitInfo segmentCommitInfo : sortable) {
       segmentInfo =
           getSegmentInfo(segmentCommitInfo, withSizeInfo, withFieldInfo, leafContexts, schema);
@@ -192,6 +200,12 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
         if (segmentDateRange != null) {
           segmentInfo.add("temporalMinDate", new Date(segmentDateRange.minDate));
           segmentInfo.add("temporalMaxDate", new Date(segmentDateRange.maxDate));
+          long temporalBucket =
+                  SegmentRoutingUtil.mapToBucket(segmentDateRange.maxDate, now);
+          segmentInfo.add("temporalBucket", temporalBucket);
+          String bucketLabel = formatTemporalBucket(temporalBucket);
+          int count = temporalBucketCounters.merge(bucketLabel, 1, Integer::sum);
+          segmentInfo.add("temporalBucketLabel", bucketLabel + "(" + count + ")");
         }
       } catch (IOException e) {
         log.warn("Exception segment range info on segment {}", segmentCommitInfo.info.name, e);
@@ -208,6 +222,7 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
       rsp.add("fieldInfoLegend", FI_LEGEND);
     }
     rsp.add("segments", segmentInfos);
+    rsp.add("bucketBoundaries", getBucketBoundaries());
     if (withRawSizeInfo) {
       IndexSizeEstimator estimator =
           new IndexSizeEstimator(
@@ -514,63 +529,66 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
       FieldInfos fieldInfos =
           si.getCodec().fieldInfosFormat().read(readerDir, si, "", IOContext.READONCE);
 
-      String temporalField = "EventStart";
-      // Validate that the temporal field exists and is a point field
-      FieldInfo fieldInfo = fieldInfos.fieldInfo(temporalField);
-      if (fieldInfo == null) {
-        return null;
-      }
+      List<String> temporalFields = resolveTemporalFields();
 
-      if (fieldInfo.getPointDimensionCount() == 0) {
-        if (log.isWarnEnabled()) {
-          log.warn(
-              "Segment {}: temporal field '{}' is not indexed as a point field (found: {}). "
-                  + "Skipping this segment for date-tiered merging. This may occur with legacy segments "
-                  + "or after schema changes.",
-              si.name,
-              temporalField,
-              fieldInfo);
-        }
-        return null;
-      }
 
-      // Read point values using the codec
       PointsFormat pointsFormat = si.getCodec().pointsFormat();
       try (PointsReader pointsReader =
           pointsFormat.fieldsReader(
               new SegmentReadState(readerDir, si, fieldInfos, IOContext.READONCE))) {
 
-        PointValues pointValues = pointsReader.getValues(temporalField);
-        if (pointValues == null) {
-          return null;
+        for (String temporalField : temporalFields) {
+          FieldInfo fieldInfo = fieldInfos.fieldInfo(temporalField);
+          if (fieldInfo == null) {
+            continue;
+          }
+
+          if (fieldInfo.getPointDimensionCount() == 0) {
+            if (log.isWarnEnabled()) {
+              log.warn(
+                      "Segment {}: temporal field '{}' is not indexed as a point field (found: {}). "
+                              + "Skipping this field. This may occur with legacy segments "
+                              + "or after schema changes.",
+                      si.name,
+                      temporalField,
+                      fieldInfo);
+            }
+            continue;
+          }
+
+          PointValues pointValues = pointsReader.getValues(temporalField);
+          if (pointValues == null) {
+            continue;
+          }
+
+          byte[] minPackedValue = pointValues.getMinPackedValue();
+          byte[] maxPackedValue = pointValues.getMaxPackedValue();
+
+          if (minPackedValue == null || maxPackedValue == null) {
+            continue;
+          }
+
+          // Decode the packed values as longs, we have to make an assumption here
+          // since we don't have the schema :/
+          long minDate = LongPoint.decodeDimension(minPackedValue, 0);
+          long maxDate = LongPoint.decodeDimension(maxPackedValue, 0);
+
+          // Convert to milliseconds based on detected unit
+          long divisor = getTemporalFieldDivisor(maxDate);
+          long minDateMillis, maxDateMillis;
+          if (divisor < 0) {
+            long multiplier = -divisor;
+            minDateMillis = minDate * multiplier;
+            maxDateMillis = maxDate * multiplier;
+          } else {
+            minDateMillis = minDate / divisor;
+            maxDateMillis = maxDate / divisor;
+          }
+
+          return new SegmentDateRange(minDateMillis, maxDateMillis);
         }
-
-        byte[] minPackedValue = pointValues.getMinPackedValue();
-        byte[] maxPackedValue = pointValues.getMaxPackedValue();
-
-        if (minPackedValue == null || maxPackedValue == null) {
-          return null;
-        }
-
-        // Decode the packed values as longs, we have to make an assumption here
-        // since we don't have the schema :/
-        long minDate = LongPoint.decodeDimension(minPackedValue, 0);
-        long maxDate = LongPoint.decodeDimension(maxPackedValue, 0);
-
-        // Convert to milliseconds based on detected unit
-        long divisor = getTemporalFieldDivisor(maxDate);
-        long minDateMillis, maxDateMillis;
-        if (divisor < 0) {
-          long multiplier = -divisor;
-          minDateMillis = minDate * multiplier;
-          maxDateMillis = maxDate * multiplier;
-        } else {
-          minDateMillis = minDate / divisor;
-          maxDateMillis = maxDate / divisor;
-        }
-
-        return new SegmentDateRange(minDateMillis, maxDateMillis);
       }
+      return null;
     } finally {
       // Close compound directory if we opened it (never close si.dir)
       if (compoundDir != null) {
@@ -590,6 +608,40 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
       // Values <= 10^11 are seconds
       return -1000;
     }
+  }
+
+  /**
+   * Temporal field names for segment date-range display. Defaults to {@code EventStart}; overridden
+   * by {@code lucene.temporalField.name} when set (comma-separated list, first match wins per
+   * segment).
+   */
+  static List<String> resolveTemporalFields() {
+    String spec = System.getProperty("lucene.temporalField.name");
+    if (spec == null || spec.isBlank()) {
+      return List.of("EventStart");
+    }
+    return Arrays.stream(spec.split(", *"))
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+            .collect(Collectors.toList());
+  }
+
+  /** Human-readable label for a {@link SegmentRoutingUtil#mapToBucket} boundary (days from now). */
+  static String formatTemporalBucket(long bucketMs) {
+    if (bucketMs == Long.MAX_VALUE) {
+      return "oldest";
+    }
+    return TimeUnit.MILLISECONDS.toDays(bucketMs) + "d";
+  }
+
+  private static List<Long> getBucketBoundaries() {
+    long[] DEFAULT_BOUNDARIES = new long[] {-9, 3, 9, 32, 94, 184};
+    List<Long> boundaries =
+            Arrays.stream(DEFAULT_BOUNDARIES)
+                    .mapToObj(TimeUnit.DAYS::toMillis)
+                    .collect(Collectors.toCollection(ArrayList::new));
+    boundaries.add(Long.MAX_VALUE);
+    return boundaries;
   }
 
   public static class SegmentDateRange {

--- a/solr/core/src/java/org/apache/solr/handler/admin/SegmentsInfoRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/SegmentsInfoRequestHandler.java
@@ -620,6 +620,8 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
   static List<String> resolveTemporalFields() {
     String spec = System.getProperty("lucene.temporalField.name");
     if (spec == null || spec.isBlank()) {
+      // specific to Fullstory usage. We still want to group segments by temporal buckets even if
+      // "lucene.temporalField.name" is not defined (ie no bucket flushing)
       spec = "EventStart,SessionStart,UserLastIndexedEventStart,UserTipLastEventStart";
     }
     return Arrays.stream(spec.split(", *"))

--- a/solr/core/src/java/org/apache/solr/handler/admin/SegmentsInfoRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/SegmentsInfoRequestHandler.java
@@ -185,7 +185,7 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
     List<LeafReaderContext> leafContexts = searcher.getIndexReader().leaves();
     IndexSchema schema = req.getSchema();
 
-    //better debugging for segment temporal buckets
+    // better debugging for segment temporal buckets
     long now = SegmentRoutingUtil.getNow();
     Map<String, Integer> temporalBucketCounters = new HashMap<>();
     for (SegmentCommitInfo segmentCommitInfo : sortable) {
@@ -200,8 +200,7 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
         if (segmentDateRange != null) {
           segmentInfo.add("temporalMinDate", new Date(segmentDateRange.minDate));
           segmentInfo.add("temporalMaxDate", new Date(segmentDateRange.maxDate));
-          long temporalBucket =
-                  SegmentRoutingUtil.mapToBucket(segmentDateRange.maxDate, now);
+          long temporalBucket = SegmentRoutingUtil.mapToBucket(segmentDateRange.maxDate, now);
           segmentInfo.add("temporalBucket", temporalBucket);
           String bucketLabel = formatTemporalBucket(temporalBucket);
           int count = temporalBucketCounters.merge(bucketLabel, 1, Integer::sum);
@@ -531,7 +530,6 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
 
       List<String> temporalFields = resolveTemporalFields();
 
-
       PointsFormat pointsFormat = si.getCodec().pointsFormat();
       try (PointsReader pointsReader =
           pointsFormat.fieldsReader(
@@ -546,12 +544,12 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
           if (fieldInfo.getPointDimensionCount() == 0) {
             if (log.isWarnEnabled()) {
               log.warn(
-                      "Segment {}: temporal field '{}' is not indexed as a point field (found: {}). "
-                              + "Skipping this field. This may occur with legacy segments "
-                              + "or after schema changes.",
-                      si.name,
-                      temporalField,
-                      fieldInfo);
+                  "Segment {}: temporal field '{}' is not indexed as a point field (found: {}). "
+                      + "Skipping this field. This may occur with legacy segments "
+                      + "or after schema changes.",
+                  si.name,
+                  temporalField,
+                  fieldInfo);
             }
             continue;
           }
@@ -621,9 +619,9 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
       return List.of("EventStart");
     }
     return Arrays.stream(spec.split(", *"))
-            .map(String::trim)
-            .filter(s -> !s.isEmpty())
-            .collect(Collectors.toList());
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .collect(Collectors.toList());
   }
 
   /** Human-readable label for a {@link SegmentRoutingUtil#mapToBucket} boundary (days from now). */
@@ -637,9 +635,9 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
   private static List<Long> getBucketBoundaries() {
     long[] DEFAULT_BOUNDARIES = new long[] {-9, 3, 9, 32, 94, 184};
     List<Long> boundaries =
-            Arrays.stream(DEFAULT_BOUNDARIES)
-                    .mapToObj(TimeUnit.DAYS::toMillis)
-                    .collect(Collectors.toCollection(ArrayList::new));
+        Arrays.stream(DEFAULT_BOUNDARIES)
+            .mapToObj(TimeUnit.DAYS::toMillis)
+            .collect(Collectors.toCollection(ArrayList::new));
     boundaries.add(Long.MAX_VALUE);
     return boundaries;
   }

--- a/solr/webapp/web/js/angular/controllers/segments.js
+++ b/solr/webapp/web/js/angular/controllers/segments.js
@@ -17,6 +17,49 @@
 
 var MB_FACTOR = 1024*1024;
 
+/** Blue-grey (future) then green (newest) -> red (oldest); extra buckets reuse the last color. */
+var BUCKET_BAR_COLORS = [
+    '#a9c3d1', // -9d / far future
+    '#a9d1a9', // 3d / newest typical bucket
+    '#c3d1a9',
+    '#d1d1a9',
+    '#d1c3a9',
+    '#d1b6a9',
+    '#d1a9a9'
+];
+
+var buildColorByBucket = function(bucketBoundaries) {
+    var colorByBucket = {};
+    if (!bucketBoundaries) {
+        return colorByBucket;
+    }
+    var lastIdx = BUCKET_BAR_COLORS.length - 1;
+    for (var i = 0; i < bucketBoundaries.length; i++) {
+        colorByBucket[String(bucketBoundaries[i])] = BUCKET_BAR_COLORS[Math.min(i, lastIdx)];
+    }
+    return colorByBucket;
+};
+
+var colorByBucketCache = { key: null, map: null };
+
+var getColorByBucket = function(bucketBoundaries) {
+    var key = bucketBoundaries ? bucketBoundaries.join('\0') : '';
+    if (colorByBucketCache.key !== key) {
+        colorByBucketCache.key = key;
+        colorByBucketCache.map = buildColorByBucket(bucketBoundaries);
+    }
+    return colorByBucketCache.map;
+};
+
+var assignBucketBarColors = function(segments, colorByBucket) {
+    for (var i = 0; i < segments.length; i++) {
+        var bucket = segments[i].temporalBucket;
+        if (bucket != null) {
+            segments[i].bucketBarColor = colorByBucket[String(bucket)];
+        }
+    }
+};
+
 solrAdminApp.controller('SegmentsController', function($scope, $routeParams, $interval, Segments, Constants) {
     $scope.resetMenu("segments", Constants.IS_CORE_PAGE);
 
@@ -64,6 +107,8 @@ solrAdminApp.controller('SegmentsController', function($scope, $routeParams, $in
                 $scope.documentCount += segment.size;
                 $scope.deletionCount += segment.delCount;
             }
+            var colorByBucket = getColorByBucket(data.bucketBoundaries);
+            assignBucketBarColors($scope.segments, colorByBucket);
             $scope.deletionsPercentage = calculateDeletionsPercentage($scope.documentCount, $scope.deletionCount);
         });
     };

--- a/solr/webapp/web/partials/segments.html
+++ b/solr/webapp/web/partials/segments.html
@@ -58,7 +58,7 @@ limitations under the License.
                                      </dt>
                                      <dd>
                                          <div class="live" ng-class="{'merge-candidate':segment.mergeCandidate}"
-                                              ng-style="{width: segment.aliveDocSize+'%'}">&nbsp;</div>
+                                              ng-style="segment.bucketBarColor ? {width: segment.aliveDocSize+'%', backgroundColor: segment.bucketBarColor} : {width: segment.aliveDocSize+'%'}">&nbsp;</div>
                                          <div class="tooltip">
                                              <div>Segment <b>{{segment.name}}</b>:</div>
                                              <div class="label">#docs:</div>
@@ -72,10 +72,12 @@ limitations under the License.
                                              <div class="label">source:</div>
                                              <div>{{ segment.source }}</div>
                                              <div ng-if="segment.temporalMinDate">
-                                                 <div class="label">EventStart from:</div>
+                                                 <div class="label">TemporalStart:</div>
                                                  <div>{{ segment.temporalMinDate }}</div>
-                                                 <div class="label">EventStart to:</div>
+                                                 <div class="label">TemporalEnd:</div>
                                                  <div>{{ segment.temporalMaxDate }}</div>
+                                                 <div class="label">TemporalBucket:</div>
+                                                 <div>{{ segment.temporalBucketLabel }}</div>
                                              </div>
                                          </div>
                                          <div class="deleted" ng-show="segment.deletedDocSize"


### PR DESCRIPTION
Better visualization of temporal bucket on segment admin UI for easier monitoring

This should also work on collection/node w/o temporal merge policy enabled.

1. The newer segments (maxDate) will be colored green (new leaves! 🌳  ) while older more mature segments will be red (🍁 ). These only overrides the existing "grey" base color. The pink (merge candidate) and solid grey (deletion docs) would still show.
2. On hover over, it will now display the temporal bucket along with the index (sorted by size DESC) of such segment. For example 3d(2), means the current segment is in the 3d (to -1d) bucket and is the 2nd largest in such bucket


**_In general, more reds on top means better, we don't want to see alot of greens (especially on top, the largest segemnts) as that means short range queries 7d/30d will operate on those expensive segments_**


For example a TMP enabled collection with most larger bars red (old segments)
<img width="1715" height="823" alt="image" src="https://github.com/user-attachments/assets/76a9f10d-aadb-4027-bf16-2c3b4e19ff2a" />


This also works even on collections w/o temporal merge policy
<img width="1275" height="643" alt="image" src="https://github.com/user-attachments/assets/96ec3ed1-d9db-46b2-9439-8751a9194333" />





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only admin/metrics UI and segment introspection; no indexing, auth, or write paths changed.
> 
> **Overview**
> **Segments admin** now exposes **temporal bucket** metadata and colors segment bars by age bucket for easier monitoring, including on cores without temporal merge policy.
> 
> The **`SegmentsInfoRequestHandler`** response adds **`temporalBucket`**, **`temporalBucketLabel`** (e.g. `3d(2)` = bucket plus size-rank within that bucket), and top-level **`bucketBoundaries`** aligned with **`SegmentRoutingUtil.mapToBucket`**. Temporal min/max still come from point fields, but field resolution is no longer hard-coded to **`EventStart`**: it tries a comma-separated list from **`lucene.temporalField.name`**, with a Fullstory-oriented default list when unset.
> 
> The **segments UI** maps **`bucketBoundaries`** to a green→red palette on the live-doc bar (merge-candidate and deletion styling unchanged), renames tooltip labels to **TemporalStart/End**, and shows **TemporalBucket** on hover.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6af4545efe7a8640940e470fe986419bb9b1d247. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->