### PR TITLE
Expose FacetSortableMerger for extension by weighted percentile agg

### DIFF
--- a/solr/core/src/java/org/apache/solr/search/facet/FacetModule.java
+++ b/solr/core/src/java/org/apache/solr/search/facet/FacetModule.java
@@ -381,7 +381,13 @@ public class FacetModule extends SearchComponent {
   }
 
   // base class for facet functions that can be used in a sort
-  abstract static class FacetSortableMerger extends FacetMerger {
+  /**
+   * Base merger for facet statistics that can also be used to sort facet buckets.
+   *
+   * <p>This type is public so external {@link AggValueSource} plugins can preserve the native
+   * distributed sorting behavior of built-in statistics.
+   */
+  public abstract static class FacetSortableMerger extends FacetMerger {
     public void prepareSort() {}
 
     @Override


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Visibility and documentation only; facet merging behavior is unchanged.
> 
> **Overview**
> Makes **`FacetSortableMerger`** in `FacetModule` **public** (it was package-private) and documents that external **`AggValueSource`** plugins can subclass it so custom facet statistics participate in the same distributed bucket-sorting path as built-in stats.
> 
> No merge or compare logic changes—only visibility and Javadoc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 099ec73cde5df87f0da84c2c849dae22c1c978ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->