### PR TITLE
SAI-6231 : Time routed segment Solr changes

### DIFF
--- a/solr/core/src/java/org/apache/solr/handler/admin/SegmentsInfoRequestHandler.java
+++ b/solr/core/src/java/org/apache/solr/handler/admin/SegmentsInfoRequestHandler.java
@@ -26,7 +26,10 @@ import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.lucene.codecs.PointsFormat;
 import org.apache.lucene.codecs.PointsReader;
@@ -50,6 +53,7 @@ import org.apache.lucene.index.SegmentInfo;
 import org.apache.lucene.index.SegmentInfos;
 import org.apache.lucene.index.SegmentReadState;
 import org.apache.lucene.index.SegmentReader;
+import org.apache.lucene.index.SegmentRoutingUtil;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
@@ -84,6 +88,7 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
   public static final String RAW_SIZE_SAMPLING_PERCENT_PARAM = "rawSizeSamplingPercent";
 
   private static final List<String> FI_LEGEND;
+  private static final long[] DEFAULT_BOUNDARIES = new long[] {-9, 3, 9, 32, 94, 184};
 
   static {
     FI_LEGEND =
@@ -180,6 +185,10 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
     SimpleOrderedMap<Object> runningMerges = getMergeInformation(req, infos, mergeCandidates);
     List<LeafReaderContext> leafContexts = searcher.getIndexReader().leaves();
     IndexSchema schema = req.getSchema();
+
+    // better debugging for segment temporal buckets
+    long now = SegmentRoutingUtil.getNow();
+    Map<String, Integer> temporalBucketCounters = new HashMap<>();
     for (SegmentCommitInfo segmentCommitInfo : sortable) {
       segmentInfo =
           getSegmentInfo(segmentCommitInfo, withSizeInfo, withFieldInfo, leafContexts, schema);
@@ -192,6 +201,11 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
         if (segmentDateRange != null) {
           segmentInfo.add("temporalMinDate", new Date(segmentDateRange.minDate));
           segmentInfo.add("temporalMaxDate", new Date(segmentDateRange.maxDate));
+          long temporalBucket = SegmentRoutingUtil.mapToBucket(segmentDateRange.maxDate, now);
+          segmentInfo.add("temporalBucket", temporalBucket);
+          String bucketLabel = formatTemporalBucket(temporalBucket);
+          int count = temporalBucketCounters.merge(bucketLabel, 1, Integer::sum);
+          segmentInfo.add("temporalBucketLabel", bucketLabel + "(" + count + ")");
         }
       } catch (IOException e) {
         log.warn("Exception segment range info on segment {}", segmentCommitInfo.info.name, e);
@@ -208,6 +222,7 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
       rsp.add("fieldInfoLegend", FI_LEGEND);
     }
     rsp.add("segments", segmentInfos);
+    rsp.add("bucketBoundaries", getBucketBoundaries());
     if (withRawSizeInfo) {
       IndexSizeEstimator estimator =
           new IndexSizeEstimator(
@@ -494,6 +509,9 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
   /**
    * Extract date range (min/max timestamps) from a single segment by reading point values.
    *
+   * <p>There's very similar code in TemporalMergePolicy in fs-solr plugin. However, this has no
+   * dependency on such plugin module so we cannot reuse that code here.
+   *
    * @param segmentInfo the segment to read from
    * @return the date range, or null if the temporal field is not present or has no values
    * @throws IOException if there's an error reading the segment
@@ -514,63 +532,65 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
       FieldInfos fieldInfos =
           si.getCodec().fieldInfosFormat().read(readerDir, si, "", IOContext.READONCE);
 
-      String temporalField = "EventStart";
-      // Validate that the temporal field exists and is a point field
-      FieldInfo fieldInfo = fieldInfos.fieldInfo(temporalField);
-      if (fieldInfo == null) {
-        return null;
-      }
+      List<String> temporalFields = resolveTemporalFields();
 
-      if (fieldInfo.getPointDimensionCount() == 0) {
-        if (log.isWarnEnabled()) {
-          log.warn(
-              "Segment {}: temporal field '{}' is not indexed as a point field (found: {}). "
-                  + "Skipping this segment for date-tiered merging. This may occur with legacy segments "
-                  + "or after schema changes.",
-              si.name,
-              temporalField,
-              fieldInfo);
-        }
-        return null;
-      }
-
-      // Read point values using the codec
       PointsFormat pointsFormat = si.getCodec().pointsFormat();
       try (PointsReader pointsReader =
           pointsFormat.fieldsReader(
               new SegmentReadState(readerDir, si, fieldInfos, IOContext.READONCE))) {
 
-        PointValues pointValues = pointsReader.getValues(temporalField);
-        if (pointValues == null) {
-          return null;
+        for (String temporalField : temporalFields) {
+          FieldInfo fieldInfo = fieldInfos.fieldInfo(temporalField);
+          if (fieldInfo == null) {
+            continue;
+          }
+
+          if (fieldInfo.getPointDimensionCount() == 0) {
+            if (log.isWarnEnabled()) {
+              log.warn(
+                  "Segment {}: temporal field '{}' is not indexed as a point field (found: {}). "
+                      + "Skipping this field. This may occur with legacy segments "
+                      + "or after schema changes.",
+                  si.name,
+                  temporalField,
+                  fieldInfo);
+            }
+            continue;
+          }
+
+          PointValues pointValues = pointsReader.getValues(temporalField);
+          if (pointValues == null) {
+            continue;
+          }
+
+          byte[] minPackedValue = pointValues.getMinPackedValue();
+          byte[] maxPackedValue = pointValues.getMaxPackedValue();
+
+          if (minPackedValue == null || maxPackedValue == null) {
+            continue;
+          }
+
+          // Decode the packed values as longs, we have to make an assumption here
+          // since we don't have the schema :/
+          long minDate = LongPoint.decodeDimension(minPackedValue, 0);
+          long maxDate = LongPoint.decodeDimension(maxPackedValue, 0);
+
+          // Convert to milliseconds based on detected unit
+          long divisor = getTemporalFieldDivisor(maxDate);
+          long minDateMillis, maxDateMillis;
+          if (divisor < 0) {
+            long multiplier = -divisor;
+            minDateMillis = minDate * multiplier;
+            maxDateMillis = maxDate * multiplier;
+          } else {
+            minDateMillis = minDate / divisor;
+            maxDateMillis = maxDate / divisor;
+          }
+
+          return new SegmentDateRange(minDateMillis, maxDateMillis);
         }
-
-        byte[] minPackedValue = pointValues.getMinPackedValue();
-        byte[] maxPackedValue = pointValues.getMaxPackedValue();
-
-        if (minPackedValue == null || maxPackedValue == null) {
-          return null;
-        }
-
-        // Decode the packed values as longs, we have to make an assumption here
-        // since we don't have the schema :/
-        long minDate = LongPoint.decodeDimension(minPackedValue, 0);
-        long maxDate = LongPoint.decodeDimension(maxPackedValue, 0);
-
-        // Convert to milliseconds based on detected unit
-        long divisor = getTemporalFieldDivisor(maxDate);
-        long minDateMillis, maxDateMillis;
-        if (divisor < 0) {
-          long multiplier = -divisor;
-          minDateMillis = minDate * multiplier;
-          maxDateMillis = maxDate * multiplier;
-        } else {
-          minDateMillis = minDate / divisor;
-          maxDateMillis = maxDate / divisor;
-        }
-
-        return new SegmentDateRange(minDateMillis, maxDateMillis);
       }
+      return null;
     } finally {
       // Close compound directory if we opened it (never close si.dir)
       if (compoundDir != null) {
@@ -590,6 +610,41 @@ public class SegmentsInfoRequestHandler extends RequestHandlerBase {
       // Values <= 10^11 are seconds
       return -1000;
     }
+  }
+
+  /**
+   * Temporal field names for segment date-range display. Defaults to {@code
+   * EventStart,SessionStart,UserLastIndexedEventStart,UserTipLastEventStart}; overridden by {@code
+   * lucene.temporalField.name} when set (comma-separated list, first match wins per segment).
+   */
+  static List<String> resolveTemporalFields() {
+    String spec = System.getProperty("lucene.temporalField.name");
+    if (spec == null || spec.isBlank()) {
+      // specific to Fullstory usage. We still want to group segments by temporal buckets even if
+      // "lucene.temporalField.name" is not defined (ie no bucket flushing)
+      spec = "EventStart,SessionStart,UserLastIndexedEventStart,UserTipLastEventStart";
+    }
+    return Arrays.stream(spec.split(", *"))
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .collect(Collectors.toList());
+  }
+
+  /** Human-readable label for a {@link SegmentRoutingUtil#mapToBucket} boundary (days from now). */
+  static String formatTemporalBucket(long bucketMs) {
+    if (bucketMs == Long.MAX_VALUE) {
+      return "oldest";
+    }
+    return TimeUnit.MILLISECONDS.toDays(bucketMs) + "d";
+  }
+
+  private static List<Long> getBucketBoundaries() {
+    List<Long> boundaries =
+        Arrays.stream(DEFAULT_BOUNDARIES)
+            .mapToObj(TimeUnit.DAYS::toMillis)
+            .collect(Collectors.toCollection(ArrayList::new));
+    boundaries.add(Long.MAX_VALUE);
+    return boundaries;
   }
 
   public static class SegmentDateRange {

--- a/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
+++ b/solr/core/src/java/org/apache/solr/servlet/PrometheusMetricsServlet.java
@@ -636,11 +636,23 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
     MAJOR_MERGE(
         "INDEX.merge.major", "merges_major", "cumulative number of major merges across cores"),
     MAJOR_MERGE_DURATION_P50(
-            "INDEX.merge.major", "merges_major_duration_p50", "p50 latency of major merges across cores", "median_ms", PrometheusMetricType.GAUGE),
+        "INDEX.merge.major",
+        "merges_major_duration_p50",
+        "p50 latency of major merges across cores",
+        "median_ms",
+        PrometheusMetricType.GAUGE),
     MAJOR_MERGE_DURATION_P95(
-            "INDEX.merge.major", "merges_major_duration_p95", "p95 latency of major merges across cores", "p95_ms", PrometheusMetricType.GAUGE),
+        "INDEX.merge.major",
+        "merges_major_duration_p95",
+        "p95 latency of major merges across cores",
+        "p95_ms",
+        PrometheusMetricType.GAUGE),
     MAJOR_MERGE_DURATION_P99(
-            "INDEX.merge.major", "merges_major_duration_p99", "p99 latency of major merges across cores", "p99_ms", PrometheusMetricType.GAUGE),
+        "INDEX.merge.major",
+        "merges_major_duration_p99",
+        "p99 latency of major merges across cores",
+        "p99_ms",
+        PrometheusMetricType.GAUGE),
     MAJOR_MERGE_RUNNING_DOCS(
         "INDEX.merge.major.running.docs",
         "merges_major_current_docs",
@@ -650,11 +662,23 @@ public final class PrometheusMetricsServlet extends BaseSolrServlet {
     MINOR_MERGE(
         "INDEX.merge.minor", "merges_minor", "cumulative number of minor merges across cores"),
     MINOR_MERGE_DURATION_P50(
-            "INDEX.merge.minor", "merges_minor_duration_p50", "p50 latency of minor merges across cores", "median_ms", PrometheusMetricType.GAUGE),
+        "INDEX.merge.minor",
+        "merges_minor_duration_p50",
+        "p50 latency of minor merges across cores",
+        "median_ms",
+        PrometheusMetricType.GAUGE),
     MINOR_MERGE_DURATION_P95(
-            "INDEX.merge.minor", "merges_minor_duration_p95", "p95 latency of minor merges across cores", "p95_ms", PrometheusMetricType.GAUGE),
+        "INDEX.merge.minor",
+        "merges_minor_duration_p95",
+        "p95 latency of minor merges across cores",
+        "p95_ms",
+        PrometheusMetricType.GAUGE),
     MINOR_MERGE_DURATION_P99(
-            "INDEX.merge.minor", "merges_minor_duration_p99", "p99 latency of minor merges across cores", "p99_ms", PrometheusMetricType.GAUGE),
+        "INDEX.merge.minor",
+        "merges_minor_duration_p99",
+        "p99 latency of minor merges across cores",
+        "p99_ms",
+        PrometheusMetricType.GAUGE),
 
     MINOR_MERGE_RUNNING_DOCS(
         "INDEX.merge.minor.running.docs",

--- a/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
@@ -51,6 +51,11 @@ import org.slf4j.LoggerFactory;
 /**
  * This config object encapsulates IndexWriter config params, defined in the &lt;indexConfig&gt;
  * section of solrconfig.xml
+ *
+ * <p>Optional {@code <preferredMergePolicyFactory class="...">...</preferredMergePolicyFactory>}
+ * selects the merge policy factory when this Solr version understands it; if absent or without a
+ * {@code class}, {@code <mergePolicyFactory>} is used. Configsets can ship both so older nodes
+ * ignore the unknown preferred element and keep using {@code mergePolicyFactory}.
  */
 public class SolrIndexConfig implements MapSerializable {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -85,7 +90,14 @@ public class SolrIndexConfig implements MapSerializable {
 
   public final int writeLockTimeout;
   public final String lockType;
+
+  /**
+   * Effective merge-policy factory: {@code <preferredMergePolicyFactory>} when present, otherwise
+   * {@code <mergePolicyFactory>}. Older Solr versions ignore the preferred element and use only
+   * {@code mergePolicyFactory}.
+   */
   public final PluginInfo mergePolicyFactoryInfo;
+
   public final PluginInfo mergeSchedulerInfo;
   public final PluginInfo metricsInfo;
 
@@ -163,7 +175,18 @@ public class SolrIndexConfig implements MapSerializable {
 
     metricsInfo = getPluginInfo(get("metrics"), def.metricsInfo);
     mergeSchedulerInfo = getPluginInfo(get("mergeScheduler"), def.mergeSchedulerInfo);
-    mergePolicyFactoryInfo = getPluginInfo(get("mergePolicyFactory"), def.mergePolicyFactoryInfo);
+    PluginInfo mergePolicyFactory =
+        getPluginInfo(get("mergePolicyFactory"), def.mergePolicyFactoryInfo);
+    PluginInfo preferredMergePolicyFactory =
+        getPluginInfo(get("preferredMergePolicyFactory"), null);
+    if (preferredMergePolicyFactory != null) {
+      mergePolicyFactoryInfo = preferredMergePolicyFactory;
+      log.info(
+          "Using <preferredMergePolicyFactory> ({}) instead of <mergePolicyFactory>",
+          preferredMergePolicyFactory);
+    } else {
+      mergePolicyFactoryInfo = mergePolicyFactory;
+    }
 
     assertWarnOrFail(
         "Beginning with Solr 7.0, <mergePolicy> is no longer supported, use <mergePolicyFactory> instead.",
@@ -292,8 +315,9 @@ public class SolrIndexConfig implements MapSerializable {
   }
 
   /**
-   * Builds a MergePolicy using the configured MergePolicyFactory or if no factory is configured
-   * uses the configured mergePolicy PluginInfo.
+   * Builds a MergePolicy using the effective {@link #mergePolicyFactoryInfo} (see {@code
+   * preferredMergePolicyFactory} vs {@code mergePolicyFactory} in class javadoc), or the default
+   * factory if none is configured.
    */
   private MergePolicy buildMergePolicy(SolrResourceLoader resourceLoader, IndexSchema schema) {
 

--- a/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
+++ b/solr/core/src/java/org/apache/solr/update/SolrIndexConfig.java
@@ -53,9 +53,9 @@ import org.slf4j.LoggerFactory;
  * section of solrconfig.xml
  *
  * <p>Optional {@code <preferredMergePolicyFactory class="...">...</preferredMergePolicyFactory>}
- * selects the merge policy factory when this Solr version understands it; if absent or without a
- * {@code class}, {@code <mergePolicyFactory>} is used. Configsets can ship both so older nodes
- * ignore the unknown preferred element and keep using {@code mergePolicyFactory}.
+ * selects the merge policy factory when this Solr version understands it; if absent, {@code
+ * <mergePolicyFactory>} is used. Configsets can ship both so older nodes ignore the unknown
+ * preferred element and keep using {@code mergePolicyFactory}.
  */
 public class SolrIndexConfig implements MapSerializable {
   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());

--- a/solr/core/src/test-files/solr/collection1/conf/solrconfig-preferred-merge-policy-factory.xml
+++ b/solr/core/src/test-files/solr/collection1/conf/solrconfig-preferred-merge-policy-factory.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" ?>
+
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<config>
+  <luceneMatchVersion>${tests.luceneMatchVersion:LATEST}</luceneMatchVersion>
+  <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.RAMDirectoryFactory}"/>
+  <schemaFactory class="ClassicIndexSchemaFactory"/>
+
+  <indexConfig>
+    <useCompoundFile>${useCompoundFile:false}</useCompoundFile>
+    <mergePolicyFactory class="org.apache.solr.index.TieredMergePolicyFactory">
+      <int name="maxMergeAtOnce">7</int>
+      <int name="segmentsPerTier">9</int>
+      <double name="noCFSRatio">0.1</double>
+    </mergePolicyFactory>
+    <preferredMergePolicyFactory class="org.apache.solr.index.DefaultMergePolicyFactory">
+    </preferredMergePolicyFactory>
+    <mergeScheduler class="org.apache.lucene.index.ConcurrentMergeScheduler">
+      <int name="maxMergeCount">987</int>
+      <int name="maxThreadCount">42</int>
+    </mergeScheduler>
+  </indexConfig>
+
+  <requestHandler name="/select" class="solr.SearchHandler"></requestHandler>
+
+</config>

--- a/solr/core/src/test/org/apache/solr/update/SolrIndexConfigTest.java
+++ b/solr/core/src/test/org/apache/solr/update/SolrIndexConfigTest.java
@@ -55,6 +55,8 @@ public class SolrIndexConfigTest extends SolrTestCaseJ4 {
       "solrconfig-concurrentmergescheduler.xml";
   private static final String solrConfigFileNameSortingMergePolicyFactory =
       "solrconfig-sortingmergepolicyfactory.xml";
+  private static final String solrConfigFileNamePreferredMergePolicyFactory =
+      "solrconfig-preferred-merge-policy-factory.xml";
   private static final String schemaFileName = "schema.xml";
 
   private static boolean compoundMergePolicySort = false;
@@ -92,6 +94,17 @@ public class SolrIndexConfigTest extends SolrTestCaseJ4 {
         ex.getMessage()
             .contains(
                 "Error instantiating class: 'org.apache.solr.index.DummyMergePolicyFactory'"));
+  }
+
+  @Test
+  public void testPreferredMergePolicyFactoryOverridesMergePolicyFactory() throws Exception {
+    SolrConfig solrConfig =
+        new SolrConfig(instanceDir, solrConfigFileNamePreferredMergePolicyFactory);
+    SolrIndexConfig solrIndexConfig = new SolrIndexConfig(solrConfig, null);
+    assertNotNull(solrIndexConfig.mergePolicyFactoryInfo);
+    assertEquals(
+        org.apache.solr.index.DefaultMergePolicyFactory.class.getName(),
+        solrIndexConfig.mergePolicyFactoryInfo.className);
   }
 
   @Test

--- a/solr/webapp/web/js/angular/controllers/segments.js
+++ b/solr/webapp/web/js/angular/controllers/segments.js
@@ -17,6 +17,49 @@
 
 var MB_FACTOR = 1024*1024;
 
+/** Blue-grey (future) then green (newest) -> red (oldest); extra buckets reuse the last color. */
+var BUCKET_BAR_COLORS = [
+    '#a9c3d1', // -9d / far future
+    '#a9d1a9', // 3d / newest typical bucket
+    '#c3d1a9',
+    '#d1d1a9',
+    '#d1c3a9',
+    '#d1b6a9',
+    '#d1a9a9'
+];
+
+var buildColorByBucket = function(bucketBoundaries) {
+    var colorByBucket = {};
+    if (!bucketBoundaries) {
+        return colorByBucket;
+    }
+    var lastIdx = BUCKET_BAR_COLORS.length - 1;
+    for (var i = 0; i < bucketBoundaries.length; i++) {
+        colorByBucket[String(bucketBoundaries[i])] = BUCKET_BAR_COLORS[Math.min(i, lastIdx)];
+    }
+    return colorByBucket;
+};
+
+var colorByBucketCache = { key: null, map: null };
+
+var getColorByBucket = function(bucketBoundaries) {
+    var key = bucketBoundaries ? bucketBoundaries.join('\0') : '';
+    if (colorByBucketCache.key !== key) {
+        colorByBucketCache.key = key;
+        colorByBucketCache.map = buildColorByBucket(bucketBoundaries);
+    }
+    return colorByBucketCache.map;
+};
+
+var assignBucketBarColors = function(segments, colorByBucket) {
+    for (var i = 0; i < segments.length; i++) {
+        var bucket = segments[i].temporalBucket;
+        if (bucket != null) {
+            segments[i].bucketBarColor = colorByBucket[String(bucket)];
+        }
+    }
+};
+
 solrAdminApp.controller('SegmentsController', function($scope, $routeParams, $interval, Segments, Constants) {
     $scope.resetMenu("segments", Constants.IS_CORE_PAGE);
 
@@ -64,6 +107,8 @@ solrAdminApp.controller('SegmentsController', function($scope, $routeParams, $in
                 $scope.documentCount += segment.size;
                 $scope.deletionCount += segment.delCount;
             }
+            var colorByBucket = getColorByBucket(data.bucketBoundaries);
+            assignBucketBarColors($scope.segments, colorByBucket);
             $scope.deletionsPercentage = calculateDeletionsPercentage($scope.documentCount, $scope.deletionCount);
         });
     };

--- a/solr/webapp/web/partials/segments.html
+++ b/solr/webapp/web/partials/segments.html
@@ -58,7 +58,7 @@ limitations under the License.
                                      </dt>
                                      <dd>
                                          <div class="live" ng-class="{'merge-candidate':segment.mergeCandidate}"
-                                              ng-style="{width: segment.aliveDocSize+'%'}">&nbsp;</div>
+                                              ng-style="segment.bucketBarColor ? {width: segment.aliveDocSize+'%', backgroundColor: segment.bucketBarColor} : {width: segment.aliveDocSize+'%'}">&nbsp;</div>
                                          <div class="tooltip">
                                              <div>Segment <b>{{segment.name}}</b>:</div>
                                              <div class="label">#docs:</div>
@@ -72,10 +72,12 @@ limitations under the License.
                                              <div class="label">source:</div>
                                              <div>{{ segment.source }}</div>
                                              <div ng-if="segment.temporalMinDate">
-                                                 <div class="label">EventStart from:</div>
+                                                 <div class="label">TemporalStart:</div>
                                                  <div>{{ segment.temporalMinDate }}</div>
-                                                 <div class="label">EventStart to:</div>
+                                                 <div class="label">TemporalEnd:</div>
                                                  <div>{{ segment.temporalMaxDate }}</div>
+                                                 <div class="label">TemporalBucket:</div>
+                                                 <div>{{ segment.temporalBucketLabel }}</div>
                                              </div>
                                          </div>
                                          <div class="deleted" ng-show="segment.deletedDocSize"


### PR DESCRIPTION
## Descriptions
Time routed segment related changes:
1.  Better visualization based on temporal bucket #323
2. preferredMergePolicyFactory to allow canary merge policy
#321
3. Reference to lucene with the time segment bucketed flush changes (hash [`928bce35dea2c5f64f2d23a4f29d15d9e791cc06`](https://github.com/cowpaths/fullstory-solr/tree/patsonluk/SAI-6231/time-routed-segment), which is the same as current Lucene [fs/branch_9_11](https://github.com/cowpaths/lucene/tree/fs/branch_9_11))



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `preferredMergePolicyFactory` changes which merge policy runs on upgraded nodes and affects merge/index behavior; segments temporal logic adds segment file reads and Fullstory-specific defaults via system property.
> 
> **Overview**
> Adds **time-routed segment** observability and **rollout-friendly merge policy** wiring for time-tiered indexing.
> 
> **Segments admin API & UI:** The segments handler no longer hard-codes `EventStart`; it walks a configurable list of temporal point fields (`lucene.temporalField.name` or Fullstory defaults). For each segment with a range it exposes `temporalBucket`, `temporalBucketLabel`, and top-level `bucketBoundaries` (aligned with `SegmentRoutingUtil` day boundaries). The Segments page colors live-doc bars by bucket and shows generic TemporalStart/End/Bucket tooltips.
> 
> **Index config:** New optional `<preferredMergePolicyFactory>` in `indexConfig` overrides `<mergePolicyFactory>` when present so configsets can ship a legacy policy plus a preferred one (e.g. canary temporal merge policy) that older Solr nodes ignore. Covered by `SolrIndexConfigTest` and sample solrconfig.
> 
> **Other:** `PrometheusMetricsServlet` enum formatting only (no metric behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ccc4fb857eecb26fadddbd311c2fb94eb11ed30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->